### PR TITLE
docs(tv24): mark local reflection probes shipped

### DIFF
--- a/docs/examples/terrain_tv24_reflection_probe_demo.md
+++ b/docs/examples/terrain_tv24_reflection_probe_demo.md
@@ -1,0 +1,83 @@
+# TV24 Reflection Probe Demo
+
+`examples/terrain_tv24_reflection_probe_demo.py` demonstrates the delivered TV24 / TV5.3 terrain reflection-probe feature set on a real repo DEM: `assets/tif/dem_rainier.tif`.
+
+## What TV24 Ships
+
+- Optional local reflection probes for terrain scenes via `ReflectionProbeSettings`.
+- Automatic or explicit probe-grid placement with `grid_dims`, `origin`, `spacing`, `height_offset`, `resolution`, `ray_count`, and `fallback_blend_distance`.
+- CPU probe baking against the terrain heightfield plus mip-aware texture storage for roughness-aware sampling.
+- Runtime invalidation when terrain heights, terrain span, `z_scale`, reflection-probe settings, or HDR environment inputs change.
+- GPU memory tracking through `TerrainRenderer.get_reflection_probe_memory_report()`.
+- Terrain shader debug views:
+  - `debug_mode=52`: raw reflection-probe color
+  - `debug_mode=53`: reflection-probe blend weight
+- Water-path integration so local probes can change reflective water pixels instead of only existing as a debug-only path.
+
+## Python Surface
+
+The public Python entry points added for TV24 are:
+
+- `forge3d.ReflectionProbeSettings`
+- `TerrainRenderParams(..., reflection_probes=...)`
+- `make_terrain_params_config(..., reflection_probes=...)`
+- `TerrainRenderer.get_reflection_probe_memory_report()`
+
+`ReflectionProbeSettings(enabled=False)` is the baseline-preserving default. When disabled or omitted, terrain rendering falls back to the existing global IBL-only behavior.
+
+## Example Behavior
+
+The demo renders five outputs:
+
+- `terrain_tv24_diffuse_only.png`
+- `terrain_tv24_reflection_on.png`
+- `terrain_tv24_reflection_debug.png`
+- `terrain_tv24_reflection_weight.png`
+- `terrain_tv24_comparison.png`
+
+The example fits the reflection-probe grid to the generated water mask before rendering. That keeps the local specular budget concentrated over the lake footprint instead of spreading probes across the full DEM extent.
+
+The returned metrics include:
+
+- `mean_abs_diff`: full-frame beauty difference
+- `water_mean_abs_diff`: beauty difference only on rendered water pixels
+- `probe_memory`
+- `reflection_probe_memory`
+- `reflection_probe_origin`
+- `reflection_probe_spacing`
+- `rendered_water_pixels`
+
+## Running It
+
+```bash
+python examples/terrain_tv24_reflection_probe_demo.py --dem assets/tif/dem_rainier.tif
+```
+
+Optional controls:
+
+- `--output-dir`: choose a custom output directory
+- `--width` / `--height`: render resolution
+- `--max-dem-size`: downsample the DEM before rendering
+
+## Verification Coverage
+
+TV24 is covered by:
+
+- `tests/test_terrain_probes.py`
+  - shader/debug-mode presence
+  - fallback identity when reflection probes are disabled
+  - memory reporting
+  - local reflection color debug output
+  - weight blending and edge falloff
+  - bake invalidation
+- `tests/test_terrain_reflection_probe_exports.py`
+  - top-level Python re-export and public API listing
+- `tests/test_terrain_tv24_demo.py`
+  - real-DEM example execution
+  - output image creation
+  - non-trivial debug/weight output
+  - non-trivial reflected-water beauty difference
+
+## Practical Outcome
+
+TV24 gives terrain scenes a bounded local-specular path that can represent nearby terrain and water-surface context better than a single global IBL cubemap. The result is most visible on reflective water, glossy built elements, and other places where global environment lighting alone is too spatially coarse.

--- a/docs/plans/2026-03-16-terrain-viz-epics.md
+++ b/docs/plans/2026-03-16-terrain-viz-epics.md
@@ -1,38 +1,48 @@
-# Forge3D Terrain Visualization: Corrected Epic Backlog
+# Forge3D Terrain Visualization Epic Backlog
 
-**Date:** 2026-03-16  
-**Sources:** `forge3d_vs_blender_gap_analysis.md`, `docs/plans/forge3d_vs_unreal_gap_analysis.md`, direct source audit  
-**Scope:** Terrain-first 3D visualization only. This document excludes editor-authoring workflows, character systems, gameplay systems, and generic DCC parity work unless they directly improve terrain rendering, terrain review, or terrain export.
+**Date:** 2026-03-26
+**Sources:** `docs/plans/forge3d_vs_unreal_gap_analysis.md`, direct audit of `src/terrain`, `python/forge3d`, `tests/`, and `examples/`. `docs/superpowers/specs/*` and `docs/superpowers/plans/*` were treated as design and implementation-plan documents, not proof of shipped runtime support.
+**Scope:** Terrain-first 3D visualization only. This roadmap covers terrain rendering, terrain population, terrain review, and terrain delivery. It excludes editor-product work, gameplay systems, character systems, and generic DCC parity unless they directly improve terrain scenes.
 
 ---
 
-## 1. Purpose of This Revision
+## 1. Baseline
 
-The previous terrain-epics draft was directionally useful but not precise enough. It overstated several gaps that are only **partial** rather than **absent**.
+Forge3D does not have a terrain-rendering foundation problem. It already has the core pieces of a credible terrain visualization stack. This document tracks the current implementation status of the terrain epics and keeps the remaining backlog limited to the terrain-specific gaps that still materially affect image quality, scene scale, review workflow, or delivery workflow.
 
-The source audit changes the assessment in four important ways:
+### Implemented foundations
 
-1. **Procedural terrain noise is already present, but ad hoc.** `src/shaders/terrain_pbr_pom.wgsl` already contains `hash`, `value_noise`, procedural detail normals, and albedo-noise wiring. The real gap is a reusable, higher-quality terrain noise module, not "add noise from scratch."
-2. **A Hosek-Wilkie sky path already exists, but mostly in the viewer path.** `src/shaders/sky.wgsl` and `src/viewer/state/sky_state.rs` implement a configurable sky model. By contrast, the terrain renderer parses `SkySettings` but does not appear to drive a full terrain-sky render path from those settings. The real gap is path parity, not sky invention.
-3. **Instanced rendering exists, but not as terrain-native scattering.** `src/scene/py_api/instanced_mesh.rs` and `src/render/instancing.rs` provide instanced mesh paths, but there is no terrain-aware placement, mask-driven scattering, terrain-specific culling, or terrain-viewer integration.
-4. **EXR channel infrastructure exists, but terrain compositing is incomplete.** `src/util/exr_write.rs` can write arbitrary named EXR channels. However, the public save path still emits one file per AOV, and terrain AOV rendering in `src/terrain/renderer/aov.rs` is still plumbing-heavy rather than a verified populated render path.
+- **TV1:** terrain atmosphere path parity is shipped.
+- **TV2:** terrain AOV capture and multi-channel EXR export are shipped.
+- **TV3:** terrain scatter is shipped, including deterministic placement, culling, and manual LOD selection.
+- **TV4:** terrain material variation is shipped, including shared terrain noise functions and bounded procedural controls.
+- **TV5:** terrain local probe lighting is shipped, including diffuse irradiance probes, local reflection probes, placement/rebake invalidation, debug views, and probe memory reporting.
+- **TV6:** terrain volumetrics are shipped. The codebase has a public volumetrics settings surface, native decode, dedicated terrain-viewer volumetrics pass/shader, and both screen and offscreen application paths with examples and tests.
+- **TV10:** terrain subsurface materials are shipped. The public Python material-layer surface, native decode path, terrain shader integration, and regression coverage are all present in this worktree.
+- **TV12:** offline terrain render quality is shipped. Deterministic accumulation, adaptive sampling, and optional OIDN-based denoising are wired through the public Python API.
+- **TV13:** terrain population LOD pipeline is shipped, including QEM mesh simplification, auto-generated scatter LOD chains, and HLOD clustering/runtime integration.
+- **TV21:** terrain-mesh blending and contact integration are shipped, including per-batch blend/contact controls across the native renderer and viewer paths.
+- **TV22:** scatter wind animation is shipped, including GPU deformation, viewer/offscreen wiring, validation, and regression coverage.
+- Terrain rendering already includes clipmap terrain, COG/COPC/3D Tiles ingestion, PBR + POM, planar water reflections, vector overlays, cloud shadows, bloom, tone mapping, and height-aware lighting controls.
+- Terrain viewer post-processing already includes TAA, depth of field, and camera motion blur.
+- Generic virtual-texture and page-table foundations already exist in the renderer, but they are not yet used as a terrain-material delivery system.
 
-This revised plan therefore distinguishes among:
+### Repository Hygiene Note
 
-- **Present:** already implemented and materially usable
-- **Partial:** implemented in one path, lightly implemented, or wired only as plumbing
-- **Missing:** not implemented in a usable form
+As of 2026-03-25, the clean local worktrees for `epic-12-clean`, `epic-21`, `epic-22`, and `tv12-ship-release` were removed after confirming their commits already exist on `origin`. The local `epic-12` worktree and branch were then removed after audit: its branch tip `98fb618` was already contained in `origin/main` via the `tv12-ship-release` merge, and the leftover worktree-only edits were stale drift rather than unshipped TV12 work.
+
+The sections below separate implemented epics from work that is still open.
 
 ---
 
 ## 2. Selection Rules
 
-A feature is included in the build backlog only if it meets all of the following:
+A feature stays in this roadmap only if it satisfies all of the following:
 
-1. It materially improves terrain scenes, terrain atmosphere, terrain population, terrain review, or terrain export.
-2. It fits Forge3D's architecture as an additive subsystem or a terrain-path integration task.
-3. It does not require turning Forge3D into a Blender-class authoring tool or an Unreal-class game engine.
-4. It can be implemented without degrading clipmap terrain streaming, COG/COPC/3D Tiles throughput, or IPC responsiveness.
+1. It materially improves terrain image quality, terrain scale, terrain population, terrain review, or terrain delivery.
+2. It fits Forge3D as an additive subsystem or a terrain-path extension.
+3. It does not require turning Forge3D into a full editor product or a general-purpose game engine.
+4. It can be implemented without regressing clipmap streaming, COG/COPC/3D Tiles throughput, memory accounting, or the Python and IPC control surfaces.
 
 ---
 
@@ -40,594 +50,214 @@ A feature is included in the build backlog only if it meets all of the following
 
 | Rating | Meaning | Effort | Risk |
 |---|---|---:|---|
-| **F1** | Natural fit; mostly wiring or contained extension | 5-15 pd | Negligible |
+| **F1** | Natural fit; mostly wiring or a contained extension | 5-15 pd | Negligible |
 | **F2** | New terrain subsystem or medium extension | 15-45 pd | Low |
 | **F3** | Cross-cutting subsystem touching several render paths | 45-90 pd | Medium |
 
-Only F1-F3 work is considered here. F4-F5 items from the Blender and Unreal reports are handled explicitly in the defer/reject section.
+Only F1-F3 work is considered here. Higher-cost engine-scale work stays out of the terrain roadmap.
 
 ---
 
-## 4. Verified Terrain-Relevant Gap Matrix
+## 4. Verified Epic Status Matrix
 
-| Feature | Blender / Unreal reference | Verified repo status | Feasibility | Desirability | Decision |
+| Feature | Blender / Unreal / top-engine reference | Verified repo status | Feasibility | Desirability | Decision |
 |---|---|---|---|---|---|
-| **Terrain sky rendering and aerial perspective** | Blender: Hosek-Wilkie / Nishita; Unreal: atmosphere quality | **Partial.** Viewer sky is implemented in `src/shaders/sky.wgsl` and `src/viewer/state/sky_state.rs`. Terrain params parse sky fields in `src/terrain/render_params/decode_atmosphere.rs`, but the terrain path appears to use fog + aerial perspective approximations rather than a full terrain-sky path. | F1-F2 | High | **Build** |
-| **Terrain AOVs and compositing export** | Blender: AOVs, multi-layer EXR, Cryptomatte-adjacent workflows | **Partial.** `render_with_aov()` exists and `src/terrain/renderer/aov.rs` allocates textures, but this is not yet a verified populated terrain-AOV path. EXR multi-channel writing exists in `src/util/exr_write.rs`, but public save paths still write per-AOV files. | F1-F2 | High | **Build** |
-| **Terrain-native scattering / foliage-style placement** | Blender: Instance on Points; Unreal: foliage instancing | **Partial.** Instanced mesh APIs exist in `src/scene/py_api/instanced_mesh.rs` and `src/render/instancing.rs`, but there is no terrain-aware placement, terrain masks, slope filters, or terrain-viewer draw path. | F2-F3 | High | **Build** |
-| **Procedural terrain material variation** | Blender: procedural texture nodes; Unreal: richer terrain material systems | **Partial.** `src/shaders/terrain_pbr_pom.wgsl` already includes `value_noise`, procedural detail normals, and albedo variation, but not a reusable or higher-fidelity terrain noise system. | F1-F2 | High | **Build** |
-| **Local light probes** | Blender: irradiance volumes + reflection cubemaps; Unreal: probe-style GI fallback | **Missing, with enum stub only.** `GiMode::IrradianceProbes` exists in `src/render/params/gi.rs`, but no corresponding terrain implementation was found. | F2-F3 | High | **Build** |
-| **Heterogeneous terrain volumetrics** | Blender: heterogeneous volume shading; Unreal: localized atmospheric FX | **Partial.** Terrain volumetrics exist in `src/viewer/terrain/volumetrics.rs` and `src/shaders/viewer_volumetrics.wgsl`, but they are height/uniform based with pseudo-noise, not 3D density volumes. | F2 | Medium-High | **Build later** |
-| **GPU weather particles** | Blender: particles; Unreal: GPU particles / weather FX | **Missing.** No terrain-oriented emitter/render/update path was found. | F3 | Medium | **Build later** |
-| **FFT ocean / spectrum water** | Blender: ocean modifier; Unreal: higher-end water simulation expectations | **Missing.** `src/shaders/water_surface.wgsl` uses analytic wave composition and foam breakup, not FFT/Tessendorf/JONSWAP. | F2 | Medium, but domain-specific | **Conditional** |
-| **OCIO color management** | Blender: OCIO pipeline | **Missing.** No active OpenColorIO integration was found. | F3 | Medium | **Conditional** |
-| **Projected decals** | Unreal: deferred decals | **Missing.** No terrain decal path was found. Existing raster/vector overlays already cover many terrain annotation needs. | F2 | Medium-Low | **Defer** |
-| **Compute tessellation for terrain** | Unreal: tessellation/displacement | **Missing.** No terrain compute-subdivision path was found. Current clipmaps + POM + detail normals already cover many practical cases. | F2 | Medium-Low | **Defer** |
-| **Adaptive sampling + OIDN** | Blender: adaptive sampling + OIDN | **Missing.** No path-tracer adaptive scheduler or OIDN integration was found. Existing denoise paths are A-trous in Rust and NumPy. | F2 | Medium, but not terrain-path critical today | **Defer until terrain export foundation lands** |
+| **Local reflection probes** | Blender: reflection cubemaps; Unreal: local reflection capture | **Implemented.** Terrain local reflection probes are exposed through `ReflectionProbeSettings`, reuse the diffuse-probe placement discipline, feed the terrain and water specular fallback path, expose memory/debug reporting, and are covered by regression tests plus a real-DEM demo. | F2 | Medium-High | **Done** |
+| **Terrain subsurface materials** | Blender: Cycles SSS for snow/ice/earth; Unreal: Subsurface Profile shading | **Implemented.** Terrain-layer subsurface controls exist in `terrain_params.py`, are decoded in the native terrain path, and are consumed by the terrain shader with dedicated regression tests. | F2 | High | **Done** |
+| **Offline terrain quality pipeline** | Blender: accumulation AA, adaptive sampling, OIDN; Unreal: movie render quality passes | **Implemented.** `OfflineQualitySettings`, `render_offline`, adaptive scheduling, and optional OIDN denoise support are present and covered by dedicated TV12 tests. | F2 | High | **Done** |
+| **Heterogeneous terrain volumetrics** | Blender: heterogeneous volume shading; Unreal: localized atmospheric FX | **Implemented in shipped scope.** Terrain volumetric fog and light shafts are exposed through `VolumetricsSettings`, decoded natively, applied in dedicated terrain-viewer screen/offscreen passes, and covered by examples/tests. The old backlog wording around bounded 3D density volumes was stale relative to the shipped feature surface. | F2 | Medium-High | **Done** |
+| **Weather particles** | Blender: particles; Unreal: GPU weather FX | **Missing.** No terrain-oriented GPU weather emitter/update/render path exists. | F3 | Medium | **Build later** |
+| **Terrain population LOD pipeline** | Blender: simplification workflows; Unreal: auto LOD + HLOD | **Implemented.** `simplify_mesh`, `generate_lod_chain`, `auto_lod_levels`, and HLOD clustering/runtime integration are present with documentation, a real-DEM demo, and regression coverage. | F2 | High | **Done** |
+| **Terrain material virtual texturing** | Unreal: virtual textures / RVT-style terrain material streaming; top engines: large-scene material paging | **Missing in the terrain path.** Generic virtual-texture foundations exist, but terrain material layers and masks are not delivered through a terrain VT/RVT-style system. | F2-F3 | High | **Build** |
+| **Terrain-mesh blending and contact integration** | Unreal: terrain/mesh blending, contact integration, terrain-aware surface transitions | **Implemented.** Terrain/mesh seam softening, terrain-aware contact darkening, per-batch controls, viewer IPC wiring, a demo, and regression coverage are present in the shipped codebase. | F2 | Medium-High | **Done** |
+| **Scatter wind animation** | Unreal: foliage wind; Blender: animated vegetation workflows | **Implemented.** Scatter wind settings, GPU deformation, viewer/offscreen wiring, time-driven animation plumbing, validation, examples, and regression coverage are present. | F1-F2 | Medium-High | **Done** |
+| **Terrain scene variants and review layers** | Unreal: Data Layers; Blender-adjacent: alternate scene states | **Partial.** Bundles persist terrain metadata and bookmarks, but there is no named terrain-variant model with atomic activation. | F1-F2 | High | **Build** |
+| **Terrain camera rig toolkit** | Unreal: camera rigs; Blender: path- and constraint-driven flyovers | **Partial.** Camera keyframes and offline frame enumeration exist, but reusable orbit/rail/target-follow terrain rigs do not. | F1-F2 | High | **Build** |
+| **Terrain shot queue and bounded timeline** | Unreal: Movie Render Queue + Sequencer; Blender: repeatable batch render workflows | **Partial.** Terrain AOV output and camera animation exist, but there is no terrain shot manifest, bounded track model, or multi-shot queue. | F2-F3 | High | **Build** |
+| **Page-based terrain shadowing** | Unreal: Virtual Shadow Maps | **Missing.** Design and implementation-plan docs exist for TV11, but the runtime terrain shadow path audited here does not expose a paged shadow backend, shadow page cache, or paged-shadow stats surface. | F3 | Medium | **Defer** |
+| **Coastal / hydrology water upgrade** | Blender: Ocean modifier; Unreal: higher-end water simulation | **Missing.** Current water uses analytic waves and foam rather than an FFT/spectrum-driven path. | F2 | Medium | **Conditional** |
+| **OCIO color-managed terrain output** | Blender: OCIO pipeline | **Missing.** No active OpenColorIO terrain output path is present. | F3 | Medium | **Conditional** |
+| **Terrain flow and trajectory visualization** | Blender: curve/path rendering; Unreal: ribbon/trail effects | **Partial.** Curve and ribbon geometry foundations exist, but not a terrain-aware flow visualization workflow. | F1-F2 | Medium | **Conditional** |
+| **Collaborative terrain review** | Unreal: collaborative viewing | **Partial.** The viewer IPC surface is a good substrate, but there is no multi-client terrain review session model. | F2 | Medium | **Conditional** |
+| **Terrain temporal upscaling** | Unreal: TSR / temporal upscalers; top engines: resolution scaling for heavy terrain scenes | **Missing.** TAA exists, but there is no lower-resolution terrain render plus temporal upscale path for the terrain renderer itself. Existing upscaled buffers in screen-space GI do not close this terrain-viewer gap. | F3 | Medium | **Conditional** |
 
 ---
 
-## 5. What Is Already Strong and Must Not Regress
+## 5. Core Build Backlog
 
-The following are differentiators. No terrain epic should regress them:
+The epics below are the remaining terrain-first work that is both feasible and worth building now. Local reflection probes, TV13, TV21, and TV22 are no longer part of this section because they now have shipped runtime coverage.
 
-- Clipmap terrain streaming and quadtree/page-table behavior
-- COG, COPC/EPT, and 3D Tiles ingestion throughput
-- Memory-budget tracking via `memory_tracker`
-- Terrain overlays and vector draping
-- Terrain PBR + POM path
-- Terrain water reflection path already present in `terrain_pbr_pom.wgsl`
-- Python and IPC control surfaces
+### Scale and Material Delivery
 
-Any terrain roadmap item that threatens those systems is incorrectly scoped.
+### Epic TV20 - Terrain Material Virtual Texturing
 
----
-
-## 6. Build Backlog
-
-### Epic TV1 - Terrain Atmosphere Path Parity
-
-**Why this is in scope:** The viewer already has a configurable Hosek-Wilkie / Preetham sky implementation, but the terrain renderer currently exposes sky settings without proving that the terrain path actually honors them. This is a high-value, low-risk parity fix.
-
-**Feasibility:** F1-F2  
-**Estimate:** 10-18 pd  
-**Priority:** P0
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV1.1 Wire `SkySettings` into the terrain render path** | Reuse the existing viewer-sky implementation, or port the minimum required logic, so `TerrainRenderParams.sky` changes terrain output instead of being dead plumbing. | Enabling `params.sky.enabled` changes output in the terrain renderer; `turbidity`, `ground_albedo`, `sun_intensity`, `sun_size`, and `sky_exposure` each produce observable, test-covered output changes; disabling sky is pixel-identical to the current baseline. |
-| **TV1.2 Remove duplicated atmosphere semantics** | Make terrain aerial perspective derive from the same sky/atmosphere configuration rather than a parallel fog-only approximation. | Terrain fog/aerial perspective parameter semantics are documented once; there is no separate terrain-only interpretation of the same sky inputs; at least one terrain scene verifies low-haze vs high-haze output differences. |
-| **TV1.3 Add terrain-sky regression tests** | Add config-level and image-level tests for the terrain path. | At least 3 terrain golden scenes cover clear sky, hazy sky, and low-sun conditions; one test fails if sky settings are parsed but ignored. |
-
-### Epic TV2 - Terrain Output and Compositing Foundation
-
-**Why this is in scope:** Terrain rendering currently has the surface API for AOVs and the low-level EXR utility pieces, but not a trustworthy terrain-output pipeline for compositing or QA.
-
-**Feasibility:** F1-F2  
-**Estimate:** 18-28 pd  
-**Priority:** P0
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV2.1 Make terrain AOV targets real** | Turn `render_with_aov()` into a populated terrain render path for beauty, albedo, normal, and depth. | `TerrainRenderer.render_with_aov()` returns populated buffers, not placeholder textures; normal output is world-space and normalized; depth is documented and stable; sizes exactly match the beauty frame. |
-| **TV2.2 Add single-file terrain EXR export** | Use `src/util/exr_write.rs` to export terrain beauty + AOVs into one multi-channel EXR file. | A single EXR contains at least `beauty`, `albedo`, `normal`, and `depth`; the file round-trips with channel names intact; the terrain API exposes an explicit save path instead of forcing one file per pass. |
-| **TV2.3 Harden terrain regression coverage** | Promote terrain visual tests from optional plumbing to a required quality gate. | A GPU-capable CI lane runs terrain golden comparisons for at least PBR terrain, terrain + water, and terrain + atmosphere; shader changes in terrain paths trigger those checks. |
-
-### Epic TV3 - Terrain Scatter and Population
-
-**Why this is in scope:** Blender's Instance on Points and Unreal's foliage tooling matter in terrain visualization because terrain scenes look unfinished without repeatable population systems. Forge3D already has instancing primitives; the missing work is terrain-native placement and render integration.
-
-**Feasibility:** F2-F3  
-**Estimate:** 28-45 pd  
-**Priority:** P1
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV3.1 Add terrain placement generators** | Implement deterministic placement strategies for terrain scenes: seeded random, grid+jitter, and mask-driven density. | Public API accepts a terrain source plus placement parameters and returns reproducible instance transforms; slope and elevation filters are supported; the same seed always generates the same transform set. |
-| **TV3.2 Reuse existing instanced mesh infrastructure in terrain scenes** | Connect terrain-generated transforms to the existing instanced mesh renderer instead of creating a second instancing system. | Terrain scenes can render instanced assets through one shared instancing path; at least one terrain-viewer example and one offscreen example use the same asset + transform contract. |
-| **TV3.3 Add terrain-specific culling and LOD policy** | Add per-batch distance culling and simple LOD switching suitable for terrain populations. | 50k placed instances render without breaking the frame budget on a representative mid-range GPU target; culling and LOD state are measurable in stats; instance memory is tracked by `memory_tracker`. |
-
-### Epic TV4 - Terrain Material Variation Upgrade
-
-**Why this is in scope:** Terrain already has procedural detail hooks, but they are local, ad hoc, and terrain-shader-specific. The gap versus Blender is not "zero procedural texturing"; it is "insufficiently reusable and too low fidelity."
-
-**Feasibility:** F1-F2  
-**Estimate:** 14-24 pd  
-**Priority:** P1
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV4.1 Extract the current terrain noise helpers into a shared WGSL unit** | Move the existing hash/value-noise logic out of terrain-only inline code into a shared shader module with stable naming and call sites. | Terrain visuals are pixel-identical at default settings after the refactor; duplicate terrain-only noise logic is removed from consumer shaders. |
-| **TV4.2 Add a bounded higher-quality noise set** | Add only the noises that materially improve terrain: FBM, ridged FBM, and one cellular-distance variant. Do not build a general-purpose shader-graph substitute. | Terrain layers can independently use low-frequency macro variation and high-frequency detail variation; at least snow/wetness/rock blending can consume the new functions; the old detail path remains available as the zero-regression default. |
-| **TV4.3 Expose terrain noise controls cleanly** | Add explicit terrain parameters for amplitude, scale, and octave count where justified. | Python terrain config exposes only the parameters that affect rendered output; setting amplitude to zero preserves the baseline image; a perf test demonstrates the new noise path stays within a documented budget. |
-
-### Epic TV5 - Local Probe Lighting for Terrain Scenes
-
-**Why this is in scope:** The Blender report correctly identifies light probes as one of the highest-value quality upgrades. Terrain scenes with buildings, underpasses, or local water reflections need more than one global IBL map.
-
-**Feasibility:** F2-F3  
-**Estimate:** 30-55 pd  
-**Priority:** P2
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV5.1 Turn `GiMode::IrradianceProbes` into a real terrain feature** | Implement baked diffuse irradiance probes for terrain scenes instead of keeping the enum as a configuration stub. | Selecting `irradiance-probes` changes indirect diffuse lighting in a terrain scene; probe data can be baked, stored, and sampled; when probes are absent, the system falls back to current IBL behavior. |
-| **TV5.2 Add probe placement, invalidation, and memory accounting** | Define how probes are positioned, rebaked, and budgeted. | Probe bounds, resolution, and max count are explicit API inputs; rebake/invalidation behavior is documented; GPU memory for probes is tracked. |
-| **TV5.3 Add local reflection probes only after diffuse probes are stable** | Add a bounded specular-probe path for terrain scenes with water or glossy built structures. | Reflection probes are optional and runtime-selectable; no reflection-probe path ships without a verified diffuse-probe baseline; at least one terrain + structure scene demonstrates better local specular than global IBL alone. |
-
-### Epic TV6 - Heterogeneous Terrain Volumetrics
-
-**Why this is in scope:** Current terrain volumetrics are useful but still fundamentally height/uniform fog with pseudo-noise. Localized fog banks, smoke plumes, and volcanic or industrial emissions are legitimate terrain-visualization use cases.
-
-**Feasibility:** F2  
-**Estimate:** 18-30 pd  
-**Priority:** P2
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV6.1 Add 3D density-volume support** | Extend the existing terrain volumetric pass to consume a bounded 3D density texture. | The terrain viewer can render a localized density field with documented world-space placement; the legacy height/uniform fog modes still work unchanged. |
-| **TV6.2 Add procedural terrain-volume generators** | Add a small preset layer for valley fog, plume, and localized haze volumes. | At least 3 named density presets can be instantiated from Python; each preset maps onto the same underlying 3D density path rather than bespoke shader forks. |
-| **TV6.3 Add quality and budget tests** | Prevent the new volume path from becoming an uncontrolled memory/perf sink. | Density textures participate in memory tracking; at least one test records expected perf and memory bounds for a representative volume size. |
-
-### Epic TV7 - Weather Particle Foundation
-
-**Why this is in scope:** Weather and airborne particulates are terrain-adjacent, not game-engine fluff. Rain, snow, dust, and ash directly improve terrain storytelling and simulation visualization.
-
-**Feasibility:** F3  
-**Estimate:** 25-40 pd  
-**Priority:** P3
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV7.1 Add a minimal GPU particle core** | Implement spawn, update, and billboard render stages for terrain scenes. | A single emitter can spawn, update, and render particles entirely on GPU; particle buffers are tracked; the system can be disabled with zero terrain-path impact when unused. |
-| **TV7.2 Add terrain-aware collision / kill logic** | Make particles aware of terrain height rather than simulating in free space only. | Rain/snow/dust particles can collide with or die on the heightfield without CPU readback; at least one weather preset uses this behavior. |
-| **TV7.3 Ship only terrain-relevant presets** | Limit the initial preset set to rain, snow, dust, and ash. | The v1 API does not include generic game VFX concepts; presets are parameterized and documented around terrain/weather use cases only. |
-
----
-
-## 7. Conditional Epics
-
-These are legitimate features, but they should not enter the core terrain backlog unless the product direction explicitly demands them.
-
-### Epic TV8 - Coastal / Hydrology Water Upgrade
-
-**Why conditional:** FFT/Tessendorf-class water is desirable for coastal, estuary, and hydrology-heavy scenes, but it is not universally required across terrain visualization. The current water path is already usable for many inland and cartographic scenarios.
-
-**Feasibility:** F2  
-**Estimate:** 20-35 pd  
-**Enter backlog only if:** coastal visualization, open-water cinematics, or wave-spectrum fidelity become a named product requirement.
-
-### Epic TV9 - OCIO Color-Managed Terrain Output
-
-**Why conditional:** OCIO matters for VFX and print pipelines, but it carries the highest regression risk because it touches final pixel output across all terrain renders.
-
-**Feasibility:** F3  
-**Estimate:** 25-45 pd  
-**Enter backlog only if:** Forge3D needs a formal color-managed interchange path with Blender/Nuke/ACES-based pipelines.
-
----
-
-## 8. Deferred But Reasonable
-
-These are not rejected forever. They are simply not the right near-term terrain backlog.
-
-| Feature | Why deferred |
-|---|---|
-| **Projected decals** | Existing raster and vector overlays already cover most terrain annotation workflows. Revisit only if terrain needs projected textured detail on arbitrary mesh surfaces. |
-| **Compute tessellation for terrain** | Current clipmaps, POM, and detail normals already cover many practical close-range needs. The risk/reward ratio is weaker than probes, scattering, or output hardening. |
-| **Adaptive sampling + OIDN** | Valuable, but currently attached to the broader offline/path-tracing story rather than the primary terrain render path. Revisit after terrain AOV/EXR output is trustworthy and if film-quality offline terrain rendering becomes a core product goal. |
-| **Virtual Shadow Maps** | Desirable for shadow stability, but the terrain path already supports multiple shadow techniques. It is not ahead of probes or terrain population in terrain-specific value. |
-
----
-
-## 9. Explicitly Out of Scope for Terrain
-
-The following appear in the Blender or Unreal comparison documents but should not be disguised as terrain-roadmap work:
-
-| Feature family | Why it stays out |
-|---|---|
-| **Nanite-class virtualized geometry** | Architecturally mismatched with Forge3D's terrain-first rendering model and unnecessary for the terrain problem it already solves with clipmaps and tiles. |
-| **Lumen-class fully dynamic GI** | Major renderer-architecture project with poor terrain-first ROI compared with probe lighting. |
-| **Skeletal animation, morph targets, advanced character shading** | Not terrain visualization work. |
-| **Material graph editor, Geometry Nodes, in-editor sculpting, full modifier stack** | These are editor-product commitments, not terrain-rendering epics. |
-| **Gameplay, AI, multiplayer replication, audio systems** | Unreal-class engine concerns, not terrain visualization roadmap items. |
-| **Grease Pencil, video editing, Blender-style authoring UI** | Blender-class DCC concerns, not Forge3D terrain priorities. |
-
----
-
-## 10. Recommended Execution Order
-
-| Phase | Epics | Reason |
-|---|---|---|
-| **Phase 1** | TV1, TV2 | Fix the terrain-path correctness issues first: atmosphere parity, real AOVs, trustworthy export, and regression coverage. |
-| **Phase 2** | TV3, TV4 | Improve what users see immediately in terrain scenes: population and material variation. |
-| **Phase 3** | TV5 | Add the first real local-lighting upgrade after terrain output and scene population are solid. |
-| **Phase 4** | TV6, TV7 | Add localized atmosphere and weather once the core terrain image is correct and compositable. |
-| **Conditional branch** | TV8, TV9 | Only if coastal/hydrology or color-managed pipeline requirements become explicit roadmap items. |
-
----
-
-## 11. Effort Summary
-
-### Core terrain backlog
-
-| Epic | Low | High |
-|---|---:|---:|
-| TV1 - Terrain Atmosphere Path Parity | 10 pd | 18 pd |
-| TV2 - Terrain Output and Compositing Foundation | 18 pd | 28 pd |
-| TV3 - Terrain Scatter and Population | 28 pd | 45 pd |
-| TV4 - Terrain Material Variation Upgrade | 14 pd | 24 pd |
-| TV5 - Local Probe Lighting for Terrain Scenes | 30 pd | 55 pd |
-| TV6 - Heterogeneous Terrain Volumetrics | 18 pd | 30 pd |
-| TV7 - Weather Particle Foundation | 25 pd | 40 pd |
-| **Total core backlog** | **143 pd** | **240 pd** |
-
-### Conditional terrain backlog
-
-| Epic | Low | High |
-|---|---:|---:|
-| TV8 - Coastal / Hydrology Water Upgrade | 20 pd | 35 pd |
-| TV9 - OCIO Color-Managed Terrain Output | 25 pd | 45 pd |
-| **Total conditional** | **45 pd** | **80 pd** |
-
----
-
-## 12. Bottom-Line Assessment
-
-Against Blender and Unreal, the **meaningful** terrain-visualization gaps are not "become a full DCC" and not "become a full game engine." They are:
-
-1. Finish the terrain paths that are currently only half-wired.
-2. Add terrain-native scene population and local-lighting tools.
-3. Improve atmosphere, export, and compositing in ways that preserve Forge3D's terrain strengths.
-
-That is the correct terrain backlog. Everything else from the Blender and Unreal reports should either remain deferred or be handled in a separate non-terrain roadmap.
-
----
-
-## 13. Implementation Status Snapshot (2026-03-22)
-
-Source audit of `main` branch as of commit `8653a6f`.
-
-| Epic | Status | Evidence |
-|---|---|---|
-| **TV1 - Terrain Atmosphere Path Parity** | **Shipped** | `src/terrain/renderer/atmosphere.rs` fully integrates `SkySettings` into terrain compute pipeline via `sky.wgsl`. Commit `e735359`. |
-| **TV2 - Terrain Output and Compositing Foundation** | **Shipped** | `src/terrain/renderer/aov.rs` (702 lines) populates albedo/normal/depth MRTs. Multi-channel EXR export via `build_terrain_exr_channels()`. Commit `d833137`. |
-| **TV3 - Terrain Scatter and Population** | **Shipped** | `src/terrain/scatter.rs` implements seeded random, grid+jitter, and mask-density placement with slope filters, distance culling, and LOD selection. Memory tracked via `TerrainScatterMemoryReport`. Commit `d341097`. |
-| **TV4 - Terrain Material Variation Upgrade** | **Shipped** | `src/shaders/terrain_noise.wgsl` (108 lines) extracts shared noise module with FBM, ridged FBM, and cellular distance. Python controls exposed. Commit `e580d8a`. |
-| **TV5 - Local Probe Lighting for Terrain Scenes** | **Shipped** | SH L2 irradiance probes with probe baker, GPU types, `SHL2` in `src/terrain/probes/`, and `terrain_probes.wgsl` shader integration (fs_main blending, debug modes). Commit `3c8ac2e`. |
-| **TV13 - Terrain Population LOD Pipeline** | **Shipped** | QEM mesh simplification in `src/geometry/simplify.rs`, auto-LOD chain generation via `generate_lod_chain()` and `auto_lod_levels()`, HLOD spatial clustering with merged proxy meshes in `src/terrain/scatter.rs`. Stats (`hlod_cluster_draws`, `hlod_covered_instances`, `effective_draws`) and memory tracking (`hlod_buffer_bytes`) plumbed through renderer, viewer, and IPC paths. Branch `epic-13`. |
-| **TV6 - Heterogeneous Terrain Volumetrics** | **Partial** | Viewer volumetrics (`viewer_volumetrics.wgsl`) implement height-based exponential fog with Henyey-Greenstein phase and god-rays, but density is height-derived only — no 3D density texture or spatial variation. Terrain renderer defers to sky pass. |
-| **TV7 - Weather Particle Foundation** | **Not started** | No GPU particle emitter, update, or render code in any terrain path. |
-| **TV8 - Coastal / Hydrology Water Upgrade** | **Not started** | `water_surface.wgsl` uses analytic wave composition. No FFT/Tessendorf path. |
-| **TV9 - OCIO Color-Managed Terrain Output** | **Not started** | No OCIO integration found. |
-
----
-
-## 14. Cross-Report Addendum: Additional Terrain-Relevant Gaps
-
-The original TV1-TV9 backlog was derived from a first-pass Blender comparison and the Unreal report's terrain-adjacent sections. Now that TV1-TV4 and TV10 are shipped and TV5 is in progress, a second pass against `docs/plans/forge3d_vs_unreal_gap_analysis.md` reveals the remaining terrain-visualization gaps that still meet the selection rules in §2 and are not covered by already-shipped work.
-
-### 14.1 Selection Methodology
-
-Each candidate was evaluated against:
-
-1. **Terrain specificity** — Does this gap directly affect terrain rendering, terrain review, or terrain export? General rendering improvements that happen to touch terrain are excluded.
-2. **Current code state** — What plumbing, stubs, or partial implementations already exist? A gap with existing infrastructure is cheaper and less risky than one requiring greenfield work.
-3. **Unblocked by shipped work** — Several items were previously deferred pending TV1-TV4. Those deferral conditions have now been met.
-4. **Blender/Unreal parity value** — Is the gap visible in a direct terrain render comparison, or is it an internal architecture concern?
-
-### 14.2 Additional Terrain Gap Matrix
-
-| Feature | Blender / Unreal reference | Verified repo status | Feasibility | Desirability | Decision |
-|---|---|---|---|---|---|
-| **Terrain subsurface materials (snow/ice/earth SSS)** | Blender: Cycles SSS for natural materials; Unreal: Subsurface Profile shading model (§1.2) | **Shipped.** TV10 adds per-layer terrain subsurface controls in `python/forge3d/terrain_params.py`, native/uniform plumbing in `src/terrain/render_params/` and `src/terrain/renderer/`, bounded shader support in `src/shaders/terrain_pbr_pom.wgsl`, and docs/example/golden coverage. | F2 | High | **Shipped** |
-| **Terrain shadow quality (VSM integration)** | Unreal: Virtual Shadow Maps (§2.2); Blender: CSM cascade quality is a known terrain limitation | **Partial.** `ShadowTechnique::VSM` and `EVSM` variants exist in `src/lighting/shadow.rs`. Terrain renderer uses CSM only. `page_table.rs` provides the page-table pattern VSM would reuse. | F2-F3 | Medium-High | **Build** |
-| **Terrain offline render quality (adaptive sampling + denoiser)** | Blender: adaptive sampling + OIDN; Unreal: movie render queue quality passes (§12.2) | **Partial.** Path tracer with ReSTIR, importance sampling, and A-trous denoiser exists. No adaptive sampling scheduler. No OIDN or production-grade learned denoiser. Existing A-trous is edge-aware but not terrain-optimized. Deferral condition ("after terrain export foundation lands") is now satisfied — TV2 shipped. | F2 | Medium-High | **Build** |
-| **Terrain population LOD pipeline** | Blender: modifier-stack mesh simplification; Unreal: auto LOD generation + HLOD (§3.2, §11.2) | **Missing for scatter.** TV3's scatter system is shipped but requires users to provide LOD levels manually. No automatic mesh simplification (quadric error metrics). No HLOD merging for distant terrain objects. `src/geometry/` has subdivision but not simplification. | F2 | Medium-High | **Build** |
-| **Terrain flow and trajectory visualization** | Blender: particle paths, curve rendering; Unreal: ribbon/trail effects (§13.2, rated F1) | **Partial.** `src/geometry/` has ribbon generation, tube generation, and curve handling. No animated terrain-aware flow rendering. No integration with terrain height sampling for draped flow paths. | F1-F2 | Medium | **Conditional** |
-
----
-
-## 15. Additional Build Backlog
-
-### Epic TV10 - Terrain Subsurface Materials
-
-**Status:** Shipped in `1.17.0`.
-
-**Why this is in scope:** Snow, glacial ice, wet earth, and dense vegetation all exhibit subsurface light transport. Blender's Cycles renders these materials with dedicated SSS; Unreal's Subsurface Profile shading model handles the same cases. Forge3D's `subsurface` material parameter already flows through `MaterialShading` but is not consumed by the terrain PBR shader. With TV4 (material variation) shipped, the material layer system now distinguishes snow, rock, and wetness layers — each of which would directly benefit from terrain-specific SSS.
-
-**Feasibility:** F2
-**Estimate:** 12-20 pd
-**Priority:** P1 (completed)
-
-| Deliverable | Scope | Shipped outcome |
-|---|---|---|
-| **TV10.1 Wire subsurface parameters into terrain PBR shader** | Extend `terrain_pbr_pom.wgsl` to read terrain-layer subsurface state inside the terrain lighting accumulation. The shipped path stays terrain-first: a bounded per-pixel approximation built from wrap lighting, backscatter, and curvature-weighted diffusion. | Snow and wet terrain layers now show visibly different light transport from rock under the same lighting conditions, while explicit zero-strength subsurface remains pixel-stable against the pre-TV10 baseline. No full-screen post-pass was added. |
-| **TV10.2 Add per-layer subsurface controls to terrain material config** | Expose `subsurface_strength` and `subsurface_color` per material layer (snow, rock, wetness) in the Python terrain params config, with defaults that improve alpine scenes out of the box without forcing the feature on when layers are disabled. | `MaterialLayerSettings` now preserves independent per-layer subsurface values; snow defaults to a non-zero terrain subsurface response, rock stays neutral by default, and the public docs page records the parameter semantics and valid ranges. |
-| **TV10.3 Add terrain SSS regression tests** | Add config-level, runtime render, and golden-image coverage that verifies terrain SSS output changes when expected and does not regress the zero-strength baseline. | TV10 ships with dedicated config/API tests, runtime render tests across two lighting setups, a real-DEM demo for Mount Rainier and Gore Range, and three dedicated goldens that lock both SSS-on scenes and the zero-strength baseline. |
-
-### Epic TV11 - Terrain Shadow Quality (VSM Integration)
-
-**Why this is in scope:** Cascaded shadow map transitions create visible banding artifacts on large terrain surfaces, particularly at medium viewing distances where cascade boundaries cross the terrain plane. This is a known terrain rendering quality gap versus both Blender (which composites shadow in a single offline pass) and Unreal (which uses page-based virtual shadow maps for per-pixel resolution). Forge3D already has `ShadowTechnique::VSM` and `EVSM` in `src/lighting/shadow.rs` and a page-table pattern in `src/terrain/clipmap/page_table.rs` — the architectural primitives exist but are not connected to the terrain shadow path.
+**Why this is in scope:** Large terrains can already stream geometry and data well, but terrain material delivery still behaves like a smaller-scene texture workflow. Top engines solve this with terrain-oriented virtual texturing and RVT-style paging.
 
 **Feasibility:** F2-F3
-**Estimate:** 22-38 pd
+**Estimate:** 24-40 pd
 **Priority:** P2
 
 | Task | Scope | Definition of done |
 |---|---|---|
-| **TV11.1 Add VSM shadow path to terrain renderer** | Wire `ShadowTechnique::VSM` into the terrain shadow pipeline as a runtime-selectable alternative to the current CSM path. Reuse the existing VSM filtering code in `shadow.rs`. | Terrain scenes can render with VSM enabled via config; cascade banding artifacts are measurably reduced or eliminated at medium viewing distances; CSM remains the default and is unaffected when VSM is not selected. |
-| **TV11.2 Add page-based shadow allocation for terrain** | Adapt the terrain page-table pattern to drive shadow-page allocation, so shadow resolution tracks the visible terrain surface rather than fixed cascades. | Shadow resolution is proportional to screen-space pixel density on the terrain surface; shadow memory is tracked by `memory_tracker`; the page allocation path does not interfere with the existing terrain clipmap page table. |
-| **TV11.3 Add shadow quality A/B comparison tests** | Add terrain-specific shadow comparison tests that quantify the CSM-to-VSM quality difference and prevent shadow regressions. | At least 2 terrain scenes compare CSM vs VSM output for shadow boundary quality; a perf test records frame-time impact of VSM on a representative terrain scene; CSM baseline golden images are not broken by the addition. |
+| **TV20.1 Define a terrain VT material contract** | Introduce a bounded terrain-material paging model for albedo, normal, and mask layers without inventing a general material-graph system. | A terrain material stack can declare paged layers with explicit tile size, residency budget, and fallback behavior; non-VT terrain scenes continue to render through the current path unchanged. |
+| **TV20.2 Add feedback-driven residency and terrain sampling** | Connect the existing virtual-texture foundations to terrain material sampling. | Camera motion requests only the needed material pages, terrain shaders sample paged material data correctly, and representative large-scene renders do not show persistent page seams or stale tiles. |
+| **TV20.3 Expose budgets, stats, and regression coverage** | Make the feature operable rather than opaque. | Cache budget, resident tile count, miss rate, and upload cost are queryable; at least one large-terrain test verifies stable residency behavior when the full material set exceeds immediate memory budget. |
 
-### Epic TV12 - Terrain Offline Render Quality
-
-**Why this is in scope:** TV2 (terrain AOV export) is shipped. The deferral condition in §8 ("Defer until terrain export foundation lands") is satisfied. Blender's offline rendering pipeline delivers adaptive sampling (concentrating samples on noisy pixels) and OIDN denoising as standard terrain-output quality tools. Forge3D's path tracer has ReSTIR, importance sampling, and an A-trous denoiser, but lacks adaptive sample scheduling and a production-grade learned denoiser. For terrain offline renders — the primary output path for print, publication, and compositing workflows — these are the remaining quality gaps between Forge3D terrain output and Blender Cycles terrain output.
-
-**Feasibility:** F2
-**Estimate:** 18-30 pd
-**Priority:** P2
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV12.1 Add adaptive sampling scheduler for terrain path tracing** | Implement per-tile or per-pixel variance estimation that concentrates additional samples on high-variance regions of the terrain render. | Adaptive mode converges to a target noise threshold with fewer total samples than uniform sampling on a representative terrain scene; the scheduler is optional and defaults to off for backward compatibility; sample counts are queryable from Python. |
-| **TV12.2 Integrate a learned denoiser for terrain offline output** | Add OIDN (Intel Open Image Denoise) or equivalent as a feature-gated post-pass for terrain path-traced output, guided by the AOV channels (albedo, normal, depth) that TV2 now provides. | The denoiser produces visibly cleaner terrain output than the existing A-trous pass alone at equivalent sample counts; the denoiser is optional and feature-gated; it consumes the same AOV channels that TV2 exports; the existing A-trous path remains available as the zero-dependency fallback. |
-| **TV12.3 Add terrain offline quality regression tests** | Add tests that verify adaptive sampling convergence and denoiser output quality on terrain scenes. | At least 1 terrain scene verifies that adaptive sampling reaches target variance in fewer samples than uniform; at least 1 scene compares denoised vs raw output PSNR; the existing path-tracing golden tests are not regressed. |
-
-### Epic TV13 - Terrain Population LOD Pipeline
-
-**Why this is in scope:** TV3 (terrain scatter) is shipped and supports multi-level LOD selection, but users must provide pre-authored LOD meshes manually. Both Blender (modifier-stack mesh simplification) and Unreal (automatic LOD generation + HLOD merging) provide automatic mesh simplification. For terrain population at scale — thousands of placed trees, rocks, or structures — manual LOD authoring is impractical. Automatic simplification and HLOD generation would make TV3's scatter system viable for dense terrain scenes without requiring users to pre-process every asset.
-
-**Feasibility:** F2
-**Estimate:** 16-28 pd
-**Priority:** P2
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV13.1 Add automatic mesh simplification** | Implement quadric error metric (QEM) mesh simplification as a preprocessing utility in `src/geometry/`. Input: a `MeshBuffers` at full resolution. Output: a simplified `MeshBuffers` at a target face ratio. | A representative mesh can be simplified to 50%, 25%, and 10% face counts with documented quality/fidelity trade-offs; the simplifier preserves UV seams and hard edges where possible; the output feeds directly into the existing instanced mesh path used by TV3. |
-| **TV13.2 Add auto-LOD chain generation for scatter assets** | Given a scatter asset, automatically generate a configurable number of LOD levels using TV13.1, and register them with the TV3 scatter system's existing `select_level_index` path. | Scatter batches can be configured with `auto_lod: true` and a target LOD count; generated LOD levels are consumed by the existing TV3 distance-based LOD selection; users can still provide manual LOD meshes to override auto-generation. |
-| **TV13.3 Add HLOD merging for distant terrain populations** | For scatter objects beyond a configurable distance threshold, merge individual instances into a single simplified imposter mesh rather than drawing each instance. | A dense scatter batch (10k+ instances) shows measurably reduced draw call count beyond the HLOD distance; the merged mesh is regenerated when scatter parameters change; HLOD memory is tracked by `memory_tracker`. |
-
----
-
-## 16. Additional Conditional Epics
-
-### Epic TV14 - Terrain Flow and Trajectory Visualization
-
-**Why conditional:** Flow paths, wind vectors, erosion patterns, and trajectory rendering are legitimate terrain-visualization use cases (hydrology, meteorology, geomorphology). The geometry module already has ribbon generation, tube generation, and curve handling — the infrastructure gap is small. However, this feature is domain-specific to scientific terrain workflows and may not justify the terrain pipeline integration cost for general terrain visualization.
-
-**Feasibility:** F1-F2
-**Estimate:** 10-18 pd
-**Enter backlog only if:** hydrology, meteorology, or trajectory visualization becomes a named product requirement for terrain scenes.
-
-### Epic TV15 - Compute Tessellation for Terrain
-
-**Why conditional:** Close-range terrain detail is limited by fixed mesh topology. Compute-driven adaptive tessellation would provide real geometric displacement for terrain close-ups, surpassing the current POM approximation. However, the existing combination of clipmaps + POM + detail normals (enhanced by TV4's noise system) already covers most practical terrain scenarios. The ROI is lower than other terrain quality upgrades.
-
-**Feasibility:** F2
-**Estimate:** 20-35 pd
-**Enter backlog only if:** close-range terrain detail fidelity becomes a named product requirement that POM cannot satisfy, or if WebGPU gains hardware tessellation stages that reduce implementation cost.
-
----
-
-## 17. Updated Effort Summary
-
-### Shipped terrain backlog
-
-| Epic | Status |
-|---|---|
-| TV1 - Terrain Atmosphere Path Parity | **Shipped** |
-| TV2 - Terrain Output and Compositing Foundation | **Shipped** |
-| TV3 - Terrain Scatter and Population | **Shipped** |
-| TV4 - Terrain Material Variation Upgrade | **Shipped** |
-| TV10 - Terrain Subsurface Materials | **Shipped** |
-
-### Active terrain backlog
-
-| Epic | Status | Low | High |
-|---|---|---:|---:|
-| TV5 - Local Probe Lighting for Terrain Scenes | In progress (worktree) | 30 pd | 55 pd |
-| TV6 - Heterogeneous Terrain Volumetrics | Partial (height fog only) | 18 pd | 30 pd |
-| TV7 - Weather Particle Foundation | Not started | 25 pd | 40 pd |
-| **Subtotal active (original)** | | **73 pd** | **125 pd** |
-
-### New terrain backlog (this addendum)
-
-| Epic | Low | High |
-|---|---:|---:|
-| TV11 - Terrain Shadow Quality (VSM Integration) | 22 pd | 38 pd |
-| TV12 - Terrain Offline Render Quality | 18 pd | 30 pd |
-| TV13 - Terrain Population LOD Pipeline | 16 pd | 28 pd |
-| **Total new backlog** | **56 pd** | **96 pd** |
-
-### Conditional terrain backlog (updated)
-
-| Epic | Low | High |
-|---|---:|---:|
-| TV8 - Coastal / Hydrology Water Upgrade | 20 pd | 35 pd |
-| TV9 - OCIO Color-Managed Terrain Output | 25 pd | 45 pd |
-| TV14 - Terrain Flow and Trajectory Visualization | 10 pd | 18 pd |
-| TV15 - Compute Tessellation for Terrain | 20 pd | 35 pd |
-| **Total conditional** | **75 pd** | **133 pd** |
-
-### Grand total remaining terrain work
-
-| Category | Low | High |
-|---|---:|---:|
-| Active original (TV5-TV7) | 73 pd | 125 pd |
-| New build (TV11-TV13) | 56 pd | 96 pd |
-| **Total build backlog** | **129 pd** | **221 pd** |
-| Conditional (TV8-TV9, TV14-TV15) | 75 pd | 133 pd |
-| **Total including conditional** | **204 pd** | **354 pd** |
-
----
-
-## 18. Updated Execution Order
-
-| Phase | Epics | Reason |
-|---|---|---|
-| **Phase 1** *(shipped)* | TV1, TV2, TV3, TV4 | Terrain-path correctness, output, population, and material foundations. **Complete.** |
-| **Phase 2** *(active)* | TV5 | Local probe lighting remains the only open item in this phase now that TV10 is shipped. |
-| **Phase 3** | TV6, TV11, TV13 | Heterogeneous volumetrics, shadow quality, and population LOD. These improve the visible quality of terrain scenes that already have atmosphere (TV1), population (TV3), and probes (TV5). |
-| **Phase 4** | TV7, TV12 | Weather particles and offline render quality. These are the final terrain-image quality features before the core terrain rendering story is complete. |
-| **Conditional branch** | TV8, TV9, TV14, TV15 | Only if coastal/hydrology, color-managed pipelines, flow visualization, or close-range displacement become explicit product requirements. |
-
----
-
-## 19. Addendum Bottom-Line Assessment
-
-With TV1-TV4 and TV10 shipped, and TV5 still in progress, the remaining terrain-visualization gap against Blender and Unreal has narrowed to four categories:
-
-1. **Terrain material realism** — probe-quality local lighting (TV5, in progress).
-2. **Terrain shadow and atmosphere quality** — VSM shadow integration (TV11), heterogeneous volumetrics (TV6), and weather particles (TV7).
-3. **Terrain output quality** — adaptive sampling and production denoiser for offline renders (TV12), now unblocked by TV2.
-4. **Terrain population at scale** — automatic LOD generation and HLOD merging for scatter objects (TV13), extending TV3.
-
-These are the gaps that remain visible in a direct terrain-render comparison. Everything else from the Blender and Unreal reports is either already shipped, in progress, correctly deferred, or not terrain-visualization work.
-
----
-
-## 20. Third-Pass Addendum: Terrain Review and Delivery Gaps
-
-The prior addenda correctly focused on image-quality gaps. A third pass across the same terrain-first scope surfaces a different class of missing capability: features that make terrain scenes easier to compare, review, animate, and deliver once the renderer is already credible.
-
-### 20.1 Method Note
-
-The user-requested root file `forge3d_vs_blender_gap_analysis.md` is not present in this worktree. This pass therefore uses:
-
-- the Blender-derived findings already embedded in sections 4-19 of this document,
-- `docs/api/blender_features.md`,
-- `docs/notes/implement.md`, and
-- `docs/plans/forge3d_vs_unreal_gap_analysis.md`.
-
-This pass also treats the active TV5 probe files now present in the workspace (`src/terrain/renderer/probes.rs`, `src/shaders/terrain_probes.wgsl`, `tests/test_terrain_probes.py`) as **in-progress implementation evidence**, not as shipped backlog closure.
-
-### 20.2 Additional Terrain Gap Matrix
-
-| Feature | Blender / Unreal reference | Verified repo status | Feasibility | Desirability | Decision |
-|---|---|---|---|---|---|
-| **Terrain scene variants and review layers** | Unreal: Data Layers / scene variants; Blender-adjacent: saved scene/view-layer state for alternate outputs | **Partial.** `python/forge3d/bundle.py` and `src/bundle/manifest.rs` persist terrain metadata, presets, and camera bookmarks, but not named runtime variants or grouped layer states. `src/viewer/ipc/protocol/request.rs` exposes per-overlay toggles, not named variant activation. | F1-F2 | High | **Build** |
-| **Terrain camera rig toolkit** | Unreal: camera rig system; Blender: path/constrained camera workflows | **Partial.** `src/animation/mod.rs` supports cubic-Hermite camera keyframes and `src/animation/render_queue.rs` enumerates frame export, but there are no orbit/rail/target-follow rig primitives, terrain-clearance constraints, or rig baking helpers. | F1-F2 | High | **Build** |
-| **Terrain delivery queue and bounded timeline** | Unreal: Movie Render Queue + Sequencer; Blender: repeatable batch render workflow | **Partial.** Terrain AOV export exists after TV2 and camera keyframe export exists, but there is no shot manifest, no multi-shot batch queue, and no bounded track system for terrain-specific property changes such as active variant, sun, sky, or overlay visibility. | F2-F3 | High | **Build** |
-| **Collaborative terrain review** | Unreal: collaborative viewing / shared review; Blender equivalent is weaker, but review sessions are a real product gap | **Partial.** The existing viewer IPC surface is already TCP + NDJSON and includes terrain, overlay, label, and camera commands, but there is no multi-client session model, no broadcast/state replay, and no shared annotation ownership semantics. | F2 | Medium-High | **Build later** |
-| **Terrain night-light fidelity** | Unreal: IES profiles; Blender: measured-light workflows | **Missing.** The lighting stack has the right shader/light infrastructure for additive profile sampling, but there is no IES asset ingestion or terrain-scene hookup. This is valuable only for night scenes with built infrastructure. | F1 | Medium-Low | **Conditional** |
-
-### 20.3 Selection Rationale
-
-These items meet the section 2 rules because they materially improve terrain review or terrain export without requiring Forge3D to become an editor product. They also sit above, rather than instead of, the TV5-TV15 rendering backlog:
-
-1. **TV16 and TV17** improve how terrain scenes are compared and authored for flyovers.
-2. **TV18** turns the existing renderer into a repeatable delivery pipeline instead of a single-shot API.
-3. **TV19** is review-specific and should stay explicitly below the rendering and delivery fundamentals.
-4. **IES lighting** remains conditional because it helps only a narrower subset of terrain scenes than variants, rigs, or delivery tooling.
-
----
-
-## 21. Additional Build Backlog
+### Review and Delivery
 
 ### Epic TV16 - Terrain Scene Variants and Review Layers
 
-**Why this is in scope:** The current bundle/runtime model is good at storing one terrain state plus bookmarks, but weak at comparing alternate states of the same scene. Unreal's Data Layers are relevant here because terrain review often requires switching among alternate overlays, scatter states, lighting presets, and annotation sets without duplicating the entire scene.
+**Why this is in scope:** Terrain review usually involves comparing alternate states of one scene, not reloading separate projects for every overlay, scatter, or lighting choice.
 
-**Feasibility:** F1-F2  
-**Estimate:** 10-16 pd  
-**Priority:** P1
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV16.1 Add named layer and variant schema** | Extend bundle/runtime state with named review layers and named variants that reference existing terrain assets, overlays, scatter batches, labels, and presets without duplicating payload files. | A bundle can persist at least 3 named variants that share one DEM and one asset set; variants round-trip through save/load without checksum ambiguity; the schema distinguishes between per-layer visibility and whole-variant activation. |
-| **TV16.2 Add atomic apply/list APIs** | Add Python and IPC surfaces to list variants, query the active variant, toggle individual layers, and apply a variant in one state transition. | One API call can switch the active variant; invalid layer or variant IDs fail explicitly; applying a variant that reuses the same terrain asset does not force a terrain reload. |
-| **TV16.3 Add variant regression tests** | Verify persistence, deterministic switching, and blast radius. | Tests prove that switching variants changes only the declared overlays/scatter/labels/preset fields, preserves camera state unless explicitly variant-owned, and survives bundle round-trip without silent state loss. |
-
-### Epic TV17 - Terrain Camera Rig Toolkit
-
-**Why this is in scope:** Forge3D already has camera keyframes, but terrain flyovers are still authored one keyframe at a time. Blender and Unreal both reduce this friction with path- and rig-driven cameras. For terrain visualization, the missing value is not character animation; it is reusable flyover authoring with terrain-aware clearance.
-
-**Feasibility:** F1-F2  
-**Estimate:** 12-20 pd  
-**Priority:** P1
-
-| Task | Scope | Definition of done |
-|---|---|---|
-| **TV17.1 Add bounded rig primitives** | Implement only terrain-relevant rig types: orbit, rail/path, and target-follow with minimum altitude-above-terrain clearance. | Each rig type can produce a deterministic camera path from a small parameter set; the target-follow rig never penetrates below a configured terrain clearance threshold on a representative DEM. |
-| **TV17.2 Bake rigs into existing `CameraAnimation`** | Keep the current keyframe/interpolation system as the execution layer by compiling rig specs into editable camera keyframes rather than inventing a parallel playback runtime. | A rig can be baked into `CameraAnimation`, inspected, edited, and rendered through the existing render queue; manual keyframe overrides survive re-render without custom rig-only code paths. |
-| **TV17.3 Add rig examples and tests** | Cover both ergonomics and safety. | At least two example flyovers exist (`orbit` and `rail`); tests verify deterministic frame count, stable timing, and no below-terrain camera samples for the clearance-constrained rigs. |
-
-### Epic TV18 - Terrain Delivery Queue and Bounded Timeline
-
-**Why this is in scope:** TV2 solved terrain AOV export and the animation module can already enumerate camera frames, but there is still no coherent terrain delivery surface comparable to Unreal's Movie Render Queue plus a constrained subset of Sequencer. The missing feature is not a full DCC timeline; it is a repeatable shot queue for terrain outputs.
-
-**Feasibility:** F2-F3  
-**Estimate:** 18-28 pd  
+**Feasibility:** F1-F2
+**Estimate:** 10-16 pd
 **Priority:** P2
 
 | Task | Scope | Definition of done |
 |---|---|---|
-| **TV18.1 Define a terrain shot manifest** | Introduce a serializable shot/job spec containing camera animation or rig, active variant, render size, frame range, output formats, and AOV selection. | One manifest can describe multiple shots with explicit output directories and pass selections; invalid shot specs fail before rendering begins; per-shot metadata records the exact terrain preset and variant used. |
-| **TV18.2 Add bounded timeline tracks** | Support only the property tracks that materially affect terrain delivery: camera, sun, sky, exposure/tonemap, active variant, and overlay visibility. Do not add generic arbitrary-property tracks, events, or audio. | A shot can animate at least camera, sun, sky, and active variant over time; evaluation is deterministic frame-to-frame; v1 explicitly excludes audio, gameplay events, and arbitrary object tracks. |
-| **TV18.3 Build pass-aware batch rendering** | Run multi-shot renders with progress, resume, and structured outputs using the TV2 terrain beauty/AOV pipeline. | A queue can render multiple shots to a stable directory layout with beauty PNG plus optional multi-channel EXR/AOV outputs; interrupted runs can resume from the current shot/frame without re-rendering completed outputs; progress is queryable from Python. |
+| **TV16.1 Add named terrain variants and review layers** | Extend bundles and runtime state with named variants and grouped layer visibility. | A bundle can persist named variants that share one terrain asset set, and the schema distinguishes between per-layer visibility and whole-variant activation. |
+| **TV16.2 Add atomic apply/list APIs** | Make variants usable from Python and IPC without ad hoc state juggling. | Clients can list variants, query the active variant, toggle layers, and apply a variant in one state transition; invalid IDs fail explicitly. |
+| **TV16.3 Add persistence and state-isolation tests** | Ensure variant switching is deterministic and bounded. | Tests prove that switching variants changes only declared overlay/scatter/label/preset state and survives bundle round-trip without silent state loss. |
 
-### Epic TV19 - Collaborative Terrain Review
+### Epic TV17 - Terrain Camera Rig Toolkit
 
-**Why this is in scope:** Terrain visualization is often a review workflow, not just a render. Unreal's collaborative-viewing direction is relevant here, but Forge3D should stop far short of multiplayer simulation. The practical goal is shared camera, shared annotations, and shared variant state over the existing NDJSON control surface.
+**Why this is in scope:** Keyframes exist, but terrain flyovers are still too manual. The missing layer is reusable rig authoring for orbit, rail, and constrained follow cameras.
 
-**Feasibility:** F2  
-**Estimate:** 16-26 pd  
+**Feasibility:** F1-F2
+**Estimate:** 12-20 pd
+**Priority:** P2
+
+| Task | Scope | Definition of done |
+|---|---|---|
+| **TV17.1 Add terrain-relevant rig primitives** | Implement orbit, rail/path, and target-follow rigs with terrain-clearance control. | Each rig produces a deterministic camera path from a small parameter set, and clearance-constrained rigs do not intersect the terrain on representative DEMs. |
+| **TV17.2 Bake rigs into `CameraAnimation`** | Keep one playback/runtime model by compiling rigs into editable camera keyframes. | Rigs bake into `CameraAnimation`, can be inspected and edited, and render through the existing frame queue without a second animation runtime. |
+| **TV17.3 Add rig examples and tests** | Cover usability and safety. | At least two example flyovers and regression tests verify deterministic timing, frame counts, and clearance behavior. |
+
+### Epic TV18 - Terrain Shot Queue and Bounded Timeline
+
+**Why this is in scope:** Forge3D can render one terrain sequence, but it still lacks a coherent terrain delivery workflow for multi-shot output.
+
+**Feasibility:** F2-F3
+**Estimate:** 18-28 pd
 **Priority:** P3
 
 | Task | Scope | Definition of done |
 |---|---|---|
-| **TV19.1 Add a session coordinator** | Add a minimal multi-client session layer above the existing viewer IPC protocol, with one authoritative scene state and client join/leave semantics. | At least two clients can connect to the same terrain review session and observe synchronized camera, active variant, and overlay/label state without manual polling glue in user code. |
-| **TV19.2 Add shared bookmark and annotation propagation** | Make camera bookmarks, labels, callouts, and review annotations session-visible and persistable. | An annotation or bookmark created by one client appears on all connected clients, can be saved into a bundle/session artifact, and includes minimal author/timestamp metadata. |
-| **TV19.3 Define recovery and conflict rules** | Keep the semantics explicit and testable. | Reconnecting clients receive the current session snapshot; last-writer-wins or host-authoritative conflict behavior is documented and test-covered; there is no hidden slide into full replicated simulation. |
+| **TV18.1 Define a terrain shot manifest** | Introduce a serializable shot/job format for terrain outputs. | One manifest can describe multiple shots with render size, frame range, active variant, and pass selection; invalid manifests fail before rendering starts. |
+| **TV18.2 Add bounded timeline tracks** | Support only terrain-relevant animated properties. | A shot can animate camera, sun, sky, exposure/tonemap, active variant, and overlay visibility; v1 explicitly excludes audio, gameplay events, and arbitrary object tracks. |
+| **TV18.3 Build pass-aware multi-shot rendering** | Run queued terrain renders with structured outputs and progress reporting. | A queue can render multiple shots to a stable directory layout with beauty PNG plus optional EXR/AOV outputs and can resume interrupted runs without re-rendering completed frames. |
+
+### Epic TV7 - Weather Particle Foundation
+
+**Why this is in scope:** Rain, snow, dust, ash, and airborne particulate events are terrain-visualization features, not game-engine fluff.
+
+**Feasibility:** F3
+**Estimate:** 25-40 pd
+**Priority:** P4
+
+| Task | Scope | Definition of done |
+|---|---|---|
+| **TV7.1 Add a minimal GPU particle core** | Implement GPU spawn, update, and billboard render for terrain scenes. | A terrain scene can spawn, update, and render at least one weather emitter entirely on GPU, with tracked memory usage and a clean disable path. |
+| **TV7.2 Add terrain-aware collision / kill behavior** | Make particles interact with the terrain heightfield without CPU readback. | Rain, snow, dust, or ash particles can collide with or die on terrain surfaces based on heightfield sampling. |
+| **TV7.3 Ship only terrain-relevant presets** | Keep the v1 scope narrow. | The initial preset set is limited to rain, snow, dust, and ash and does not expand into generic game-VFX concepts. |
 
 ---
 
-## 22. Revised Prioritization for Terrain Visualization
+## 6. Conditional and Deferred Epics
 
-These epics do not replace TV5-TV15. They are the next terrain-first layer once render quality is credible enough to support review and delivery workflows.
+The items below are valid, but they are not core near-term terrain backlog. They are intentionally not decomposed into task tables yet. Doing that now would add speculative work to the plan before the entry conditions are met.
 
-### Additional effort summary
+| Epic | Feasibility | Estimate | Status | Why it is not core right now |
+|---|---|---:|---|---|
+| **TV8 - Coastal / Hydrology Water Upgrade** | F2 | 20-35 pd | Conditional | Worth doing only if coastal, estuary, open-water, or hydrology visualization becomes a named product requirement. |
+| **TV9 - OCIO Color-Managed Terrain Output** | F3 | 25-45 pd | Conditional | Valuable for VFX interchange, but high regression risk because it changes final pixel semantics across terrain outputs. |
+| **TV11 - Page-Based Terrain Shadowing** | F3 | 22-40 pd | Deferred | Real work with real value, but lower ROI than terrain VT, offline quality, population scale, and terrain/mesh integration. |
+| **TV14 - Terrain Flow and Trajectory Visualization** | F1-F2 | 10-18 pd | Conditional | Useful for hydrology, meteorology, or geomorphology workflows, but not core to general terrain visualization. |
+| **TV15 - Compute Tessellation for Terrain** | F2 | 20-35 pd | Conditional | Current clipmaps + POM + detail normals cover most practical close-up terrain needs. |
+| **TV19 - Collaborative Terrain Review** | F2 | 16-26 pd | Conditional | Useful, but it should follow scene variants, camera rigs, and the single-user shot/delivery workflow rather than precede them. |
+| **TV23 - Terrain Temporal Upscaling and Upscaled Viewer Path** | F3 | 18-32 pd | Conditional | TAA already exists. Add a true upscaled viewer path only if interactive high-resolution terrain performance becomes a stated product goal. |
+
+---
+
+## 7. Explicitly Out of Scope
+
+The following should not be smuggled back into the terrain roadmap:
+
+| Feature family | Why it stays out |
+|---|---|
+| **Nanite-class virtualized geometry** | Architecturally mismatched with Forge3D's terrain-first rendering model and unnecessary for the terrain problem clipmaps and tiles already solve well. |
+| **Lumen-class fully dynamic GI** | Much larger renderer work with worse terrain-first ROI than local probe lighting. |
+| **Material graph editors, Geometry Nodes equivalents, in-editor sculpting, full DCC authoring** | These are editor-product commitments, not terrain-rendering epics. |
+| **Skeletal animation, hair/fur pipelines, advanced character systems** | Not terrain visualization work. |
+| **Gameplay frameworks, AI, audio systems, multiplayer replication** | Engine-product concerns, not terrain roadmap items. |
+
+---
+
+## 8. Effort Summary
+
+### Implemented foundations
+
+| Epic | Status |
+|---|---|
+| TV1 - Terrain Atmosphere Path Parity | Implemented |
+| TV2 - Terrain Output and Compositing Foundation | Implemented |
+| TV3 - Terrain Scatter and Population | Implemented |
+| TV4 - Terrain Material Variation Upgrade | Implemented |
+| TV5 - Terrain Local Probe Lighting | Implemented |
+| TV6 - Heterogeneous Terrain Volumetrics | Implemented |
+| TV10 - Terrain Subsurface Materials | Implemented |
+| TV12 - Terrain Offline Render Quality | Implemented |
+| TV13 - Terrain Population LOD Pipeline | Implemented |
+| TV21 - Terrain-Mesh Blending and Contact Integration | Implemented |
+| TV22 - Scatter Wind Animation | Implemented |
+
+### Core build backlog
 
 | Epic | Low | High |
 |---|---:|---:|
+| TV20 - Terrain Material Virtual Texturing | 24 pd | 40 pd |
 | TV16 - Terrain Scene Variants and Review Layers | 10 pd | 16 pd |
 | TV17 - Terrain Camera Rig Toolkit | 12 pd | 20 pd |
-| TV18 - Terrain Delivery Queue and Bounded Timeline | 18 pd | 28 pd |
-| TV19 - Collaborative Terrain Review | 16 pd | 26 pd |
-| **Total new workflow backlog** | **56 pd** | **90 pd** |
+| TV18 - Terrain Shot Queue and Bounded Timeline | 18 pd | 28 pd |
+| TV7 - Weather Particle Foundation | 25 pd | 40 pd |
+| **Total core backlog** | **89 pd** | **144 pd** |
 
-### Updated remaining terrain work
+### Conditional and deferred backlog
 
-| Category | Low | High |
+| Epic | Low | High |
 |---|---:|---:|
-| Existing build backlog before this addendum | 141 pd | 241 pd |
-| New workflow backlog (TV16-TV19) | 56 pd | 90 pd |
-| **Revised total build backlog** | **197 pd** | **331 pd** |
-| Existing conditional backlog (TV8-TV9, TV14-TV15) | 75 pd | 133 pd |
-| Terrain night-light fidelity (conditional) | 5 pd | 10 pd |
-| **Revised total including conditional** | **277 pd** | **474 pd** |
-
-### Revised execution order
-
-| Phase | Epics | Reason |
-|---|---|---|
-| **Phase 5** | TV16, TV17 | Scene variants and rig authoring unlock the most immediately useful terrain review/flyover workflows with low architectural risk. |
-| **Phase 6** | TV18 | A delivery queue only becomes coherent after there is a stable variant model and a reusable camera-authoring layer. |
-| **Phase 7** | TV19 | Collaborative review should land only after single-user review and delivery workflows are explicit and persistence semantics are stable. |
-| **Conditional branch** | Terrain night-light fidelity | Only if night-time built-environment terrain scenes become a named product requirement. |
+| TV8 - Coastal / Hydrology Water Upgrade | 20 pd | 35 pd |
+| TV9 - OCIO Color-Managed Terrain Output | 25 pd | 45 pd |
+| TV11 - Page-Based Terrain Shadowing | 22 pd | 40 pd |
+| TV14 - Terrain Flow and Trajectory Visualization | 10 pd | 18 pd |
+| TV15 - Compute Tessellation for Terrain | 20 pd | 35 pd |
+| TV19 - Collaborative Terrain Review | 16 pd | 26 pd |
+| TV23 - Terrain Temporal Upscaling and Upscaled Viewer Path | 18 pd | 32 pd |
+| **Total conditional / deferred backlog** | **131 pd** | **231 pd** |
 
 ---
 
-## 23. Final Assessment After the Third Pass
+## 9. Execution Order
 
-After TV5-TV15, the highest-value remaining terrain gaps are no longer only about shading. The package is still missing the workflow layer that makes terrain scenes easy to compare, animate, batch-render, and review with other people.
+| Phase | Epics | Reason |
+|---|---|---|
+| **Phase 1** | TV20 | Close the remaining terrain material delivery gap now that local-specular probe lighting is shipped. |
+| **Phase 2** | TV16, TV17 | Add review-state management and reusable flyover authoring once the remaining renderer backlog is narrower. |
+| **Phase 3** | TV18 | Build the shot queue and bounded timeline after variants and rig authoring exist. |
+| **Phase 4** | TV7 | Weather particles matter, but they are less foundational than terrain material delivery and review/delivery tooling. |
+| **Later / optional** | TV8, TV9, TV11, TV14, TV15, TV19, TV23 | Only pursue when product direction or scene requirements clearly justify them. |
 
-The honest priority order is:
+---
 
-1. **Finish image-quality fundamentals already on the board**: TV5, TV11, TV12, TV13.
-2. **Add scene variants and camera rigs next**: TV16 and TV17 are the most leverage-heavy workflow additions and have the lowest scope risk.
-3. **Add a bounded delivery queue before any broad editor ambitions**: TV18 closes a real Blender/Unreal workflow gap without dragging Forge3D into full editor scope.
-4. **Keep collaboration review-only**: TV19 is worthwhile, but only as synchronized review state on top of the existing viewer protocol, not as replication or gameplay infrastructure.
+## 10. Bottom Line
 
-That is the surgically precise terrain backlog after a third systematic pass. The remaining out-of-scope items from Blender and Unreal are still out of scope for the same reasons recorded earlier: they either require an editor product, a game-engine runtime, or a renderer-architecture rewrite.
+Forge3D no longer has a terrain-roadmap problem of "missing everything." Terrain local probe lighting, TV6, TV10, TV12, TV13, TV21, and TV22 are now in the shipped column, so the real remaining gaps are narrower and more concrete:
+
+1. **The remaining terrain/material delivery gap:** TV20.
+2. **Review and delivery workflow:** TV16, TV17, and TV18.
+3. **Terrain atmosphere and weather richness:** later TV7.
+4. **Conditional renderer upgrades that still are not in runtime code despite adjacent design work:** especially TV11.
+
+Terrain-local specular probes, terrain population scale, terrain/mesh integration, and scatter wind now have shipped first-pass runtime coverage rather than sitting in the remaining core backlog.
+
+That is the coherent terrain backlog. Everything else from Blender, Unreal, or other top-tier engines should remain conditional, deferred, or out of scope unless the product direction changes.

--- a/docs/terrain-tv5-probe-lighting.md
+++ b/docs/terrain-tv5-probe-lighting.md
@@ -92,7 +92,9 @@ memory = renderer.get_probe_memory_report()
 ## Example and tests
 
 - Example: `python examples/terrain_tv5_probe_lighting_demo.py`
+- Water-focused reflection-probe demo: `python examples/terrain_tv24_reflection_probe_demo.py`
 - API and behavior tests: `tests/test_terrain_probes.py`
+- Real-DEM demo notes: `docs/examples/terrain_tv24_reflection_probe_demo.md`
 - Detailed design/spec: `docs/superpowers/specs/2026-03-21-tv5-local-probe-lighting-design.md`
 
 The bundled demo writes six outputs:

--- a/examples/terrain_tv24_reflection_probe_demo.py
+++ b/examples/terrain_tv24_reflection_probe_demo.py
@@ -1,0 +1,415 @@
+from __future__ import annotations
+
+import argparse
+import math
+import tempfile
+from pathlib import Path
+
+import numpy as np
+
+
+def _import_forge3d():
+    try:
+        import forge3d as f3d
+
+        return f3d
+    except ModuleNotFoundError:
+        from _import_shim import ensure_repo_import
+
+        ensure_repo_import()
+        import forge3d as f3d
+
+        return f3d
+
+
+f3d = _import_forge3d()
+f3dio = f3d.io
+from forge3d.terrain_params import (
+    PomSettings,
+    ProbeSettings,
+    ReflectionProbeSettings,
+    make_terrain_params_config,
+)
+
+
+DEFAULT_DEM = Path(__file__).resolve().parent.parent / "assets" / "tif" / "dem_rainier.tif"
+DEFAULT_OUTPUT_DIR = Path(__file__).resolve().parent / "out" / "terrain_tv24_reflection_probe"
+
+
+def _write_preview_hdr(path: Path, width: int = 8, height: int = 4) -> None:
+    with path.open("wb") as handle:
+        handle.write(b"#?RADIANCE\n")
+        handle.write(b"FORMAT=32-bit_rle_rgbe\n\n")
+        handle.write(f"-Y {height} +X {width}\n".encode())
+        for y in range(height):
+            for x in range(width):
+                r = int((x / max(width - 1, 1)) * 255)
+                g = int((y / max(height - 1, 1)) * 255)
+                b = int((1.0 - x / max(width - 1, 1)) * 220)
+                handle.write(bytes([r, g, b, 128]))
+
+
+def _downsample_heightmap(heightmap: np.ndarray, max_dim: int) -> np.ndarray:
+    if max_dim <= 0:
+        return np.ascontiguousarray(heightmap)
+    longest = max(int(heightmap.shape[0]), int(heightmap.shape[1]))
+    if longest <= max_dim:
+        return np.ascontiguousarray(heightmap)
+    step = int(math.ceil(longest / max_dim))
+    return np.ascontiguousarray(heightmap[::step, ::step])
+
+
+def _load_dem(path: Path, max_dim: int) -> tuple[object, np.ndarray]:
+    dem = f3dio.load_dem(str(path), fill_nodata_values=True)
+    heightmap = np.asarray(dem.data, dtype=np.float32).copy()
+    return dem, _downsample_heightmap(heightmap, max_dim)
+
+
+def _terrain_span(dem: object, heightmap: np.ndarray) -> float:
+    fallback = float(max(heightmap.shape))
+    resolution = getattr(dem, "resolution", None)
+    if resolution is not None:
+        try:
+            dx = float(resolution[0] or 1.0)
+            dy = float(resolution[1] or 1.0)
+            if dx > 0.0 and dy > 0.0:
+                span = max(dx * heightmap.shape[1], dy * heightmap.shape[0])
+                if np.isfinite(span) and span >= 1.0:
+                    return float(span)
+        except Exception:
+            pass
+    return fallback
+
+
+def _relief_scale(domain: tuple[float, float], terrain_span: float) -> float:
+    relief = max(float(domain[1]) - float(domain[0]), 1e-6)
+    return float(np.clip((terrain_span / relief) * 0.18, 0.12, 10.0))
+
+
+def _make_overlay(domain: tuple[float, float]):
+    lo, hi = map(float, domain)
+    span = max(hi - lo, 1e-6)
+    cmap = f3d.Colormap1D.from_stops(
+        stops=[
+            (lo + 0.00 * span, "#102d16"),
+            (lo + 0.16 * span, "#315a28"),
+            (lo + 0.40 * span, "#69723d"),
+            (lo + 0.62 * span, "#8d7754"),
+            (lo + 0.82 * span, "#c8b7a5"),
+            (lo + 1.00 * span, "#f5f7fb"),
+        ],
+        domain=(lo, hi),
+    )
+    return f3d.OverlayLayer.from_colormap1d(cmap, strength=1.0)
+
+
+def _build_water_mask(heightmap: np.ndarray) -> np.ndarray:
+    h, w = heightmap.shape
+    x = np.linspace(-1.0, 1.0, w, dtype=np.float32)
+    y = np.linspace(-1.0, 1.0, h, dtype=np.float32)
+    xx, yy = np.meshgrid(x, y)
+    lake_a = np.exp(-(((xx + 0.22) / 0.20) ** 2 + ((yy - 0.08) / 0.10) ** 2) * 2.2)
+    lake_b = np.exp(-(((xx - 0.18) / 0.16) ** 2 + ((yy + 0.18) / 0.09) ** 2) * 2.0)
+    basin_mask = (heightmap <= np.quantile(heightmap, 0.42)).astype(np.float32)
+    mask = np.clip(np.maximum(lake_a, lake_b) * basin_mask * 1.35, 0.0, 1.0).astype(np.float32)
+    if float(mask.max()) < 0.1:
+        fallback = np.exp(-((xx * xx + yy * yy) / 0.08)).astype(np.float32)
+        mask = np.clip(fallback * (heightmap <= np.quantile(heightmap, 0.50)), 0.0, 1.0)
+    return np.ascontiguousarray(mask.astype(np.float32))
+
+
+def _fit_reflection_probe_settings(
+    water_mask: np.ndarray,
+    terrain_span: float,
+    *,
+    grid_dims: tuple[int, int] = (4, 4),
+    resolution: int = 32,
+) -> ReflectionProbeSettings:
+    ys, xs = np.where(water_mask > 0.15)
+    if xs.size == 0:
+        return ReflectionProbeSettings(
+            enabled=True,
+            grid_dims=grid_dims,
+            resolution=resolution,
+            ray_count=16,
+        )
+
+    h, w = water_mask.shape
+    u0 = float(xs.min()) / max(w - 1, 1)
+    u1 = float(xs.max()) / max(w - 1, 1)
+    v0 = float(ys.min()) / max(h - 1, 1)
+    v1 = float(ys.max()) / max(h - 1, 1)
+    x0 = (u0 - 0.5) * terrain_span
+    x1 = (u1 - 0.5) * terrain_span
+    y0 = (v0 - 0.5) * terrain_span
+    y1 = (v1 - 0.5) * terrain_span
+    span_x = max(x1 - x0, terrain_span * 0.06)
+    span_y = max(y1 - y0, terrain_span * 0.06)
+    margin_x = max(span_x * 0.20, terrain_span * 0.02)
+    margin_y = max(span_y * 0.20, terrain_span * 0.02)
+    origin = (x0 - margin_x, y0 - margin_y)
+    spacing = (
+        (span_x + margin_x * 2.0) / max(grid_dims[0] - 1, 1),
+        (span_y + margin_y * 2.0) / max(grid_dims[1] - 1, 1),
+    )
+    return ReflectionProbeSettings(
+        enabled=True,
+        grid_dims=grid_dims,
+        origin=origin,
+        spacing=spacing,
+        height_offset=max(terrain_span * 0.005, 5.0),
+        resolution=resolution,
+        ray_count=16,
+        fallback_blend_distance=min(spacing) * 0.85,
+    )
+
+
+def _build_params(
+    *,
+    width: int,
+    height: int,
+    terrain_span: float,
+    domain: tuple[float, float],
+    overlay,
+    z_scale: float,
+    debug_mode: int,
+    reflection_probes: ReflectionProbeSettings | None,
+):
+    clip_far = max(terrain_span * 4.5, 6000.0)
+    config = make_terrain_params_config(
+        size_px=(width, height),
+        render_scale=1.0,
+        terrain_span=terrain_span,
+        msaa_samples=4,
+        z_scale=z_scale,
+        exposure=1.0,
+        domain=domain,
+        albedo_mode="mix",
+        colormap_strength=0.34,
+        ibl_enabled=True,
+        ibl_intensity=2.8,
+        light_azimuth_deg=142.0,
+        light_elevation_deg=24.0,
+        sun_intensity=1.2,
+        cam_radius=max(terrain_span * 1.75, 5.0),
+        cam_phi_deg=150.0,
+        cam_theta_deg=57.0,
+        fov_y_deg=48.0,
+        camera_mode="mesh",
+        clip=(0.1, clip_far),
+        debug_mode=debug_mode,
+        overlays=[overlay],
+        pom=PomSettings(False, "Occlusion", 0.0, 1, 1, 0, False, False),
+        probes=ProbeSettings(enabled=True, grid_dims=(6, 6), ray_count=32),
+        reflection_probes=reflection_probes,
+    )
+    return f3d.TerrainRenderParams(config)
+
+
+def _compose_comparison(left: np.ndarray, right: np.ndarray) -> np.ndarray:
+    divider = np.full((left.shape[0], 12, 4), 255, dtype=np.uint8)
+    divider[..., :3] = 16
+    return np.concatenate([left, divider, right], axis=1)
+
+
+def render_demo(
+    *,
+    dem_path: Path,
+    output_dir: Path,
+    width: int,
+    height: int,
+    max_dem_size: int = 768,
+) -> dict[str, object]:
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    dem, heightmap = _load_dem(dem_path, max_dem_size)
+    domain = tuple(map(float, getattr(dem, "domain", (float(np.min(heightmap)), float(np.max(heightmap))))))
+    terrain_span = _terrain_span(dem, heightmap)
+    z_scale = _relief_scale(domain, terrain_span)
+    overlay = _make_overlay(domain)
+    water_mask = _build_water_mask(heightmap)
+    reflection_probe_settings = _fit_reflection_probe_settings(water_mask, terrain_span)
+
+    session = f3d.Session(window=False)
+    renderer = f3d.TerrainRenderer(session)
+    material_set = f3d.MaterialSet.terrain_default()
+
+    with tempfile.NamedTemporaryFile(suffix=".hdr", delete=False) as tmp:
+        hdr_path = Path(tmp.name)
+    try:
+        _write_preview_hdr(hdr_path)
+        ibl = f3d.IBL.from_hdr(str(hdr_path), intensity=1.0)
+    finally:
+        hdr_path.unlink(missing_ok=True)
+
+    diffuse_only = renderer.render_terrain_pbr_pom(
+        material_set=material_set,
+        env_maps=ibl,
+        params=_build_params(
+            width=width,
+            height=height,
+            terrain_span=terrain_span,
+            domain=domain,
+            overlay=overlay,
+            z_scale=z_scale,
+            debug_mode=0,
+            reflection_probes=ReflectionProbeSettings(enabled=False),
+        ),
+        heightmap=heightmap,
+        water_mask=water_mask,
+    )
+    reflection_on = renderer.render_terrain_pbr_pom(
+        material_set=material_set,
+        env_maps=ibl,
+        params=_build_params(
+            width=width,
+            height=height,
+            terrain_span=terrain_span,
+            domain=domain,
+            overlay=overlay,
+            z_scale=z_scale,
+            debug_mode=0,
+            reflection_probes=reflection_probe_settings,
+        ),
+        heightmap=heightmap,
+        water_mask=water_mask,
+    )
+    reflection_debug = renderer.render_terrain_pbr_pom(
+        material_set=material_set,
+        env_maps=ibl,
+        params=_build_params(
+            width=width,
+            height=height,
+            terrain_span=terrain_span,
+            domain=domain,
+            overlay=overlay,
+            z_scale=z_scale,
+            debug_mode=52,
+            reflection_probes=reflection_probe_settings,
+        ),
+        heightmap=heightmap,
+        water_mask=water_mask,
+    )
+    reflection_weight = renderer.render_terrain_pbr_pom(
+        material_set=material_set,
+        env_maps=ibl,
+        params=_build_params(
+            width=width,
+            height=height,
+            terrain_span=terrain_span,
+            domain=domain,
+            overlay=overlay,
+            z_scale=z_scale,
+            debug_mode=53,
+            reflection_probes=reflection_probe_settings,
+        ),
+        heightmap=heightmap,
+        water_mask=water_mask,
+    )
+    probe_memory = renderer.get_probe_memory_report()
+    reflection_probe_memory = renderer.get_reflection_probe_memory_report()
+    water_debug = renderer.render_terrain_pbr_pom(
+        material_set=material_set,
+        env_maps=ibl,
+        params=_build_params(
+            width=width,
+            height=height,
+            terrain_span=terrain_span,
+            domain=domain,
+            overlay=overlay,
+            z_scale=z_scale,
+            debug_mode=4,
+            reflection_probes=ReflectionProbeSettings(enabled=False),
+        ),
+        heightmap=heightmap,
+        water_mask=water_mask,
+    )
+
+    diffuse_path = output_dir / "terrain_tv24_diffuse_only.png"
+    reflection_path = output_dir / "terrain_tv24_reflection_on.png"
+    reflection_debug_path = output_dir / "terrain_tv24_reflection_debug.png"
+    reflection_weight_path = output_dir / "terrain_tv24_reflection_weight.png"
+    comparison_path = output_dir / "terrain_tv24_comparison.png"
+
+    diffuse_path.parent.mkdir(parents=True, exist_ok=True)
+    diffuse_only.save(str(diffuse_path))
+    reflection_on.save(str(reflection_path))
+    reflection_debug.save(str(reflection_debug_path))
+    reflection_weight.save(str(reflection_weight_path))
+
+    left = diffuse_only.to_numpy()
+    right = reflection_on.to_numpy()
+    comparison = _compose_comparison(left, right)
+    f3d.numpy_to_png(comparison_path, comparison)
+
+    mean_abs_diff = float(np.mean(np.abs(left[..., :3].astype(np.float32) - right[..., :3].astype(np.float32))))
+    water_pixels = int(np.count_nonzero(water_mask > 0.15))
+    rendered_water = np.all(
+        water_debug.to_numpy()[..., :3] == np.array([0, 255, 255], dtype=np.uint8),
+        axis=-1,
+    )
+    rendered_water_pixels = int(np.count_nonzero(rendered_water))
+    water_mean_abs_diff = (
+        float(np.mean(np.abs(left[..., :3].astype(np.float32)[rendered_water] - right[..., :3].astype(np.float32)[rendered_water])))
+        if rendered_water_pixels > 0
+        else 0.0
+    )
+
+    return {
+        "diffuse_path": str(diffuse_path),
+        "reflection_path": str(reflection_path),
+        "reflection_debug_path": str(reflection_debug_path),
+        "reflection_weight_path": str(reflection_weight_path),
+        "comparison_path": str(comparison_path),
+        "mean_abs_diff": mean_abs_diff,
+        "probe_memory": probe_memory,
+        "reflection_probe_memory": reflection_probe_memory,
+        "terrain_span": terrain_span,
+        "domain": domain,
+        "z_scale": z_scale,
+        "heightmap_shape": tuple(int(v) for v in heightmap.shape),
+        "reflection_probe_grid_dims": reflection_probe_settings.grid_dims,
+        "reflection_probe_origin": reflection_probe_settings.origin,
+        "reflection_probe_spacing": reflection_probe_settings.spacing,
+        "water_pixels": water_pixels,
+        "rendered_water_pixels": rendered_water_pixels,
+        "water_mean_abs_diff": water_mean_abs_diff,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="TV24 local reflection probe demo")
+    parser.add_argument("--dem", type=Path, default=DEFAULT_DEM, help="DEM asset to render")
+    parser.add_argument("--output-dir", type=Path, default=DEFAULT_OUTPUT_DIR, help="Output directory")
+    parser.add_argument("--width", type=int, default=1280, help="Render width")
+    parser.add_argument("--height", type=int, default=720, help="Render height")
+    parser.add_argument("--max-dem-size", type=int, default=768, help="Downsample DEM so its longest side is <= this size")
+    args = parser.parse_args()
+
+    result = render_demo(
+        dem_path=args.dem.resolve(),
+        output_dir=args.output_dir.resolve(),
+        width=int(args.width),
+        height=int(args.height),
+        max_dem_size=int(args.max_dem_size),
+    )
+
+    print(f"DEM: {args.dem}")
+    print(f"Heightmap: {result['heightmap_shape'][1]}x{result['heightmap_shape'][0]}")
+    print(f"Terrain span: {result['terrain_span']:.2f}")
+    print(f"Domain: {result['domain'][0]:.2f} .. {result['domain'][1]:.2f}")
+    print(f"Z scale: {result['z_scale']:.3f}")
+    print(f"Water pixels: {result['water_pixels']}")
+    print(f"Diffuse probe memory: {result['probe_memory']}")
+    print(f"Reflection probe memory: {result['reflection_probe_memory']}")
+    print(f"Mean abs diff: {result['mean_abs_diff']:.4f}")
+    print(f"Wrote {result['diffuse_path']}")
+    print(f"Wrote {result['reflection_path']}")
+    print(f"Wrote {result['reflection_debug_path']}")
+    print(f"Wrote {result['reflection_weight_path']}")
+    print(f"Wrote {result['comparison_path']}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/forge3d/__init__.py
+++ b/python/forge3d/__init__.py
@@ -399,6 +399,7 @@ __all__ = [
     "HeightAoSettings",
     "SunVisibilitySettings",
     "ProbeSettings",
+    "ReflectionProbeSettings",
     "DetailSettings",
     "MaterialNoiseSettings",
     "MaterialLayerSettings",

--- a/tests/test_terrain_reflection_probe_exports.py
+++ b/tests/test_terrain_reflection_probe_exports.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+import forge3d as f3d
+
+from forge3d.terrain_params import ReflectionProbeSettings
+
+
+def test_reflection_probe_settings_reexported() -> None:
+    assert f3d.ReflectionProbeSettings is ReflectionProbeSettings
+
+
+def test_reflection_probe_settings_listed_in_public_api() -> None:
+    assert "ReflectionProbeSettings" in f3d.__all__

--- a/tests/test_terrain_tv24_demo.py
+++ b/tests/test_terrain_tv24_demo.py
@@ -1,0 +1,77 @@
+# Executes the real-DEM TV24 example and validates that the example writes
+# non-trivial image output from repo assets.
+
+from __future__ import annotations
+
+import importlib.util
+import types
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import forge3d as f3d
+from _terrain_runtime import terrain_rendering_available
+
+
+if not terrain_rendering_available():
+    pytest.skip("TV24 example test requires a terrain-capable hardware-backed forge3d runtime", allow_module_level=True)
+
+
+def _load_module_by_path(path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location("terrain_tv24_reflection_probe_demo", str(path))
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)  # type: ignore[attr-defined]
+    return module
+
+
+def test_tv24_example_renders_real_dem(tmp_path: Path) -> None:
+    repo = Path(__file__).resolve().parents[1]
+    mod = _load_module_by_path(repo / "examples" / "terrain_tv24_reflection_probe_demo.py")
+
+    result = mod.render_demo(
+        dem_path=mod.DEFAULT_DEM,
+        output_dir=tmp_path / "tv24-demo",
+        width=960,
+        height=600,
+        max_dem_size=768,
+    )
+
+    diffuse_path = Path(result["diffuse_path"])
+    reflection_path = Path(result["reflection_path"])
+    reflection_debug_path = Path(result["reflection_debug_path"])
+    reflection_weight_path = Path(result["reflection_weight_path"])
+    comparison_path = Path(result["comparison_path"])
+
+    for path in [
+        diffuse_path,
+        reflection_path,
+        reflection_debug_path,
+        reflection_weight_path,
+        comparison_path,
+    ]:
+        assert path.exists()
+        assert path.stat().st_size > 0
+
+    diffuse = f3d.png_to_numpy(diffuse_path)
+    reflection = f3d.png_to_numpy(reflection_path)
+    reflection_debug = f3d.png_to_numpy(reflection_debug_path)
+    reflection_weight = f3d.png_to_numpy(reflection_weight_path)
+    comparison = f3d.png_to_numpy(comparison_path)
+
+    assert diffuse.shape == (600, 960, 4)
+    assert reflection.shape == (600, 960, 4)
+    assert reflection_debug.shape == (600, 960, 4)
+    assert reflection_weight.shape == (600, 960, 4)
+    assert comparison.shape == (600, 1932, 4)
+
+    mean_abs = float(np.mean(np.abs(diffuse[..., :3].astype(np.float32) - reflection[..., :3].astype(np.float32))))
+    water_mean_abs = float(result["water_mean_abs_diff"])
+    assert water_mean_abs > 0.10
+    assert float(result["mean_abs_diff"]) >= mean_abs - 1e-3
+    assert float(np.mean(reflection_debug[..., :3])) > 1.0
+    assert float(np.mean(reflection_weight[..., 0])) > 1.0
+    assert int(result["water_pixels"]) > 0
+    assert int(result["rendered_water_pixels"]) > 0
+    assert int(result["reflection_probe_memory"]["probe_count"]) > 0


### PR DESCRIPTION
## Summary
- mark local reflection probes as shipped in the terrain epic backlog and remove the dedicated backlog item from that plan
- add a dedicated real-DEM reflection-probe demo doc/example plus a focused example test
- expose `ReflectionProbeSettings` in the top-level public API list and link the new demo from the probe-lighting docs

## Validation
- python -m pytest tests/test_terrain_reflection_probe_exports.py -v --tb=short
- python -m pytest tests/test_terrain_probes.py -k "reflection_probe_settings_defaults_disabled or reflection_probe_settings_validation_probe_limit or reflection_probe_settings_validation_resolution_power_of_two" -v --tb=short
- python -m pytest tests/test_terrain_tv24_demo.py -v --tb=short
