### PR TITLE
[codex] Add diagnostics support matrices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -343,6 +343,7 @@ docs/_build/
 # Large data files
 landuse/landuse/glad_cropland_2019.tif
 examples/*
+!examples/diagnostics_support_matrices_demo.py
 !examples/germany_terrain_landcover_viewer.py
 !examples/khumbu_icefall_sentinel_timelapse.py
 !examples/turkiye_river_basins_3d.py

--- a/docs/guides/building_support_matrix.md
+++ b/docs/guides/building_support_matrix.md
@@ -1,0 +1,12 @@
+# Building Support Matrix
+
+| Capability | Support level | Scope | Diagnostics |
+| --- | --- | --- | --- |
+| Native GeoJSON building import | `Pro-gated` | Available only when the native/Pro path is present. | `pro_gated_path` when unavailable. |
+| Native CityJSON building import | `Pro-gated` | Available only when the native/Pro path is present. | `pro_gated_path` when unavailable. |
+| Python fallback geometry | `placeholder/fallback` | Current fallback paths can create zero-geometry building records. | `placeholder_fallback`. |
+| Scalar PBR materials | `underdeveloped` | Scalar material values exist; typed MapScene workflow is later work. | Support matrix entry plus later validation diagnostics. |
+| Textured PBR buildings | `missing` | End-to-end textured building workflow is not implemented here. | Future material/texture diagnostics. |
+
+Building workflows must not treat zero-geometry fallback output as successful
+ingestion.

--- a/docs/guides/competitive_positioning.md
+++ b/docs/guides/competitive_positioning.md
@@ -1,0 +1,17 @@
+# Competitive Positioning
+
+forge3d is an offline, Python-native 3D map-production engine. It should not be
+described as a replacement for every capability in Blender, Mapbox GL, Cesium,
+three.js, or Unreal.
+
+| Comparison pressure | forge3d position | Support level wording |
+| --- | --- | --- |
+| Offline map plates and reproducible terrain renders | Product focus. | `supported` or `underdeveloped` according to the exact public path. |
+| Streamed browser map delivery | Out of scope for the MVP. | `non-goal`. |
+| Complete Mapbox style parity | Out of scope for P0. | `unsupported` or `non-goal` by workflow. |
+| Cesium-grade global runtime parity | Out of scope for P0/P1. | `non-goal`. |
+| General DCC or game-editor workflows | Outside the product boundary. | `non-goal`. |
+| Pro/native-only geospatial import paths | Must be called out honestly. | `Pro-gated`. |
+
+Docs and diagnostics should use the exact support classification instead of
+umbrella wording.

--- a/docs/guides/diagnostics_reference.md
+++ b/docs/guides/diagnostics_reference.md
@@ -1,0 +1,39 @@
+# Diagnostics Reference
+
+forge3d map-production diagnostics are structured records for validation and
+bundle-ready review data. They are not log messages.
+
+Each diagnostic contains:
+
+| Field | Meaning |
+| --- | --- |
+| `code` | Stable diagnostic identifier. |
+| `severity` | One of `info`, `warning`, `error`, or `fatal`. |
+| `message` | Short user-facing description. |
+| `remediation` | Action or support boundary. |
+| `support_level` | PRD classification where applicable. |
+| `layer_id` | Affected layer when known. |
+| `object_id` | Affected object, label, tile, or asset when known. |
+| `details` | Deterministic JSON-ready context. |
+
+## Required Codes
+
+| Code | Minimum output-affecting severity | Support level | Trigger |
+| --- | --- | --- | --- |
+| `crs_mismatch` | `error` | `unsupported` | Layer CRS differs from scene or terrain CRS and no transform was provided. |
+| `missing_glyphs` | `warning` | `underdeveloped` | Labels reference glyphs missing from the active atlas. |
+| `unsupported_style_field` | `warning` | `unsupported` | A supported style layer uses paint or layout fields forge3d does not consume. |
+| `unsupported_style_layer_type` | `error` | `unsupported` | A style layer type is outside the supported local feature subset. |
+| `pro_gated_path` | `error` | `Pro-gated` | The requested workflow requires a native or Pro path. |
+| `placeholder_fallback` | `error` | `placeholder/fallback` | A path would produce zero geometry or non-renderable placeholder output. |
+| `experimental_feature` | `warning` | `experimental` | A feature exists but is not production-stable. |
+| `vt_unsupported_family` | `error` | `unsupported` | A non-albedo VT family is requested while runtime pages only albedo. |
+| `python_public_3dtiles_incomplete` | `error` | `underdeveloped` | Public Python 3D Tiles workflow cannot complete render preparation. |
+| `estimated_gpu_memory` | `warning` | `supported` | Estimated GPU memory exceeds the configured budget. |
+| `label_rejection_summary` | `warning` | `underdeveloped` | Label placement rejected candidates and exposes reason counts. |
+
+## Render Policy
+
+`continue_on_warning` permits warning-only reports to proceed while preserving
+diagnostics. `fail_on_warning` blocks warning reports. `error` and `fatal`
+diagnostics always block successful render completion.

--- a/docs/guides/label_support_matrix.md
+++ b/docs/guides/label_support_matrix.md
@@ -1,0 +1,12 @@
+# Label Support Matrix
+
+| Capability | Support level | Scope | Diagnostics |
+| --- | --- | --- | --- |
+| Point label substrate | `underdeveloped` | Existing viewer and native label paths exist, but high-level API truth is owned by feature `002`. | `missing_glyphs`, `experimental_feature`. |
+| Line labels | `experimental` | Must render glyph instances and path rotation before production support can be claimed. | `experimental_feature` until proven or replaced by typed unsupported behavior. |
+| Curved labels | `experimental` | Curved placement is not production-stable in the P0 diagnostics feature. | `experimental_feature`. |
+| Deterministic `LabelPlan` | `missing` | Owned by feature `003`. | `label_rejection_summary` only when reason-coded plan data exists. |
+| Missing glyph detection | `underdeveloped` | Diagnostics contract exists; full atlas integration belongs to label features. | `missing_glyphs`. |
+
+No label command should report success while doing nothing. Unsupported or
+unverified label behavior must produce typed diagnostics or explicit failure.

--- a/docs/guides/offline_3d_map_rendering.md
+++ b/docs/guides/offline_3d_map_rendering.md
@@ -1,0 +1,22 @@
+# Offline 3D Map Rendering
+
+forge3d's product direction is an offline 3D map-production workflow:
+
+```text
+MapScene + LabelPlan + ValidationReport + Bundle
+```
+
+Feature `001` establishes the diagnostics contract and support matrices used by
+that workflow. The complete typed `MapScene` and deterministic `LabelPlan`
+APIs are owned by later P0 features.
+
+| Area | Support level in this feature | Notes |
+| --- | --- | --- |
+| Structured diagnostics | `supported` | `Diagnostic` and `ValidationReport` are public Python objects. |
+| Full MapScene rendering | `missing` | Owned by feature `004`. |
+| Deterministic LabelPlan | `missing` | Owned by feature `003`. |
+| Unsupported-path validation | `underdeveloped` | Diagnostic factories exist; full render-path wiring is incremental. |
+| Web-first hosted tile delivery | `non-goal` | Offline map production remains the scope. |
+
+Unsupported, `Pro-gated`, `placeholder/fallback`, `experimental`, or
+`underdeveloped` paths must be reported before successful render completion.

--- a/docs/guides/style_support_matrix.md
+++ b/docs/guides/style_support_matrix.md
@@ -1,0 +1,16 @@
+# Style Support Matrix
+
+forge3d style support is scoped to local/provided features. It is not streamed MVT
+rendering and it is not complete Mapbox style parity.
+
+| Capability | Support level | Scope | Diagnostics |
+| --- | --- | --- | --- |
+| `fill` layers | `supported` | Local/provided polygon features with `fill-color`, `fill-opacity`, and `fill-outline-color`. | `unsupported_style_field` for unsupported paint/layout fields. |
+| `line` layers | `supported` | Local/provided line features with `line-color`, `line-width`, and `line-opacity`. | `unsupported_style_field` for unsupported paint/layout fields. |
+| `circle` layers | `supported` | Local/provided point features with `circle-color`, `circle-radius`, and `circle-opacity`. | `unsupported_style_field` for unsupported paint/layout fields. |
+| `symbol` text layers | `underdeveloped` | Existing style-to-label helpers can preserve some text styling, but production LabelLayer integration is owned by later features. | `experimental_feature` or label diagnostics when used in production workflows. |
+| Other style layer types | `unsupported` | Heatmap, raster, hillshade, fill-extrusion, background, and other layer types are outside the P0 local-feature subset. | `unsupported_style_layer_type`. |
+| Streamed vector tiles | `non-goal` | Hosted/live tile delivery is outside this feature. | Documentation boundary, not a render path. |
+
+Unsupported style fields must be reported before render; they must not be
+silently dropped in PRD-scoped workflows.

--- a/docs/guides/tiles3d_support_matrix.md
+++ b/docs/guides/tiles3d_support_matrix.md
@@ -1,0 +1,11 @@
+# 3D Tiles Support Matrix
+
+| Capability | Support level | Scope | Diagnostics |
+| --- | --- | --- | --- |
+| Rust B3DM and tileset substrate | `underdeveloped` | Parser and renderer substrate exists, but public Python MapScene workflow is not complete. | `python_public_3dtiles_incomplete`. |
+| Public Python scene integration | `underdeveloped` | Owned by later MapScene and asset bundle features. | `python_public_3dtiles_incomplete`. |
+| Unsupported tile features | `unsupported` | Unsupported B3DM/GLB features must be diagnosed before render. | Future tile-format diagnostics. |
+| Large production tile hierarchies | `non-goal` | This feature does not claim Cesium runtime parity. | Documentation boundary. |
+
+3D Tiles support must distinguish Rust infrastructure from a public, renderable
+Python product workflow.

--- a/docs/guides/virtual_texturing_support_matrix.md
+++ b/docs/guides/virtual_texturing_support_matrix.md
@@ -1,0 +1,11 @@
+# Virtual Texturing Support Matrix
+
+| Capability | Support level | Scope | Diagnostics |
+| --- | --- | --- | --- |
+| Albedo terrain VT family | `supported` | Runtime pages the albedo family. | `estimated_gpu_memory` where budget risk is knowable. |
+| Normal terrain VT family | `missing` | Python accepts the family for forward compatibility, but native runtime does not page it. | `vt_unsupported_family`. |
+| Mask terrain VT family | `missing` | Python accepts the family for forward compatibility, but native runtime does not page it. | `vt_unsupported_family`. |
+| Runtime residency stats | `underdeveloped` | Lower-level stats exist; product validation integration belongs to later features. | Future large-scene diagnostics. |
+
+Non-albedo family requests must be surfaced before render instead of being
+only log-visible.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -19,6 +19,14 @@ data loading, cartography, export, and the runnable examples in ``examples/``.
    :caption: Guides
 
    guides/feature_map
+   guides/offline_3d_map_rendering
+   guides/diagnostics_reference
+   guides/style_support_matrix
+   guides/label_support_matrix
+   guides/building_support_matrix
+   guides/tiles3d_support_matrix
+   guides/virtual_texturing_support_matrix
+   guides/competitive_positioning
    guides/data_and_scene_workflows
    guides/rendering_and_analysis
    terrain/offline-render-quality

--- a/examples/diagnostics_support_matrices_demo.py
+++ b/examples/diagnostics_support_matrices_demo.py
@@ -1,0 +1,223 @@
+"""Showcase feature 001 diagnostics and support-matrix behavior.
+
+This example is intentionally validation-only: it does not require a GPU,
+native rendering, or Pro-gated asset paths. It demonstrates how feature 001
+surfaces incomplete map-rendering paths as structured diagnostics before a
+render workflow treats them as successful.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+
+def _ensure_repo_import() -> None:
+    from _import_shim import ensure_repo_import
+
+    ensure_repo_import()
+
+
+def _merge_reports(*reports):
+    from forge3d.diagnostics import ValidationReport
+
+    diagnostics = []
+    layer_summaries = []
+    supported_features: dict[str, str] = {}
+    unsupported_features: dict[str, str] = {}
+
+    for report in reports:
+        diagnostics.extend(report.diagnostics)
+        layer_summaries.extend(report.layer_summaries)
+        supported_features.update(report.supported_features)
+        unsupported_features.update(report.unsupported_features)
+
+    return ValidationReport(
+        diagnostics=diagnostics,
+        layer_summaries=layer_summaries,
+        supported_features=supported_features,
+        unsupported_features=unsupported_features,
+    )
+
+
+def _style_report():
+    from forge3d.style import validate_style_support
+
+    return validate_style_support(
+        {
+            "version": 8,
+            "name": "diagnostics-demo-style",
+            "layers": [
+                {
+                    "id": "land",
+                    "type": "fill",
+                    "paint": {"fill-color": "#9fbf8f", "fill-opacity": 0.8},
+                },
+                {
+                    "id": "roads",
+                    "type": "line",
+                    "paint": {
+                        "line-color": "#303030",
+                        "line-width": 2.0,
+                        "line-gradient": ["interpolate", ["linear"], ["get", "speed"], 0, "#00f", 80, "#f00"],
+                    },
+                },
+                {
+                    "id": "places",
+                    "type": "symbol",
+                    "layout": {"text-field": ["get", "name"], "text-size": 14},
+                    "paint": {"text-color": "#1f2933"},
+                },
+                {"id": "traffic-heat", "type": "heatmap"},
+            ],
+        }
+    )
+
+
+def _building_report():
+    from forge3d.buildings import Building, BuildingLayer, validate_building_layer_support
+
+    fallback_building = Building(
+        id="building-zero-geometry",
+        positions=np.asarray([], dtype=np.float32),
+        indices=np.asarray([], dtype=np.uint32),
+        height=18.0,
+        attributes={"source": "public fallback"},
+    )
+    layer = BuildingLayer(
+        name="buildings.public-fallback",
+        buildings=[fallback_building],
+        crs_epsg=3857,
+        source_format="geojson",
+    )
+    return validate_building_layer_support(layer, layer_id=layer.name)
+
+
+def _tiles_report():
+    from forge3d.tiles3d import BoundingVolume, Tile, TileContent, Tileset, validate_tiles3d_support
+
+    root = Tile(
+        bounding_volume=BoundingVolume("sphere", [0.0, 0.0, 0.0, 10.0]),
+        geometric_error=128.0,
+        content=TileContent(uri="sample.b3dm"),
+    )
+    tileset = Tileset(
+        base_path=Path("fixtures/tiles3d"),
+        version="1.0",
+        geometric_error=128.0,
+        root=root,
+    )
+    return validate_tiles3d_support(tileset, layer_id="tiles3d.local-fixture")
+
+
+def _vt_report():
+    from forge3d.terrain_params import TerrainVTSettings, VTLayerFamily, validate_terrain_vt_support
+
+    settings = TerrainVTSettings(
+        enabled=True,
+        layers=[
+            VTLayerFamily("albedo"),
+            VTLayerFamily("normal"),
+            VTLayerFamily("mask"),
+        ],
+    )
+    return validate_terrain_vt_support(settings, layer_id="terrain.material-vt")
+
+
+def _label_report():
+    from forge3d.diagnostics import validate_label_support
+
+    labels = [
+        {"id": "city-1", "kind": "point", "text": "Cafe"},
+        {"id": "road-1", "kind": "line", "text": "A1"},
+        {"id": "river-curve", "kind": "curved", "text": "River"},
+    ]
+    glyphs = set("ABCDFRivaor 1")
+    return validate_label_support(labels, atlas_glyphs=glyphs, layer_id="labels.demo")
+
+
+def _manual_report():
+    from forge3d.diagnostics import (
+        ValidationReport,
+        crs_mismatch_diagnostic,
+        estimated_gpu_memory_diagnostic,
+        label_rejection_summary_diagnostic,
+        pro_gated_path_diagnostic,
+    )
+
+    return ValidationReport(
+        diagnostics=[
+            crs_mismatch_diagnostic("EPSG:4326", "EPSG:3857", layer_id="roads.source"),
+            pro_gated_path_diagnostic("native CityJSON import", layer_id="buildings.native"),
+            estimated_gpu_memory_diagnostic(
+                estimated_bytes=5_368_709_120,
+                budget_bytes=4_294_967_296,
+                layer_id="terrain.large-scene",
+            ),
+            label_rejection_summary_diagnostic(
+                {"collision": 3, "missing_glyph": 1},
+                layer_id="labels.demo",
+            ),
+        ]
+    )
+
+
+def build_demo_report():
+    """Build one deterministic ValidationReport covering feature 001 paths."""
+    _ensure_repo_import()
+    return _merge_reports(
+        _style_report(),
+        _building_report(),
+        _tiles_report(),
+        _vt_report(),
+        _label_report(),
+        _manual_report(),
+    )
+
+
+def _print_summary(payload: dict[str, Any]) -> None:
+    print(f"status: {payload['status']}")
+    print(f"render_blocked_continue_on_warning: {payload['render_blocked']}")
+    print("diagnostics:")
+    for diagnostic in payload["diagnostics"]:
+        layer = diagnostic["layer_id"] or "-"
+        obj = diagnostic["object_id"] or "-"
+        print(
+            "  "
+            f"{diagnostic['severity']:7s} "
+            f"{diagnostic['code']:36s} "
+            f"layer={layer} object={obj}"
+        )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Create a feature 001 diagnostics/support-matrix example report."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("examples/out/diagnostics_support_matrices_report.json"),
+        help="Path for the deterministic JSON report.",
+    )
+    args = parser.parse_args()
+
+    report = build_demo_report()
+    payload = report.to_dict()
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(
+        json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=True) + "\n",
+        encoding="utf-8",
+    )
+
+    _print_summary(payload)
+    print(f"wrote: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/forge3d/__init__.py
+++ b/python/forge3d/__init__.py
@@ -126,6 +126,7 @@ from .terrain_params import (
     OfflineQualitySettings,
     VTLayerFamily,
     TerrainVTSettings,
+    validate_terrain_vt_support,
 )
 from .offline import OfflineProgress, OfflineResult, render_offline
 from .denoise_oidn import oidn_available, oidn_denoise
@@ -354,6 +355,7 @@ from .buildings import (
     add_buildings,
     add_buildings_cityjson,
     add_buildings_3dtiles,
+    validate_building_layer_support,
     infer_roof_type,
     material_from_tags,
     material_from_name,
@@ -367,6 +369,9 @@ from .style import (
     parse_style,
     apply_style,
     parse_color,
+    validate_style_support,
+    vector_overlay_configs_from_style,
+    label_layer_contracts_from_style,
     paint_to_vector_style,
     layout_to_label_style,
     layer_to_vector_style,
@@ -377,6 +382,31 @@ from .style import (
     LabelStyle as StyleLabelStyle,
     PaintProps,
     LayoutProps,
+)
+
+# -----------------------------------------------------------------------------
+# Product diagnostics
+# -----------------------------------------------------------------------------
+from .diagnostics import (
+    Diagnostic,
+    LayerSummary,
+    REQUIRED_DIAGNOSTIC_CODES,
+    RenderFailurePolicy,
+    SeverityPolicy,
+    SupportMatrixEntry,
+    ValidationReport,
+    crs_mismatch_diagnostic,
+    estimated_gpu_memory_diagnostic,
+    experimental_feature_diagnostic,
+    label_rejection_summary_diagnostic,
+    missing_glyphs_diagnostic,
+    placeholder_fallback_diagnostic,
+    pro_gated_path_diagnostic,
+    python_public_3dtiles_incomplete_diagnostic,
+    unsupported_style_field_diagnostic,
+    unsupported_style_layer_type_diagnostic,
+    validate_label_support,
+    vt_unsupported_family_diagnostic,
 )
 
 # -----------------------------------------------------------------------------
@@ -433,6 +463,7 @@ __all__ = [
     "OfflineQualitySettings",
     "VTLayerFamily",
     "TerrainVTSettings",
+    "validate_terrain_vt_support",
     "OfflineProgress",
     "OfflineResult",
     "render_offline",
@@ -524,6 +555,9 @@ __all__ = [
     "parse_style",
     "apply_style",
     "parse_color",
+    "validate_style_support",
+    "vector_overlay_configs_from_style",
+    "label_layer_contracts_from_style",
     "paint_to_vector_style",
     "layout_to_label_style",
     "layer_to_vector_style",
@@ -534,6 +568,26 @@ __all__ = [
     "StyleLabelStyle",
     "PaintProps",
     "LayoutProps",
+    # Product diagnostics
+    "Diagnostic",
+    "LayerSummary",
+    "REQUIRED_DIAGNOSTIC_CODES",
+    "RenderFailurePolicy",
+    "SeverityPolicy",
+    "SupportMatrixEntry",
+    "ValidationReport",
+    "crs_mismatch_diagnostic",
+    "estimated_gpu_memory_diagnostic",
+    "experimental_feature_diagnostic",
+    "label_rejection_summary_diagnostic",
+    "missing_glyphs_diagnostic",
+    "placeholder_fallback_diagnostic",
+    "pro_gated_path_diagnostic",
+    "python_public_3dtiles_incomplete_diagnostic",
+    "unsupported_style_field_diagnostic",
+    "unsupported_style_layer_type_diagnostic",
+    "validate_label_support",
+    "vt_unsupported_family_diagnostic",
     # P3-reproject: CRS utilities
     "proj_available",
     "transform_coords",
@@ -548,6 +602,7 @@ __all__ = [
     "add_buildings",
     "add_buildings_cityjson",
     "add_buildings_3dtiles",
+    "validate_building_layer_support",
     "infer_roof_type",
     "material_from_tags",
     "material_from_name",

--- a/python/forge3d/__init__.pyi
+++ b/python/forge3d/__init__.pyi
@@ -22,6 +22,7 @@ from .bundle import (
     load_bundle,
     save_bundle,
 )
+from .buildings import validate_building_layer_support
 from .terrain_params import (
     LightSettings,
     IblSettings,
@@ -45,6 +46,33 @@ from .terrain_params import (
     OfflineQualitySettings,
     VTLayerFamily,
     TerrainVTSettings,
+    validate_terrain_vt_support,
+)
+from .diagnostics import (
+    Diagnostic,
+    LayerSummary,
+    REQUIRED_DIAGNOSTIC_CODES,
+    RenderFailurePolicy,
+    SeverityPolicy,
+    SupportMatrixEntry,
+    ValidationReport,
+    crs_mismatch_diagnostic,
+    estimated_gpu_memory_diagnostic,
+    experimental_feature_diagnostic,
+    label_rejection_summary_diagnostic,
+    missing_glyphs_diagnostic,
+    placeholder_fallback_diagnostic,
+    pro_gated_path_diagnostic,
+    python_public_3dtiles_incomplete_diagnostic,
+    unsupported_style_field_diagnostic,
+    unsupported_style_layer_type_diagnostic,
+    validate_label_support,
+    vt_unsupported_family_diagnostic,
+)
+from .style import (
+    label_layer_contracts_from_style,
+    validate_style_support,
+    vector_overlay_configs_from_style,
 )
 
 PathLikeStr = os.PathLike[str] | str

--- a/python/forge3d/buildings.py
+++ b/python/forge3d/buildings.py
@@ -25,6 +25,12 @@ from typing import Any
 import numpy as np
 
 from ._license import _check_pro_access
+from .diagnostics import (
+    LayerSummary,
+    ValidationReport,
+    placeholder_fallback_diagnostic,
+    python_public_3dtiles_incomplete_diagnostic,
+)
 
 # Try to import native module
 try:
@@ -556,6 +562,61 @@ def add_buildings_3dtiles(
     )
 
 
+def validate_building_layer_support(
+    layer: BuildingLayer,
+    *,
+    layer_id: str | None = None,
+) -> ValidationReport:
+    """Validate public building-layer support without claiming render success."""
+    effective_layer_id = layer_id or layer.name
+    diagnostics = []
+    diagnostic_codes: list[str] = []
+
+    for building in layer.buildings:
+        if building.vertex_count == 0 or building.triangle_count == 0:
+            diag = placeholder_fallback_diagnostic(
+                f"{layer.source_format} building fallback",
+                layer_id=effective_layer_id,
+                object_id=building.id,
+            )
+            diagnostics.append(diag)
+            diagnostic_codes.append(diag.code)
+
+    if layer.source_format == "3dtiles":
+        diag = python_public_3dtiles_incomplete_diagnostic(layer_id=effective_layer_id)
+        diagnostics.append(diag)
+        diagnostic_codes.append(diag.code)
+
+    support_level = "supported" if not diagnostics else "placeholder/fallback"
+    if layer.source_format == "3dtiles":
+        support_level = "underdeveloped"
+
+    return ValidationReport(
+        diagnostics=diagnostics,
+        layer_summaries=[
+            LayerSummary(
+                layer_id=effective_layer_id,
+                layer_type=f"building.{layer.source_format}",
+                support_level=support_level,
+                diagnostic_codes=diagnostic_codes,
+                object_count=layer.building_count,
+                bounds=layer.bounds(),
+                details={
+                    "source_format": layer.source_format,
+                    "total_triangles": layer.total_triangles,
+                    "total_vertices": layer.total_vertices,
+                },
+            )
+        ],
+        supported_features={"buildings.scalar_materials": "underdeveloped"},
+        unsupported_features={
+            "buildings.placeholder_fallback": "placeholder/fallback"
+        }
+        if diagnostics
+        else {},
+    )
+
+
 # ============================================================================
 # Module exports
 # ============================================================================
@@ -569,6 +630,7 @@ __all__ = [
     "add_buildings",
     "add_buildings_cityjson",
     "add_buildings_3dtiles",
+    "validate_building_layer_support",
     # Inference functions
     "infer_roof_type",
     "material_from_tags",

--- a/python/forge3d/bundle.py
+++ b/python/forge3d/bundle.py
@@ -22,6 +22,7 @@ from pathlib import Path
 from typing import Any, Iterable, Mapping
 
 from ._license import _check_pro_access
+from .diagnostics import ValidationReport
 
 BUNDLE_VERSION = 2
 BUNDLE_EXTENSION = "forge3d"
@@ -50,6 +51,18 @@ def _copy_json_mapping(value: Mapping[str, Any] | None, *, name: str) -> dict[st
     if not isinstance(value, Mapping):
         raise TypeError(f"{name} must be a mapping or None")
     return dict(_deepcopy_json(dict(value)))
+
+
+def _coerce_validation_report(
+    report: ValidationReport | Mapping[str, Any] | None,
+) -> ValidationReport | None:
+    if report is None:
+        return None
+    if isinstance(report, ValidationReport):
+        return ValidationReport.from_dict(report.to_dict())
+    if isinstance(report, Mapping):
+        return ValidationReport.from_dict(report)
+    raise TypeError("validation_report must be a ValidationReport, mapping, or None")
 
 
 def _coerce_bookmarks(
@@ -493,10 +506,12 @@ class SceneState:
     review_layers: list[ReviewLayer] = field(default_factory=list)
     variants: list[SceneVariant] = field(default_factory=list)
     active_variant_id: str | None = None
+    validation_report: ValidationReport | None = None
 
     def __post_init__(self) -> None:
         if not isinstance(self.base, SceneBaseState):
             self.base = SceneBaseState.from_dict(self.base)
+        self.validation_report = _coerce_validation_report(self.validation_report)
         self.review_layers = [
             layer if isinstance(layer, ReviewLayer) else ReviewLayer.from_dict(layer)
             for layer in self.review_layers
@@ -517,6 +532,8 @@ class SceneState:
             data["variants"] = [variant.to_dict() for variant in self.variants]
         if self.active_variant_id is not None:
             data["active_variant_id"] = self.active_variant_id
+        if self.validation_report is not None:
+            data["validation_report"] = self.validation_report.to_dict()
         return data
 
     @classmethod
@@ -528,6 +545,7 @@ class SceneState:
             review_layers=data.get("review_layers", []),
             variants=data.get("variants", []),
             active_variant_id=data.get("active_variant_id"),
+            validation_report=data.get("validation_report"),
         )
 
 
@@ -745,6 +763,7 @@ def _prepare_scene_state_for_save(
         review_layers=review_layers,
         variants=scene_state.variants,
         active_variant_id=scene_state.active_variant_id,
+        validation_report=scene_state.validation_report,
     )
 
 
@@ -782,6 +801,7 @@ def _resolve_scene_state_after_load(scene_state: SceneState, *, bundle_path: Pat
         review_layers=review_layers,
         variants=scene_state.variants,
         active_variant_id=scene_state.active_variant_id,
+        validation_report=scene_state.validation_report,
     )
 
 
@@ -816,6 +836,7 @@ def _scene_state_with_legacy_kwargs(
         review_layers=state.review_layers,
         variants=state.variants,
         active_variant_id=state.active_variant_id,
+        validation_report=state.validation_report,
     )
 
 
@@ -878,6 +899,7 @@ class LoadedBundle:
     hdr_path: Path | None = None
     camera_bookmarks: list[CameraBookmark] = field(default_factory=list)
     scene_state: SceneState = field(default_factory=SceneState)
+    validation_report: ValidationReport | None = None
     _layer_visibility_overrides: dict[str, bool] = field(default_factory=dict, init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -886,6 +908,9 @@ class LoadedBundle:
             self.manifest = BundleManifest.from_dict(self.manifest)
         if not isinstance(self.scene_state, SceneState):
             self.scene_state = SceneState.from_dict(self.scene_state)
+        self.validation_report = _coerce_validation_report(
+            self.validation_report or self.scene_state.validation_report
+        )
         self.overlays = None if self.overlays is None else _coerce_vector_payloads(self.overlays, name="LoadedBundle.overlays")
         self.labels = None if self.labels is None else _coerce_labels(self.labels)
         self.preset = _copy_json_mapping(self.preset, name="LoadedBundle.preset")
@@ -978,6 +1003,7 @@ def save_bundle(
     camera_bookmarks: list[CameraBookmark] | None = None,
     hdr_path: str | Path | None = None,
     scene_state: SceneState | Mapping[str, Any] | None = None,
+    validation_report: ValidationReport | Mapping[str, Any] | None = None,
 ) -> Path:
     """[Pro] Save a scene bundle to disk."""
 
@@ -1022,6 +1048,8 @@ def save_bundle(
         camera_bookmarks=camera_bookmarks,
         hdr_path=hdr_path,
     )
+    if validation_report is not None:
+        state.validation_report = _coerce_validation_report(validation_report)
     state = _prepare_scene_state_for_save(
         state,
         bundle_path=bundle_path,
@@ -1147,6 +1175,7 @@ def load_bundle(path: str | Path, verify_checksums: bool = True) -> LoadedBundle
         hdr_path=hdr_resolved,
         camera_bookmarks=scene_state.base.camera_bookmarks,
         scene_state=scene_state,
+        validation_report=scene_state.validation_report,
     )
 
 

--- a/python/forge3d/diagnostics.py
+++ b/python/forge3d/diagnostics.py
@@ -1,0 +1,612 @@
+"""Structured diagnostics for offline map-rendering validation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Any, Mapping, Sequence
+
+
+SEVERITIES = ("info", "warning", "error", "fatal")
+SUPPORT_LEVELS = (
+    "supported",
+    "underdeveloped",
+    "missing",
+    "Pro-gated",
+    "placeholder/fallback",
+    "experimental",
+    "unsupported",
+    "non-goal",
+)
+REQUIRED_DIAGNOSTIC_CODES = frozenset(
+    {
+        "crs_mismatch",
+        "missing_glyphs",
+        "unsupported_style_field",
+        "unsupported_style_layer_type",
+        "pro_gated_path",
+        "placeholder_fallback",
+        "experimental_feature",
+        "vt_unsupported_family",
+        "python_public_3dtiles_incomplete",
+        "estimated_gpu_memory",
+        "label_rejection_summary",
+    }
+)
+
+_STATUS_RANK = {"ok": 0, "info": 0, "warning": 1, "error": 2, "fatal": 3}
+_DIAGNOSTIC_SORT_RANK = {"fatal": 0, "error": 1, "warning": 2, "info": 3}
+
+
+class RenderFailurePolicy:
+    """Render blocking policy for warning-level diagnostics."""
+
+    CONTINUE_ON_WARNING = "continue_on_warning"
+    FAIL_ON_WARNING = "fail_on_warning"
+
+    _VALUES = (CONTINUE_ON_WARNING, FAIL_ON_WARNING)
+
+    @classmethod
+    def validate(cls, policy: str) -> str:
+        if policy not in cls._VALUES:
+            raise ValueError(f"Unknown render failure policy: {policy!r}")
+        return policy
+
+
+class SeverityPolicy:
+    """Severity validation and report status behavior."""
+
+    @staticmethod
+    def validate(severity: str) -> str:
+        if severity not in SEVERITIES:
+            raise ValueError(f"Unknown diagnostic severity: {severity!r}")
+        return severity
+
+    @staticmethod
+    def status_for(severities: Sequence[str]) -> str:
+        status = "ok"
+        for severity in severities:
+            SeverityPolicy.validate(severity)
+            if _STATUS_RANK[severity] > _STATUS_RANK[status]:
+                status = severity
+        return status
+
+    @staticmethod
+    def render_blocked(status: str, policy: str = RenderFailurePolicy.CONTINUE_ON_WARNING) -> bool:
+        RenderFailurePolicy.validate(policy)
+        if status not in ("ok", "warning", "error", "fatal"):
+            raise ValueError(f"Unknown validation status: {status!r}")
+        if status in ("error", "fatal"):
+            return True
+        return status == "warning" and policy == RenderFailurePolicy.FAIL_ON_WARNING
+
+
+def _validate_support_level(support_level: str | None) -> str | None:
+    if support_level is not None and support_level not in SUPPORT_LEVELS:
+        raise ValueError(f"Unknown support level: {support_level!r}")
+    return support_level
+
+
+def _normalize_support_summary(summary: Mapping[str, str] | None) -> dict[str, str]:
+    normalized: dict[str, str] = {}
+    for key, value in sorted(dict(summary or {}).items()):
+        normalized[str(key)] = _validate_support_level(str(value)) or str(value)
+    return normalized
+
+
+def _json_safe(value: Any, *, context: str) -> Any:
+    if isinstance(value, Mapping):
+        normalized: dict[str, Any] = {}
+        for key in sorted(value.keys(), key=str):
+            if not isinstance(key, str):
+                raise TypeError(f"{context} must use string mapping keys")
+            normalized[key] = _json_safe(value[key], context=context)
+        return normalized
+    if isinstance(value, tuple):
+        return [_json_safe(item, context=context) for item in value]
+    if isinstance(value, list):
+        return [_json_safe(item, context=context) for item in value]
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    raise TypeError(f"{context} must be JSON-serializable")
+
+
+def _stable_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+@dataclass
+class Diagnostic:
+    code: str
+    severity: str
+    message: str
+    remediation: str
+    support_level: str | None = None
+    layer_id: str | None = None
+    object_id: str | None = None
+    details: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        self.severity = SeverityPolicy.validate(str(self.severity))
+        self.support_level = _validate_support_level(self.support_level)
+        self.details = _json_safe(dict(self.details or {}), context="details")
+        _stable_json(self.details)
+
+    def sort_key(self) -> tuple[int, str, str, str, str, str]:
+        return (
+            _DIAGNOSTIC_SORT_RANK[self.severity],
+            self.code,
+            self.layer_id or "",
+            self.object_id or "",
+            self.message,
+            _stable_json(self.details),
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+            "remediation": self.remediation,
+            "support_level": self.support_level,
+            "layer_id": self.layer_id,
+            "object_id": self.object_id,
+            "details": _json_safe(dict(self.details or {}), context="details"),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "Diagnostic":
+        return cls(
+            code=str(data["code"]),
+            severity=str(data["severity"]),
+            message=str(data["message"]),
+            remediation=str(data["remediation"]),
+            support_level=data.get("support_level"),
+            layer_id=data.get("layer_id"),
+            object_id=data.get("object_id"),
+            details=data.get("details") or {},
+        )
+
+
+def crs_mismatch_diagnostic(
+    scene_crs: str,
+    layer_crs: str,
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        code="crs_mismatch",
+        severity="error",
+        message="Layer CRS differs from the scene or terrain CRS and no transform was provided.",
+        remediation="Use matching CRS metadata or provide an explicit transform before rendering.",
+        support_level="unsupported",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={"layer_crs": layer_crs, "scene_crs": scene_crs},
+    )
+
+
+def missing_glyphs_diagnostic(
+    missing_glyphs: Sequence[str],
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    glyphs = sorted(str(glyph) for glyph in missing_glyphs)
+    return Diagnostic(
+        code="missing_glyphs",
+        severity="warning",
+        message=f"{len(glyphs)} glyphs are missing from the active atlas.",
+        remediation="Load an atlas with the missing glyphs or change label text before rendering.",
+        support_level="underdeveloped",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={"count": len(glyphs), "missing_glyphs": glyphs},
+    )
+
+
+def unsupported_style_field_diagnostic(
+    layer_id: str,
+    fields: Sequence[str],
+    *,
+    section: str | None = None,
+) -> Diagnostic:
+    unsupported_fields = sorted(str(field) for field in fields)
+    details: dict[str, Any] = {"fields": unsupported_fields}
+    if section:
+        details["section"] = section
+    return Diagnostic(
+        code="unsupported_style_field",
+        severity="warning",
+        message="Style layer uses paint or layout fields that forge3d does not support.",
+        remediation="Remove unsupported fields or use the documented local feature styling subset.",
+        support_level="unsupported",
+        layer_id=layer_id,
+        details=details,
+    )
+
+
+def unsupported_style_layer_type_diagnostic(layer_id: str, layer_type: str) -> Diagnostic:
+    return Diagnostic(
+        code="unsupported_style_layer_type",
+        severity="error",
+        message="Style layer type is not supported by forge3d offline feature styling.",
+        remediation="Use a supported local feature layer type such as fill, line, or circle.",
+        support_level="unsupported",
+        layer_id=layer_id,
+        details={"layer_type": layer_type},
+    )
+
+
+def pro_gated_path_diagnostic(
+    feature: str,
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        code="pro_gated_path",
+        severity="error",
+        message="Requested workflow requires a Pro-gated native path.",
+        remediation="Enable the required Pro/native capability or choose a supported public path.",
+        support_level="Pro-gated",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={"feature": feature},
+    )
+
+
+def placeholder_fallback_diagnostic(
+    feature: str,
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        code="placeholder_fallback",
+        severity="error",
+        message="Requested workflow would use placeholder or non-renderable fallback output.",
+        remediation="Use a renderable supported path or keep the workflow blocked before render.",
+        support_level="placeholder/fallback",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={"feature": feature},
+    )
+
+
+def experimental_feature_diagnostic(
+    feature: str,
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        code="experimental_feature",
+        severity="warning",
+        message="Requested workflow uses a feature that is not production-stable.",
+        remediation="Treat this path as experimental or use a documented supported alternative.",
+        support_level="experimental",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={"feature": feature},
+    )
+
+
+def vt_unsupported_family_diagnostic(
+    family: str,
+    *,
+    supported_family: str = "albedo",
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        code="vt_unsupported_family",
+        severity="error",
+        message="Requested terrain virtual-texturing family is not paged by the native runtime.",
+        remediation="Use the albedo VT family or wait for native normal/mask runtime support.",
+        support_level="unsupported",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={"family": family, "supported_family": supported_family},
+    )
+
+
+def python_public_3dtiles_incomplete_diagnostic(
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    return Diagnostic(
+        code="python_public_3dtiles_incomplete",
+        severity="error",
+        message="Public Python 3D Tiles workflow cannot complete the requested render path.",
+        remediation="Use supported local fixtures only for validation, or wait for public MapScene integration.",
+        support_level="underdeveloped",
+        layer_id=layer_id,
+        object_id=object_id,
+    )
+
+
+def estimated_gpu_memory_diagnostic(
+    estimated_bytes: int,
+    budget_bytes: int | None,
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    exceeds_budget = budget_bytes is not None and estimated_bytes > budget_bytes
+    return Diagnostic(
+        code="estimated_gpu_memory",
+        severity="warning" if exceeds_budget else "info",
+        message=(
+            "Estimated GPU memory use exceeds the configured budget."
+            if exceeds_budget
+            else "Estimated GPU memory use is available for review."
+        ),
+        remediation=(
+            "Reduce layer resolution, simplify inputs, or increase the configured GPU memory budget."
+            if exceeds_budget
+            else "No action is required unless other diagnostics indicate risk."
+        ),
+        support_level="supported",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={
+            "budget_bytes": budget_bytes,
+            "estimated_bytes": int(estimated_bytes),
+        },
+    )
+
+
+def label_rejection_summary_diagnostic(
+    rejection_counts: Mapping[str, int],
+    *,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+) -> Diagnostic:
+    counts = {str(key): int(value) for key, value in sorted(dict(rejection_counts).items())}
+    total = sum(counts.values())
+    return Diagnostic(
+        code="label_rejection_summary",
+        severity="warning",
+        message=f"{total} label candidates were rejected during placement.",
+        remediation="Inspect rejection reasons and adjust priorities, keepouts, glyph coverage, or geometry.",
+        support_level="underdeveloped",
+        layer_id=layer_id,
+        object_id=object_id,
+        details={"rejection_counts": counts, "total": total},
+    )
+
+
+def validate_label_support(
+    labels: Sequence[Mapping[str, Any]],
+    *,
+    atlas_glyphs: set[str] | frozenset[str] | None = None,
+    layer_id: str | None = None,
+) -> "ValidationReport":
+    """Validate label support boundaries without requiring raw viewer IPC.
+
+    This helper does not compile or render labels. It reports PRD-scoped
+    diagnostics for experimental line/curved label paths and known missing
+    glyphs so callers can include those findings in validation reports before
+    render.
+    """
+    diagnostics: list[Diagnostic] = []
+    glyphs = set(atlas_glyphs) if atlas_glyphs is not None else None
+
+    for index, label in enumerate(labels):
+        object_id = str(label.get("id", f"label_{index}"))
+        kind = str(label.get("kind", "point"))
+        text = str(label.get("text", ""))
+
+        if kind in {"line", "curved"}:
+            diagnostics.append(
+                experimental_feature_diagnostic(
+                    f"{kind} labels",
+                    layer_id=layer_id,
+                    object_id=object_id,
+                )
+            )
+
+        if glyphs is not None:
+            missing = sorted({char for char in text if char not in glyphs})
+            if missing:
+                diagnostics.append(
+                    missing_glyphs_diagnostic(
+                        missing,
+                        layer_id=layer_id,
+                        object_id=object_id,
+                    )
+                )
+
+    return ValidationReport(
+        diagnostics=diagnostics,
+        supported_features={"labels.point": "underdeveloped"},
+        unsupported_features={
+            "labels.curved.production": "experimental",
+            "labels.line.production": "experimental",
+        },
+    )
+
+
+@dataclass
+class LayerSummary:
+    layer_id: str
+    layer_type: str
+    support_level: str
+    diagnostic_codes: Sequence[str] = field(default_factory=tuple)
+    object_count: int | None = None
+    bounds: Sequence[float] | None = None
+    memory_estimate_bytes: int | None = None
+    details: Mapping[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        self.support_level = _validate_support_level(self.support_level) or self.support_level
+        self.diagnostic_codes = tuple(sorted(str(code) for code in self.diagnostic_codes))
+        self.bounds = tuple(float(value) for value in self.bounds) if self.bounds is not None else None
+        self.details = _json_safe(dict(self.details or {}), context="details")
+
+    def sort_key(self) -> tuple[str, str, str]:
+        return (self.layer_id, self.layer_type, self.support_level)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "layer_id": self.layer_id,
+            "layer_type": self.layer_type,
+            "support_level": self.support_level,
+            "diagnostic_codes": list(self.diagnostic_codes),
+            "object_count": self.object_count,
+            "bounds": list(self.bounds) if self.bounds is not None else None,
+            "memory_estimate_bytes": self.memory_estimate_bytes,
+            "details": _json_safe(dict(self.details or {}), context="details"),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "LayerSummary":
+        return cls(
+            layer_id=str(data["layer_id"]),
+            layer_type=str(data["layer_type"]),
+            support_level=str(data["support_level"]),
+            diagnostic_codes=data.get("diagnostic_codes") or (),
+            object_count=data.get("object_count"),
+            bounds=data.get("bounds"),
+            memory_estimate_bytes=data.get("memory_estimate_bytes"),
+            details=data.get("details") or {},
+        )
+
+
+@dataclass
+class SupportMatrixEntry:
+    area: str
+    capability: str
+    support_level: str
+    scope: str
+    limitations: Sequence[str] = field(default_factory=tuple)
+    diagnostic_codes: Sequence[str] = field(default_factory=tuple)
+    remediation: str = ""
+    evidence: Sequence[str] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        self.support_level = _validate_support_level(self.support_level) or self.support_level
+        self.limitations = tuple(sorted(str(item) for item in self.limitations))
+        self.diagnostic_codes = tuple(sorted(str(code) for code in self.diagnostic_codes))
+        self.evidence = tuple(sorted(str(item) for item in self.evidence))
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "area": self.area,
+            "capability": self.capability,
+            "support_level": self.support_level,
+            "scope": self.scope,
+            "limitations": list(self.limitations),
+            "diagnostic_codes": list(self.diagnostic_codes),
+            "remediation": self.remediation,
+            "evidence": list(self.evidence),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "SupportMatrixEntry":
+        return cls(
+            area=str(data["area"]),
+            capability=str(data["capability"]),
+            support_level=str(data["support_level"]),
+            scope=str(data["scope"]),
+            limitations=data.get("limitations") or (),
+            diagnostic_codes=data.get("diagnostic_codes") or (),
+            remediation=str(data.get("remediation") or ""),
+            evidence=data.get("evidence") or (),
+        )
+
+
+@dataclass
+class ValidationReport:
+    diagnostics: Sequence[Diagnostic | Mapping[str, Any]] = field(default_factory=tuple)
+    layer_summaries: Sequence[LayerSummary | Mapping[str, Any]] = field(default_factory=tuple)
+    estimated_gpu_memory_bytes: int | None = None
+    supported_features: Mapping[str, str] | None = None
+    unsupported_features: Mapping[str, str] | None = None
+    status: str | None = None
+
+    def __post_init__(self) -> None:
+        self.diagnostics = tuple(
+            sorted(
+                (
+                    diag if isinstance(diag, Diagnostic) else Diagnostic.from_dict(diag)
+                    for diag in self.diagnostics
+                ),
+                key=lambda diag: diag.sort_key(),
+            )
+        )
+        self.layer_summaries = tuple(
+            sorted(
+                (
+                    summary if isinstance(summary, LayerSummary) else LayerSummary.from_dict(summary)
+                    for summary in self.layer_summaries
+                ),
+                key=lambda summary: summary.sort_key(),
+            )
+        )
+        derived_status = SeverityPolicy.status_for([diag.severity for diag in self.diagnostics])
+        if self.status is not None:
+            if self.status not in ("ok", "warning", "error", "fatal"):
+                raise ValueError(f"Unknown validation status: {self.status!r}")
+            if _STATUS_RANK[self.status] > _STATUS_RANK[derived_status]:
+                derived_status = self.status
+        self.status = derived_status
+        self.supported_features = _normalize_support_summary(self.supported_features)
+        self.unsupported_features = _normalize_support_summary(self.unsupported_features)
+
+    @property
+    def has_errors(self) -> bool:
+        return self.status in ("error", "fatal")
+
+    def render_blocked(self, policy: str = RenderFailurePolicy.CONTINUE_ON_WARNING) -> bool:
+        return SeverityPolicy.render_blocked(self.status or "ok", policy)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "status": self.status,
+            "diagnostics": [diag.to_dict() for diag in self.diagnostics],
+            "layer_summaries": [summary.to_dict() for summary in self.layer_summaries],
+            "estimated_gpu_memory_bytes": self.estimated_gpu_memory_bytes,
+            "supported_features": dict(self.supported_features or {}),
+            "unsupported_features": dict(self.unsupported_features or {}),
+            "render_blocked": self.render_blocked(),
+        }
+
+    @classmethod
+    def from_dict(cls, data: Mapping[str, Any]) -> "ValidationReport":
+        return cls(
+            diagnostics=data.get("diagnostics") or (),
+            layer_summaries=data.get("layer_summaries") or (),
+            estimated_gpu_memory_bytes=data.get("estimated_gpu_memory_bytes"),
+            supported_features=data.get("supported_features") or {},
+            unsupported_features=data.get("unsupported_features") or {},
+            status=data.get("status"),
+        )
+
+
+__all__ = [
+    "Diagnostic",
+    "LayerSummary",
+    "REQUIRED_DIAGNOSTIC_CODES",
+    "RenderFailurePolicy",
+    "SeverityPolicy",
+    "SupportMatrixEntry",
+    "ValidationReport",
+    "SEVERITIES",
+    "SUPPORT_LEVELS",
+    "crs_mismatch_diagnostic",
+    "estimated_gpu_memory_diagnostic",
+    "experimental_feature_diagnostic",
+    "label_rejection_summary_diagnostic",
+    "missing_glyphs_diagnostic",
+    "placeholder_fallback_diagnostic",
+    "pro_gated_path_diagnostic",
+    "python_public_3dtiles_incomplete_diagnostic",
+    "unsupported_style_field_diagnostic",
+    "unsupported_style_layer_type_diagnostic",
+    "validate_label_support",
+    "vt_unsupported_family_diagnostic",
+]

--- a/python/forge3d/style.py
+++ b/python/forge3d/style.py
@@ -6,9 +6,11 @@ files into forge3d's native vector and label styles.
 
 Supported layer types (v1):
 - fill: Polygon fill with color, opacity, outline
-- line: Polyline with color, width, opacity  
-- symbol: Text labels with size, color, halo
-- background: Background color (informational only)
+- line: Polyline with color, width, opacity
+- circle: Point circles with color, radius, opacity
+
+This is local/provided feature styling, not streamed MVT rendering or full
+Mapbox Style Specification support.
 
 Example:
     >>> from forge3d.style import load_style, apply_style
@@ -25,6 +27,26 @@ from pathlib import Path
 from typing import Any
 
 from ._license import _check_pro_access
+from .diagnostics import (
+    LayerSummary,
+    ValidationReport,
+    experimental_feature_diagnostic,
+    unsupported_style_field_diagnostic,
+    unsupported_style_layer_type_diagnostic,
+)
+
+
+P0_SUPPORTED_STYLE_LAYER_TYPES = ("fill", "line", "circle")
+_SUPPORTED_PAINT_FIELDS = {
+    "fill": {"fill-color", "fill-opacity", "fill-outline-color"},
+    "line": {"line-color", "line-width", "line-opacity"},
+    "circle": {"circle-color", "circle-radius", "circle-opacity"},
+}
+_SUPPORTED_LAYOUT_FIELDS = {
+    "fill": {"visibility"},
+    "line": {"visibility"},
+    "circle": {"visibility"},
+}
 
 
 @dataclass
@@ -91,6 +113,8 @@ class StyleLayer:
     filter: list[Any] | None = None
     minzoom: float | None = None
     maxzoom: float | None = None
+    unsupported_paint_fields: tuple[str, ...] = field(default_factory=tuple)
+    unsupported_layout_fields: tuple[str, ...] = field(default_factory=tuple)
 
     def is_visible(self) -> bool:
         """Check if layer is visible."""
@@ -115,7 +139,7 @@ class StyleLayer:
 
 @dataclass
 class StyleSpec:
-    """Complete Mapbox GL Style specification."""
+    """Parsed Mapbox-style document for local/provided feature styling."""
     version: int = 8
     name: str = ""
     layers: list[StyleLayer] = field(default_factory=list)
@@ -203,6 +227,11 @@ def _parse_layer(data: dict) -> StyleLayer:
     """Parse a single layer from JSON, preserving raw expressions."""
     paint_data = data.get("paint", {})
     layout_data = data.get("layout", {})
+    layer_type = data.get("type", "unknown")
+    supported_paint_fields = _SUPPORTED_PAINT_FIELDS.get(layer_type, set())
+    supported_layout_fields = _SUPPORTED_LAYOUT_FIELDS.get(layer_type, set())
+    unsupported_paint_fields = tuple(sorted(set(paint_data.keys()) - supported_paint_fields))
+    unsupported_layout_fields = tuple(sorted(set(layout_data.keys()) - supported_layout_fields))
 
     # Store raw values to preserve expressions for later evaluation
     paint = PaintProps(
@@ -236,7 +265,7 @@ def _parse_layer(data: dict) -> StyleLayer:
 
     return StyleLayer(
         id=data.get("id", ""),
-        layer_type=data.get("type", "unknown"),
+        layer_type=layer_type,
         source=data.get("source"),
         source_layer=data.get("source-layer"),
         paint=paint,
@@ -244,7 +273,109 @@ def _parse_layer(data: dict) -> StyleLayer:
         filter=data.get("filter"),
         minzoom=data.get("minzoom"),
         maxzoom=data.get("maxzoom"),
+        unsupported_paint_fields=unsupported_paint_fields,
+        unsupported_layout_fields=unsupported_layout_fields,
     )
+
+
+def validate_style_support(style: StyleSpec | dict[str, Any]) -> ValidationReport:
+    """Validate P0 offline style support without claiming streamed MVT parity.
+
+    Supported P0 style validation covers local/provided feature styling for
+    ``fill``, ``line``, and ``circle`` layers. Unsupported layer types and
+    unsupported paint/layout fields are returned as structured diagnostics.
+    """
+    raw_layers: list[dict[str, Any]] | None = None
+    if isinstance(style, StyleSpec):
+        spec = style
+    else:
+        raw_layers = list(style.get("layers", []))
+        spec = parse_style(style)
+
+    diagnostics = []
+    layer_summaries = []
+    supported_features = {
+        "style.local_provided_features": "supported",
+        **{
+            f"style.layer.{layer_type}": "supported"
+            for layer_type in P0_SUPPORTED_STYLE_LAYER_TYPES
+        },
+    }
+    unsupported_features = {
+        "style.streamed_mvt": "non-goal",
+        "style.full_mapbox_spec": "unsupported",
+    }
+
+    raw_by_id = {
+        str(layer.get("id", "")): layer
+        for layer in raw_layers or []
+        if isinstance(layer, dict)
+    }
+    for index, layer in enumerate(spec.layers):
+        layer_id = layer.id or f"layer_{index}"
+        diagnostic_codes: list[str] = []
+
+        if layer.layer_type == "symbol":
+            diag = experimental_feature_diagnostic(
+                "symbol text layer",
+                layer_id=layer_id,
+            )
+            diagnostics.append(diag)
+            diagnostic_codes.append(diag.code)
+            support_level = "underdeveloped"
+            unsupported_features["style.layer.symbol"] = "underdeveloped"
+        elif layer.layer_type not in P0_SUPPORTED_STYLE_LAYER_TYPES:
+            diag = unsupported_style_layer_type_diagnostic(layer_id, layer.layer_type)
+            diagnostics.append(diag)
+            diagnostic_codes.append(diag.code)
+            support_level = "unsupported"
+        else:
+            support_level = "supported"
+            raw_layer = raw_by_id.get(layer.id)
+            if raw_layer is not None:
+                paint_fields = set((raw_layer.get("paint") or {}).keys())
+                unsupported_paint = paint_fields - _SUPPORTED_PAINT_FIELDS[layer.layer_type]
+                layout_fields = set((raw_layer.get("layout") or {}).keys())
+                unsupported_layout = layout_fields - _SUPPORTED_LAYOUT_FIELDS[layer.layer_type]
+            else:
+                unsupported_paint = set(layer.unsupported_paint_fields)
+                unsupported_layout = set(layer.unsupported_layout_fields)
+
+            if unsupported_paint:
+                diag = unsupported_style_field_diagnostic(
+                    layer_id,
+                    sorted(unsupported_paint),
+                    section="paint",
+                )
+                diagnostics.append(diag)
+                diagnostic_codes.append(diag.code)
+
+            if unsupported_layout:
+                diag = unsupported_style_field_diagnostic(
+                    layer_id,
+                    sorted(unsupported_layout),
+                    section="layout",
+                )
+                diagnostics.append(diag)
+                diagnostic_codes.append(diag.code)
+
+        layer_summaries.append(
+            LayerSummary(
+                layer_id=layer_id,
+                layer_type=layer.layer_type,
+                support_level=support_level,
+                diagnostic_codes=diagnostic_codes,
+            )
+        )
+
+    return ValidationReport(
+        diagnostics=diagnostics,
+        layer_summaries=layer_summaries,
+        supported_features=supported_features,
+        unsupported_features=unsupported_features,
+    )
+
+
 def evaluate_color_expr(
     value: Any,
     properties: dict[str, Any],
@@ -545,6 +676,158 @@ def apply_style(
             result.append((feature, VectorStyle()))
 
     return result
+
+
+def _style_coord_to_vertex(
+    coord: list[float] | tuple[float, ...],
+    color: tuple[float, float, float, float],
+    *,
+    feature_id: int,
+):
+    from .terrain_params import VectorVertex
+
+    x = float(coord[0])
+    z = float(coord[1]) if len(coord) > 1 else 0.0
+    y = float(coord[2]) if len(coord) > 2 else 0.0
+    return VectorVertex(x=x, y=y, z=z, r=color[0], g=color[1], b=color[2], a=color[3], feature_id=feature_id)
+
+
+def _feature_geometry_to_vector_overlay(
+    *,
+    name: str,
+    feature: dict[str, Any],
+    layer: StyleLayer,
+    vector_style: VectorStyle,
+    feature_id: int,
+):
+    from .terrain_params import PrimitiveType, VectorOverlayConfig
+
+    geometry = feature.get("geometry") or {}
+    geom_type = geometry.get("type")
+    coordinates = geometry.get("coordinates")
+    if not coordinates:
+        return None
+
+    if geom_type == "Point" and layer.layer_type == "circle":
+        color = vector_style.fill_color
+        return VectorOverlayConfig(
+            name=name,
+            vertices=[_style_coord_to_vertex(coordinates, color, feature_id=feature_id)],
+            indices=[0],
+            primitive=PrimitiveType.POINTS,
+            point_size=max(vector_style.point_size, 0.1),
+        )
+
+    if geom_type == "LineString" and layer.layer_type == "line":
+        color = vector_style.stroke_color
+        vertices = [
+            _style_coord_to_vertex(coord, color, feature_id=feature_id)
+            for coord in coordinates
+        ]
+        indices: list[int] = []
+        for idx in range(max(0, len(vertices) - 1)):
+            indices.extend([idx, idx + 1])
+        return VectorOverlayConfig(
+            name=name,
+            vertices=vertices,
+            indices=indices,
+            primitive=PrimitiveType.LINES,
+            line_width=max(vector_style.stroke_width, 0.1),
+        )
+
+    if geom_type == "Polygon" and layer.layer_type == "fill":
+        rings = coordinates
+        if not rings or len(rings[0]) < 3:
+            return None
+        color = vector_style.fill_color
+        ring = rings[0]
+        vertices = [
+            _style_coord_to_vertex(coord, color, feature_id=feature_id)
+            for coord in ring[:-1] if len(ring) > 3
+        ] or [
+            _style_coord_to_vertex(coord, color, feature_id=feature_id)
+            for coord in ring
+        ]
+        indices: list[int] = []
+        for idx in range(1, max(1, len(vertices) - 1)):
+            indices.extend([0, idx, idx + 1])
+        return VectorOverlayConfig(
+            name=name,
+            vertices=vertices,
+            indices=indices,
+            primitive=PrimitiveType.TRIANGLES,
+        )
+
+    return None
+
+
+def vector_overlay_configs_from_style(
+    style: StyleSpec | dict[str, Any],
+    features: list[dict[str, Any]],
+    source_layer: str | None = None,
+    zoom: float = 10.0,
+    *,
+    name_prefix: str = "style",
+):
+    """Convert supported local/provided style output to vector overlay configs."""
+    spec = style if isinstance(style, StyleSpec) else parse_style(style)
+    layers = spec.layers_for_source_layer(source_layer) if source_layer else spec.layers
+    layers = [
+        layer for layer in layers
+        if layer.is_visible()
+        and layer.in_zoom_range(zoom)
+        and layer.layer_type in P0_SUPPORTED_STYLE_LAYER_TYPES
+    ]
+
+    overlays = []
+    for feature_index, feature in enumerate(features):
+        props = feature.get("properties", {})
+        for layer in layers:
+            if not layer.matches_filter(props):
+                continue
+            vector_style = layer_to_vector_style(layer)
+            overlay = _feature_geometry_to_vector_overlay(
+                name=f"{name_prefix}.{layer.id}.{feature_index}",
+                feature=feature,
+                layer=layer,
+                vector_style=vector_style,
+                feature_id=feature_index,
+            )
+            if overlay is not None:
+                overlays.append(overlay)
+                break
+    return overlays
+
+
+def label_layer_contracts_from_style(
+    style: StyleSpec | dict[str, Any],
+    source_layer: str | None = None,
+    zoom: float = 10.0,
+) -> list[dict[str, Any]]:
+    """Return future LabelLayer-compatible contracts from symbol style layers."""
+    spec = style if isinstance(style, StyleSpec) else parse_style(style)
+    layers = spec.layers_for_source_layer(source_layer) if source_layer else spec.layers
+    contracts = []
+    for layer in layers:
+        if layer.layer_type != "symbol" or not layer.is_visible() or not layer.in_zoom_range(zoom):
+            continue
+        label_style = layer_to_label_style(layer)
+        contracts.append(
+            {
+                "layer_id": layer.id,
+                "source_layer": layer.source_layer,
+                "text_field": layer.layout.text_field,
+                "support_level": "underdeveloped",
+                "label_style": {
+                    "size": label_style.size,
+                    "color": label_style.color,
+                    "halo_color": label_style.halo_color,
+                    "halo_width": label_style.halo_width,
+                    "offset": label_style.offset,
+                },
+            }
+        )
+    return contracts
 
 
 def parse_color(color_str: str) -> tuple[float, float, float, float] | None:

--- a/python/forge3d/terrain_params.py
+++ b/python/forge3d/terrain_params.py
@@ -1348,6 +1348,44 @@ class TerrainVTSettings:
         return min(self.max_mip_levels, layer.full_pyramid_levels)
 
 
+def validate_terrain_vt_support(
+    settings: TerrainVTSettings,
+    *,
+    layer_id: str | None = None,
+):
+    """Validate terrain VT family support against the current native runtime."""
+    from .diagnostics import LayerSummary, ValidationReport, vt_unsupported_family_diagnostic
+
+    effective_layer_id = layer_id or "terrain.vt"
+    diagnostics = [
+        vt_unsupported_family_diagnostic(layer.family, layer_id=effective_layer_id)
+        for layer in settings.layers
+        if layer.family != "albedo"
+    ]
+    return ValidationReport(
+        diagnostics=diagnostics,
+        layer_summaries=[
+            LayerSummary(
+                layer_id=effective_layer_id,
+                layer_type="terrain.virtual_texture",
+                support_level="supported" if not diagnostics else "unsupported",
+                diagnostic_codes=[diag.code for diag in diagnostics],
+                details={
+                    "enabled": settings.enabled,
+                    "families": sorted(layer.family for layer in settings.layers),
+                    "native_supported_family": "albedo",
+                },
+            )
+        ],
+        supported_features={"vt.albedo": "supported"},
+        unsupported_features={
+            f"vt.{layer.family}": "missing"
+            for layer in settings.layers
+            if layer.family != "albedo"
+        },
+    )
+
+
 @dataclass
 class OverlayBlendMode:
     """Blend mode constants for overlay layers."""
@@ -2226,6 +2264,7 @@ __all__ = [
     "localized_haze_volume",
     "VTLayerFamily",
     "TerrainVTSettings",
+    "validate_terrain_vt_support",
     "OverlayBlendMode",
     "OverlayLayerConfig",
     "OverlaySettings",

--- a/python/forge3d/tiles3d.py
+++ b/python/forge3d/tiles3d.py
@@ -21,6 +21,12 @@ from pathlib import Path
 from typing import List, Optional, Tuple, Dict, Any
 import numpy as np
 
+from .diagnostics import (
+    LayerSummary,
+    ValidationReport,
+    python_public_3dtiles_incomplete_diagnostic,
+)
+
 
 @dataclass
 class BoundingVolume:
@@ -401,3 +407,31 @@ def decode_pnts(data: bytes) -> Dict[str, Any]:
         "normals": None,
         "point_count": points_length,
     }
+
+
+def validate_tiles3d_support(
+    tileset: Tileset,
+    *,
+    layer_id: str | None = None,
+) -> ValidationReport:
+    """Validate public Python 3D Tiles support before render preparation."""
+    effective_layer_id = layer_id or "tiles3d"
+    diag = python_public_3dtiles_incomplete_diagnostic(layer_id=effective_layer_id)
+    return ValidationReport(
+        diagnostics=[diag],
+        layer_summaries=[
+            LayerSummary(
+                layer_id=effective_layer_id,
+                layer_type="tiles3d",
+                support_level="underdeveloped",
+                diagnostic_codes=[diag.code],
+                object_count=tileset.tile_count,
+                details={
+                    "max_depth": tileset.max_depth,
+                    "tile_count": tileset.tile_count,
+                    "version": tileset.version,
+                },
+            )
+        ],
+        unsupported_features={"tiles3d.public_python_render": "underdeveloped"},
+    )

--- a/specs/001-diagnostics-support-matrices/checklists/requirements.md
+++ b/specs/001-diagnostics-support-matrices/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Diagnostics and Support Matrices
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-14
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation passed on 2026-05-14 after checking the spec against PRD P0-R5, P0-R6, Section 13, Section 16, Appendix B, Milestone 0, and constitution diagnostics/support-honesty requirements.
+- No clarification markers remain. Assumptions are recorded in `spec.md`.
+- Clarification review on 2026-05-14 applied PRD-aligned safe defaults for severity blocking, CRS mismatch behavior, support classification, bundle-ready diagnostics, deterministic ordering, and documentation wording discipline.

--- a/specs/001-diagnostics-support-matrices/contracts/diagnostics-contract.md
+++ b/specs/001-diagnostics-support-matrices/contracts/diagnostics-contract.md
@@ -1,0 +1,56 @@
+# Contract: Diagnostics And Validation Report
+
+Public API names are contract-level names; final file paths are TBD until task inspection chooses the package location.
+
+```python
+Diagnostic(
+    code: str,
+    severity: Literal["info", "warning", "error", "fatal"],
+    message: str,
+    remediation: str,
+    support_level: str | None = None,
+    layer_id: str | None = None,
+    object_id: str | None = None,
+    details: Mapping[str, JSONValue] | None = None,
+)
+
+ValidationReport(
+    status: Literal["ok", "warning", "error", "fatal"],
+    diagnostics: Sequence[Diagnostic],
+    layer_summaries: Sequence[LayerSummary] = (),
+    estimated_gpu_memory_bytes: int | None = None,
+    supported_features: Mapping[str, str] | None = None,
+    unsupported_features: Mapping[str, str] | None = None,
+)
+```
+
+Required methods:
+
+- `Diagnostic.to_dict()` and `Diagnostic.from_dict()`.
+- `ValidationReport.to_dict()` and `ValidationReport.from_dict()`.
+- `ValidationReport.has_errors`.
+- `ValidationReport.render_blocked(policy="continue_on_warning" | "fail_on_warning")`.
+
+Required diagnostic codes:
+
+```text
+crs_mismatch
+missing_glyphs
+unsupported_style_field
+unsupported_style_layer_type
+pro_gated_path
+placeholder_fallback
+experimental_feature
+vt_unsupported_family
+python_public_3dtiles_incomplete
+estimated_gpu_memory
+label_rejection_summary
+```
+
+Contract rules:
+
+- Unknown support-level terms are invalid.
+- Unknown severities are invalid.
+- Serialization must preserve all public fields.
+- Repeated serialization of fixed inputs must be byte-stable when encoded with sorted keys.
+- A warning may block only under fail-on-warning; an error or fatal always blocks.

--- a/specs/001-diagnostics-support-matrices/data-model.md
+++ b/specs/001-diagnostics-support-matrices/data-model.md
@@ -1,0 +1,58 @@
+# Data Model: Diagnostics and Support Matrices
+
+## Diagnostic
+
+- `code`: stable string from required inventory or feature-local extension.
+- `severity`: one of `info`, `warning`, `error`, `fatal`.
+- `message`: concise user-facing description.
+- `remediation`: actionable next step or support boundary.
+- `support_level`: optional PRD Appendix B classification.
+- `layer_id`: optional affected layer ID.
+- `object_id`: optional affected object, feature, label, tile, or asset ID.
+- `details`: JSON-serializable deterministic mapping for extra context.
+
+Validation: unknown severities and support levels are invalid. `details` must be serializable and sorted for output.
+
+## ValidationReport
+
+- `status`: highest blocking status derived from diagnostics and render policy.
+- `diagnostics`: ordered list of `Diagnostic`.
+- `layer_summaries`: ordered `LayerSummary` entries.
+- `estimated_gpu_memory_bytes`: optional integer estimate.
+- `supported_features`: deterministic mapping.
+- `unsupported_features`: deterministic mapping.
+- `render_blocked`: boolean.
+
+Ordering: severity rank, code, layer ID, object ID, message, then stable details hash.
+
+## LayerSummary
+
+- `layer_id`
+- `layer_type`
+- `support_level`
+- `diagnostic_codes`
+- `object_count`
+- `bounds`
+- `memory_estimate_bytes`
+- `details`
+
+## SupportMatrixEntry
+
+- `area`
+- `capability`
+- `support_level`
+- `scope`
+- `limitations`
+- `diagnostic_codes`
+- `remediation`
+- `evidence`
+
+## RenderFailurePolicy
+
+- `continue_on_warning`: default.
+- `fail_on_warning`: warnings block successful render.
+- Errors and fatals always block.
+
+## SeverityPolicy
+
+Maps severities to report status and render blocking behavior. Informational diagnostics never block by themselves.

--- a/specs/001-diagnostics-support-matrices/plan.md
+++ b/specs/001-diagnostics-support-matrices/plan.md
@@ -1,0 +1,200 @@
+# Implementation Plan: Diagnostics and Support Matrices
+
+**Branch**: `001-diagnostics-support-matrices` | **Date**: 2026-05-15 | **Spec**: `specs/001-diagnostics-support-matrices/spec.md`
+**Input**: Feature specification from `specs/001-diagnostics-support-matrices/spec.md`
+
+## Summary
+
+Define the product-level structured diagnostics contract and support-matrix documentation that all later map-rendering features consume. The plan wraps existing substrate in `python/forge3d/style.py`, `python/forge3d/buildings.py`, `python/forge3d/tiles3d.py`, `python/forge3d/bundle.py`, `python/forge3d/crs.py`, `python/forge3d/terrain_params.py`, `python/forge3d/mem.py`, `python/forge3d/viewer_ipc.py`, and native label/VT/building/tile paths. The public diagnostics contract is planned for `python/forge3d/diagnostics.py`, exported through `python/forge3d/__init__.py` and typed in `python/forge3d/__init__.pyi`; strict audit remediation additionally persists diagnostic reports through the existing scene-bundle state, adds public non-style diagnostic validators, and proves style output handoff shapes without implementing full `MapScene`, `LabelPlan`, or render-path ownership.
+
+## Technical Context
+
+**Language/Version**: Python `>=3.10` from `pyproject.toml`; Rust 2021 crate with PyO3 `0.21.2` and maturin `>=1.5,<2.0` from `Cargo.toml` and `pyproject.toml`.
+**Primary Dependencies**: Existing forge3d Python modules, PyO3 extension, pytest, native device/memory diagnostics, style/building/tile/bundle/label/VT substrate.
+**Storage**: Filesystem docs and bundle-ready JSON-serializable diagnostic payloads.
+**Testing**: pytest for Python contracts and negative paths; cargo tests only if native diagnostic hooks are changed.
+**Target Platform**: Offline Python library workflows on supported forge3d desktop/server platforms.
+**Project Type**: Python/Rust library with documentation.
+**Performance Goals**: Validation ordering deterministic; diagnostics should be cheap enough to run before render and must avoid GPU work unless explicitly needed for memory/device summaries.
+**Constraints**: No raw IPC required for MVP workflows; diagnostics must be structured, serializable, deterministic, and must not turn unsupported paths into success.
+**Scale/Scope**: P0 diagnostics inventory plus support matrices for style, labels, buildings, 3D Tiles, VT, and diagnostics reference.
+
+## Constitution Check
+
+- [x] PRD traceability: in scope P0-R5-AC1 through P0-R5-AC6, P0-R6-AC1 through P0-R6-AC6, PRD Sections 13 and 16, Appendix B, Milestone 0.
+- [x] Offline map scope: limited to offline 3D map rendering diagnostics and docs.
+- [x] API truthfulness: unsupported, experimental, Pro-gated, placeholder/fallback, and underdeveloped paths produce typed diagnostics or documented failures.
+- [x] Determinism: reports sort diagnostics and summaries by severity rank, code, layer ID, object ID, and stable message/detail keys.
+- [x] Diagnostics first: validation surfaces issues before render where enough input information exists.
+- [x] Typed product contract: defines `Diagnostic`, `ValidationReport`, `LayerSummary`, `SupportMatrixEntry`, `RenderFailurePolicy`, and `SeverityPolicy` for later `MapScene`, `LabelPlan`, and `Bundle` workflows.
+- [x] Evidence plan: each acceptance criterion maps to components, tests, docs, diagnostics, and matrix updates below.
+- [x] Support wording: uses only PRD Appendix B classifications.
+- [x] Compatibility: existing APIs remain available; new diagnostics wrap or augment behavior rather than removing current helpers.
+- [x] Continuity: tasks must update `docs/superpowers/state/current-context-pack.md`, `docs/superpowers/state/implementation-ledger.md`, and the verification matrix when statuses change.
+
+## Hostile Review Risk Table
+
+| Area | Status | Risk after amendment | Required disposition |
+|---|---|---|---|
+| 1. PRD acceptance-criterion coverage | Green | P0-R5 and P0-R6 acceptance criteria are mapped below; Section 13, Section 16, Appendix B, and Milestone 0 are in scope. | Generated tasks must include every mapped PRD AC tag and must not mark rows beyond `Planned` without evidence. |
+| 2. Test coverage | Green | Contract, negative, style, policy, serialization, determinism, and docs-audit tests are explicitly required. | Generated tasks must create test files named in this plan or amend the plan first. |
+| 3. Diagnostics/support honesty | Green | Required diagnostic codes, severity floors, support levels, remediation, and affected IDs are part of the contract. | Unsupported, underdeveloped, Pro-gated, placeholder/fallback, and experimental paths must be diagnosed before render where inputs are knowable. |
+| 4. Determinism/reproducibility | Green | Report ordering and serialization use stable sort keys and sorted JSON output. | Tasks must include repeated-run comparison tests. |
+| 5. No-op success prevention | Green | Known silent-ignore and placeholder paths are required negative-test targets. | A path that cannot be wired must return a typed diagnostic or typed failure, not success. |
+| 6. Raw IPC avoidance | Green | `viewer_ipc` may be inspected as substrate only; no canonical MVP validation workflow may require raw IPC. | Tasks must keep public validation helpers typed and Python-level. |
+| 7. Bundle/documentation requirements | Green | Bundle-ready serialization, diagnostic-only scene-bundle persistence, and exact docs/support-matrix paths are listed below. | Full map-scene review-bundle round-trip remains later-feature scope, but diagnostic payloads must be lossless and embeddable. |
+| 8. New-chat continuity artifacts | Green | Ledger, context pack, and verification matrix rules are explicit. | Every implementation/task session must update continuity artifacts before completion. |
+| 9. P0/P1/P2 scope boundaries | Yellow | Feature `001` may reference P1/P2-owned paths only to classify and diagnose them, not to implement them. | Accepted risk: support matrices mention later features as `underdeveloped`, `missing`, `experimental`, `Pro-gated`, `placeholder/fallback`, or `unsupported`; implementation tasks must not pull P1/P2 rendering work into P0. |
+| 10. File-path accuracy | Yellow | Proposed new code/docs/test paths are fixed by this plan, but task inspection may reveal a stronger local convention. | Accepted risk: any path change must update `plan.md`, `contracts/diagnostics-contract.md`, and generated tasks in the same planning pass before code edits. |
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/001-diagnostics-support-matrices/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── diagnostics-contract.md
+└── tasks.md                    # generated later by /speckit-tasks
+```
+
+### Existing Source Paths To Inspect During Tasks
+
+```text
+python/forge3d/__init__.py
+python/forge3d/__init__.pyi
+python/forge3d/style.py
+python/forge3d/buildings.py
+python/forge3d/tiles3d.py
+python/forge3d/bundle.py
+python/forge3d/crs.py
+python/forge3d/terrain_params.py
+python/forge3d/mem.py
+python/forge3d/viewer_ipc.py
+src/labels/
+src/viewer/cmd/labels_command.rs
+src/terrain/render_params/native_vt.rs
+src/terrain/renderer/virtual_texture.rs
+src/import/
+src/tiles3d/
+src/bundle/
+tests/
+docs/
+```
+
+### Planned Product Source And Test Paths
+
+```text
+python/forge3d/diagnostics.py
+python/forge3d/__init__.py
+python/forge3d/__init__.pyi
+tests/test_diagnostics_contract.py
+tests/test_diagnostics_style_support.py
+tests/test_diagnostics_support_paths.py
+tests/test_diagnostics_bundle_serialization.py
+tests/test_bundle_roundtrip.py
+tests/test_support_matrices_docs.py
+```
+
+### Planned Documentation Paths
+
+```text
+docs/guides/offline_3d_map_rendering.md
+docs/guides/diagnostics_reference.md
+docs/guides/style_support_matrix.md
+docs/guides/label_support_matrix.md
+docs/guides/building_support_matrix.md
+docs/guides/tiles3d_support_matrix.md
+docs/guides/virtual_texturing_support_matrix.md
+docs/guides/competitive_positioning.md
+docs/index.rst
+```
+
+Generated `docs/_build/` output is not a source path and must not be edited by this feature. Documentation tasks must update `docs/index.rst` to include any new source docs that should be built.
+
+**Structure Decision**: Add the product diagnostics contract in `python/forge3d/diagnostics.py` and re-export public classes from `python/forge3d/__init__.py` with matching type stubs in `python/forge3d/__init__.pyi`. Support matrices live as source docs under `docs/guides/`; the listed paths are the default and may change only through an explicit plan amendment before implementation.
+
+## Test Strategy First
+
+1. Contract tests for `Diagnostic`, severity values, support-level vocabulary, serialization, deterministic ordering, and report status calculation.
+2. Negative tests for `crs_mismatch`, `missing_glyphs`, `unsupported_style_field`, `unsupported_style_layer_type`, `pro_gated_path`, `placeholder_fallback`, `experimental_feature`, `vt_unsupported_family`, `python_public_3dtiles_incomplete`, `estimated_gpu_memory`, and `label_rejection_summary`.
+3. Render policy tests showing warnings continue by default, fail when fail-on-warning is selected, and errors/fatals always block successful completion.
+4. Style diagnostics tests against known supported `fill`, `line`, and `circle` paths plus unsupported layer/field fixtures after auditing `python/forge3d/style.py`.
+5. Serialization tests proving diagnostics can be embedded in bundle-ready structures and preserved through the existing scene-bundle state without losing code, severity, affected IDs, support level, or remediation.
+6. Docs audit tests or review checklist proving no public docs claim full Mapbox Style Specification, production 3D Tiles, VT normal/mask runtime, textured PBR buildings, or production line/curved labels.
+7. No-op success regression tests for known risky paths from `research.md`: style fields dropped by parsing/application, building zero-geometry fallbacks, 3D Tiles incomplete decode/render paths, VT non-albedo family requests, and label command truthfulness diagnostics.
+8. Determinism tests that build the same report twice and compare diagnostic order, support-summary order, and sorted JSON serialization byte-for-byte.
+9. Raw IPC avoidance tests or docs audits proving public validation examples use `Diagnostic`/`ValidationReport` helpers and do not require users to call `python/forge3d/viewer_ipc.py`.
+
+## Implementation Strategy
+
+1. Confirm that `python/forge3d/diagnostics.py` fits existing export and typing conventions in `python/forge3d/__init__.py`, `python/forge3d/__init__.pyi`, and nearby dataclass modules; if not, amend this plan before selecting a different path.
+2. Add Python dataclass or typed wrapper models for diagnostics and validation reports with deterministic `to_dict()`/`from_dict()` behavior and sorted JSON-friendly output.
+3. Add support-level and severity validation helpers; reject unknown support terms rather than silently accepting them.
+4. Add style-support audit logic around existing `StyleLayer`, `PaintProps`, and `LayoutProps` parsing without claiming streamed MVT support; unsupported fields and layer types must produce structured diagnostics, not dropped fields.
+5. Add adapter functions or pure validation helpers for known placeholder/fallback/pro-gated paths so later `MapScene` and bundle features can report them before render. These adapters must not make the underlying render path look supported.
+6. Preserve `ValidationReport` in the existing scene-bundle `SceneState` and `LoadedBundle` path as a diagnostic-only payload without claiming full `MapScene` bundle reconstruction.
+7. Add docs support matrices and diagnostics reference using the PRD classifications exactly, with a source-doc audit that fails on forbidden overclaims.
+8. Keep raw IPC as an inspected implementation substrate only. Public examples and tests for this feature must use typed diagnostics/report objects or future `MapScene.validate()`-compatible shapes.
+
+## Acceptance Mapping
+
+| PRD AC | Components | Tests | Docs | Diagnostics |
+|---|---|---|---|---|
+| P0-R5-AC1 | `Diagnostic`, `ValidationReport` | object-field contract tests | Diagnostics Reference | all required codes |
+| P0-R5-AC2 | severity enum/policy | severity coverage tests | Diagnostics Reference | `info`, `warning`, `error`, `fatal` |
+| P0-R5-AC3 | affected ID fields | layer/object ID propagation tests | Diagnostics Reference | affected layer/object IDs |
+| P0-R5-AC4 | `to_dict`/`from_dict`, `SceneState.validation_report`, `LoadedBundle.validation_report` | serialization and bundle round-trip tests | Bundle diagnostics note | serializable payload |
+| P0-R5-AC5 | `RenderFailurePolicy`, `SeverityPolicy` | warning-policy tests | Quickstart | blocking status |
+| P0-R5-AC6 | support adapters and public validators | negative no-silent-ignore tests | support matrices | unsupported/fallback/pro-gated codes |
+| P0-R6-AC1 | style docs | docs audit | Style Support Matrix | N/A |
+| P0-R6-AC2 | style audit inventory | docs/test audit | Style Support Matrix | N/A |
+| P0-R6-AC3 | style layer support mapping | fill/line/circle tests | Style Support Matrix | unsupported codes for gaps |
+| P0-R6-AC4 | style diagnostics | unsupported style tests | Style Support Matrix | `unsupported_style_*` |
+| P0-R6-AC5 | style output contract | vector/label-consumable shape tests | Style Support Matrix | unsupported fields |
+| P0-R6-AC6 | docs wording audit | overclaim audit | all public docs | N/A |
+
+## Required Diagnostic Coverage
+
+| Code | Minimum severity when output-affecting | Support-level requirement | Test requirement |
+|---|---|---|---|
+| `crs_mismatch` | `error` | `unsupported` until an explicit compatible transform/policy exists | Mismatched scene/layer CRS fixture emits affected layer ID and remediation. |
+| `missing_glyphs` | `warning` | `underdeveloped` or `unsupported` according to atlas/path context | Missing glyph fixture emits code before render and preserves missing glyph details. |
+| `unsupported_style_field` | `warning` | `unsupported` for the field, with layer still classified by actual renderability | Style fixture with unknown paint/layout fields emits layer ID and field names. |
+| `unsupported_style_layer_type` | `error` | `unsupported` for requested layer rendering | Style fixture with unsupported layer type emits layer ID and does not claim MVT parity. |
+| `pro_gated_path` | `error` | `Pro-gated` | Building/style/bundle path without Pro/native availability emits diagnostic before success. |
+| `placeholder_fallback` | `error` | `placeholder/fallback` | Zero-geometry or non-renderable fallback emits diagnostic and blocks success. |
+| `experimental_feature` | `warning` | `experimental` | Line/curved label or other experimental path reports honest status. |
+| `vt_unsupported_family` | `error` | `unsupported` or `missing` for non-albedo runtime family | Normal/mask VT request emits diagnostic instead of log-only warning. |
+| `python_public_3dtiles_incomplete` | `error` | `underdeveloped` or `unsupported` according to requested workflow | Public 3D Tiles path that cannot complete render workflow emits diagnostic. |
+| `estimated_gpu_memory` | `warning` | `supported` for estimate availability; `underdeveloped` if unavailable for a layer | Budget-risk fixture emits deterministic estimate or honest unavailable detail. |
+| `label_rejection_summary` | `warning` | `supported` only when reason-coded plan data exists, otherwise `underdeveloped` | Synthetic rejected-label summary serializes counts/reasons deterministically. |
+
+## Future Task Generation Requirements
+
+Tasks generated later must include, at minimum:
+
+1. Create or amend `python/forge3d/diagnostics.py` plus exports/stubs for `Diagnostic`, `ValidationReport`, `LayerSummary`, `SupportMatrixEntry`, `RenderFailurePolicy`, and `SeverityPolicy` with PRD AC tags `P0-R5-AC1` through `P0-R5-AC5`.
+2. Add contract tests in `tests/test_diagnostics_contract.py` for field validation, unknown severity/support rejection, status calculation, render policy, and deterministic serialization.
+3. Add style diagnostics tasks in `tests/test_diagnostics_style_support.py` and docs tasks for `docs/guides/style_support_matrix.md`, covering `P0-R6-AC1` through `P0-R6-AC6`.
+4. Add support-path negative tests in `tests/test_diagnostics_support_paths.py` for Pro-gated, placeholder/fallback, experimental, VT, 3D Tiles, CRS, glyph, memory, and label-rejection diagnostics.
+5. Add bundle-ready serialization tests in `tests/test_diagnostics_bundle_serialization.py` and diagnostic-only scene-bundle persistence tests in `tests/test_bundle_roundtrip.py`; full `MapScene` review-bundle reconstruction remains feature `005`.
+6. Add docs/source audit coverage in `tests/test_support_matrices_docs.py` or an equivalent explicit verification command for the required docs paths and forbidden overclaim wording.
+7. Update `docs/superpowers/state/current-context-pack.md` and `docs/superpowers/state/implementation-ledger.md` in every implementation session; update `docs/superpowers/state/requirements-verification-matrix.md` only when evidence justifies a status change.
+8. Preserve P0 scope: do not implement `LabelPlan`, `MapScene`, buildings, 3D Tiles runtime rendering, or VT normal/mask runtime in feature `001`; only define diagnostics/support contracts, public validation helpers, diagnostic-only bundle persistence, and honest reporting for those paths.
+
+## Migration And Compatibility
+
+Existing public helpers remain importable. New diagnostics must not change success behavior silently; where current helpers are known to over-acknowledge or drop fields, the first compatible step is to expose validation/reporting helpers and later wire fail-fast behavior in owning features. Bundle schema additions must be additive and tolerate missing diagnostics for older bundles. Any compatibility shim that cannot prove real state mutation or renderability must surface `unsupported`, `experimental`, `Pro-gated`, or `placeholder/fallback` diagnostics rather than returning unqualified success.
+
+## Verification Matrix And Ledger
+
+Tasks must move P0-R5 and P0-R6 rows from `Planned` only when code, tests, docs, diagnostics, and command evidence exist. This plan does not change matrix status. Implementation must append continuity notes to `docs/superpowers/state/implementation-ledger.md` and refresh `docs/superpowers/state/current-context-pack.md`. If a future session changes a requirement status, it must update `docs/superpowers/state/requirements-verification-matrix.md` in the same session with commands and evidence.
+
+## Rollback And Safe Failure
+
+If the shared diagnostics contract cannot be wired to a path, that path must report an `unsupported` or feature-specific diagnostic rather than success. If bundle serialization fails, keep the original render/report result but return an error diagnostic and avoid writing a misleading bundle.

--- a/specs/001-diagnostics-support-matrices/quickstart.md
+++ b/specs/001-diagnostics-support-matrices/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Diagnostics And Support Matrices
+
+These scenarios are validation targets for task implementation, not current working code.
+
+## Validate Style Support
+
+1. Build a local style fixture with supported `fill`, `line`, and `circle` layers plus one unsupported layer.
+2. Run the public validation helper or `MapScene.validate()` once feature `004` exists.
+3. Expect structured diagnostics for unsupported layer types and fields.
+4. Confirm docs state local/provided feature styling only, not streamed MVT.
+
+## Validate Render Warning Policy
+
+1. Create a report with one `missing_glyphs` warning.
+2. Confirm `continue_on_warning` does not block by itself.
+3. Confirm `fail_on_warning` blocks successful render completion.
+4. Add an `error` diagnostic and confirm both policies block.
+
+## Validate Bundle-Ready Serialization
+
+1. Serialize a report containing every required diagnostic code.
+2. Deserialize it and compare code, severity, support level, affected IDs, remediation, and details.
+3. Repeat serialization and compare exact output ordering.
+
+## Negative Path Checks
+
+- Pro-gated building path emits `pro_gated_path`, not success.
+- Zero-geometry building fallback emits `placeholder_fallback`, not success.
+- Non-albedo VT family emits `vt_unsupported_family`, not a warning-only log.
+- Incomplete public 3D Tiles path emits `python_public_3dtiles_incomplete`, not supported status.

--- a/specs/001-diagnostics-support-matrices/research.md
+++ b/specs/001-diagnostics-support-matrices/research.md
@@ -1,0 +1,355 @@
+# Diagnostics and Support Matrices Implementation Inventory
+
+Created: 2026-05-15
+Feature: `001-diagnostics-support-matrices`
+Scope: pre-plan repository inventory only. No implementation decisions or code changes are made here.
+
+## Source Artifacts Inspected
+
+- `docs/superpowers/plans/prd.md`
+- `.specify/memory/constitution.md`
+- `specs/001-diagnostics-support-matrices/spec.md`
+- `docs/superpowers/state/current-context-pack.md`
+- `docs/superpowers/state/implementation-ledger.md`
+- `docs/superpowers/state/requirements-verification-matrix.md`
+- `docs/superpowers/state/open-blockers.md`
+- `git status --short --branch`
+
+## 1. Existing Modules, Classes, and Functions Relevant To This Feature
+
+### Diagnostics-adjacent substrate
+
+- `src/py_module/functions/diagnostics.rs` registers native utility diagnostics: `enumerate_adapters`, `device_probe`, `global_memory_metrics`, `render_debug_pattern_frame`, `engine_info`, `report_device`, and framegraph/demo diagnostics.
+- `python/forge3d/_gpu.py` exposes `enumerate_adapters()`, `device_probe()`, and `has_gpu()`.
+- `python/forge3d/mem.py` exposes `memory_metrics()`, `update_memory_usage()`, `enforce_memory_budget()`, and `override_memory_limit()`.
+- `src/geometry/validate.rs` contains `MeshValidationReport`, `validate_mesh()`, and mesh validation issues. This is not the PRD `ValidationReport`, but it is an existing validation-report pattern.
+- No implemented product-level `Diagnostic`, `ValidationReport`, `LayerSummary`, `SupportMatrixEntry`, `RenderFailurePolicy`, or `SeverityPolicy` was found outside specs/docs/state. This finding is based on `rg` searches and should be rechecked before planning.
+
+### Style support
+
+- `python/forge3d/style.py`
+  - Dataclasses: `VectorStyle`, `LabelStyle`, `PaintProps`, `LayoutProps`, `StyleLayer`, `StyleSpec`, `SpriteEntry`, `SpriteAtlas`, `GlyphRange`, `FontStack`.
+  - Functions: `load_style()`, `parse_style()`, `_parse_layer()`, `evaluate_color_expr()`, `evaluate_number_expr()`, `paint_to_vector_style()`, `layout_to_label_style()`, `layer_to_vector_style()`, `layer_to_label_style()`, `apply_style()`, `parse_color()`, `_evaluate_filter()`, sprite/glyph helpers.
+  - `load_style()` and `apply_style()` are Pro-gated through `_check_pro_access()`.
+  - `apply_style()` filters render application to visible `fill`, `line`, and `circle` layers.
+  - Uncertain: unsupported paint/layout fields appear to be ignored during `_parse_layer()` because only known fields are copied into dataclasses.
+- `python/forge3d/style_expressions.py`
+  - `EvalContext` and `evaluate()` plus expression helpers including `get`, `interpolate`, `step`, `match`, `case`, `coalesce`, arithmetic/comparison/logical expressions, `concat`, `downcase`, `upcase`, and color conversions.
+- `src/style/converters.rs` contains Rust-side style-to-vector/label conversion helpers, including `layout_to_label_style()` and `layer_to_label_style()`.
+
+### Buildings and Pro/fallback paths
+
+- `python/forge3d/buildings.py`
+  - Dataclasses: `BuildingMaterial`, `Building`, `BuildingLayer`.
+  - Functions: `infer_roof_type()`, `_parse_roof_tag()`, `material_from_tags()`, `material_from_name()`, `add_buildings()`, `add_buildings_cityjson()`, `add_buildings_3dtiles()`.
+  - `add_buildings()`, `add_buildings_cityjson()`, and `add_buildings_3dtiles()` are Pro-gated through `_check_pro_access()`.
+  - Native fast paths probe `_NATIVE.import_osm_buildings_from_geojson_py` and `_NATIVE.parse_cityjson_py`.
+  - Fallback paths construct zero-geometry `Building` entries with `np.zeros((0, 3))` positions and empty indices.
+  - `add_buildings_3dtiles()` currently validates tileset metadata and returns an empty `BuildingLayer` with `source_format="3dtiles"`.
+- `src/import/osm_buildings.rs`, `src/import/cityjson/*`, and `src/import/building_materials.rs` contain native building import, CityJSON parsing, material inference, and PyO3 functions.
+
+### 3D Tiles
+
+- `python/forge3d/tiles3d.py`
+  - Dataclasses/classes: `BoundingVolume`, `TileContent`, `Tile`, `Tileset`, `VisibleTile`, `SseParams`, `Tiles3dRenderer`.
+  - Functions: `load_tileset()`, `decode_b3dm()`, `decode_pnts()`.
+  - `decode_b3dm()` validates B3DM and embedded GLB presence, then raises `NotImplementedError` for glTF mesh extraction.
+  - `decode_pnts()` creates zero positions when `POSITION` is absent.
+  - No public Python `Tiles3DLayer` was found.
+- `src/tiles3d/*`
+  - Native modules include `b3dm.rs`, `pnts.rs`, `tileset.rs`, `tile.rs`, `traversal.rs`, `sse.rs`, `renderer.rs`, `bounds.rs`, and `error.rs`.
+  - `src/tiles3d/renderer.rs` has `Tiles3dRenderer`, `TileContent`, `CacheStats`, cache budgeting, SSE configuration, and unsupported-format errors.
+  - Uncertain: Rust 3D Tiles APIs are crate-internal substrate; no PyO3 registration for a public Python 3D Tiles renderer was found during this inventory.
+
+### Labels and glyph-related substrate
+
+- `python/forge3d/viewer_ipc.py`
+  - Label/vector IPC helpers: `add_label()`, `remove_label()`, `clear_labels()`, `set_labels_enabled()`, `load_label_atlas()`, `add_line_label()`, `add_curved_label()`, `add_callout()`, `set_label_typography()`, `set_declutter_algorithm()`, `add_vector_overlay()`.
+- `src/labels/*`
+  - `src/labels/mod.rs`: `LabelManager`, `add_label()`, `add_line_label()`, `remove_label()`, `set_label_style()`, `clear()`, `set_enabled()`, `set_zoom()`, `set_max_visible()`, `update_with_camera()`, `upload_to_renderer()`.
+  - `src/labels/layer.rs`: native `LabelLayer`, `LabelLayerConfig`, `LabelFeature`, `FeatureGeometry`, `PlacementStrategy`, `GeneratedLabel`, `MapboxSymbolLayer`, `features_from_points()`, `features_from_lines()`, `label_layer_from_mapbox_style()`, `apply_mapbox_text_style()`.
+  - `src/labels/declutter.rs`, `src/labels/line_label.rs`, `src/labels/curved.rs`, `src/labels/rtree.rs`, `src/labels/typography.rs`, `src/labels/projection.rs`, `src/labels/callout.rs`, and `src/labels/leader.rs` are relevant to support classification and future diagnostic triggers.
+  - `src/labels/py_bindings.rs` exposes only `LabelStyle` and `LabelFlags` to Python.
+- `src/viewer/cmd/labels_command.rs`
+  - `SetLabelTypography` and `SetDeclutterAlgorithm` print success-like messages and return `true` without visible state mutation in the inspected handler.
+  - `AddCurvedLabel` maps to `add_line_label(..., LineLabelPlacement::Along, 0.0)`.
+  - Line labels compute glyph placements, but `src/labels/mod.rs` notes that line label rotation is tracked but not applied to glyph rendering.
+
+### Bundles and serializable state
+
+- `python/forge3d/bundle.py`
+  - Dataclasses: `TerrainMeta`, `CameraBookmark`, `RasterOverlaySpec`, `SceneBaseState`, `ReviewLayer`, `SceneVariant`, `SceneState`, `BundleManifest`, `LoadedBundle`.
+  - Functions: `save_bundle()`, `load_bundle()`, `is_bundle()`, internal coercion/path/validation helpers.
+  - `save_bundle()` and `load_bundle()` are Pro-gated through `_check_pro_access()`.
+  - Existing state serializes terrain metadata, camera bookmarks, raster overlays, vector overlays, labels, scatter batches, review layers, variants, preset data, assets, and checksums.
+  - No explicit diagnostics field was found in `SceneState`, `ReviewLayer`, `SceneVariant`, or `BundleManifest`.
+- `src/bundle/*` contains native manifest helpers but does not appear to provide PRD diagnostics serialization.
+
+### CRS, VT, memory, and public API aggregation
+
+- `python/forge3d/crs.py`: `proj_available()`, `transform_coords()`, `reproject_geom()`, `parse_crs_from_wkt()`, `crs_to_epsg()`, `_crs_equal()`, `get_crs_from_rasterio()`, `get_crs_from_geopandas()`.
+- `python/forge3d/terrain_params.py`: `VTLayerFamily` and `TerrainVTSettings` accept `albedo`, `normal`, and `mask`, with comments stating that current native runtime pages only `albedo`.
+- `src/terrain/render_params/native_vt.rs` and `src/terrain/renderer/virtual_texture.rs` mirror the albedo-only VT runtime; native `register_source()` logs a warning for non-albedo families.
+- `python/forge3d/__init__.py` exports/imports style, buildings, bundle, CRS, and VT settings. It does not appear to export `MapScene`, `SceneRecipe`, `LabelPlan`, `ValidationReport`, or `Diagnostic`.
+- `python/forge3d/__init__.pyi` includes public stubs for `LabelStyle`/`LabelFlags`, terrain render APIs, memory/device helpers, and bundle imports, but no PRD product diagnostics objects were found.
+
+## 2. Existing Tests and Fixtures Relevant To This Feature
+
+### Tests
+
+- Style:
+  - `tests/test_style_parser.py`
+  - `tests/test_style_render.py`
+  - `tests/test_style_visual.py`
+  - `tests/test_style_pixel_diff.py`
+  - `tests/test_mapbox_streets_fixture.py`
+- Buildings:
+  - `tests/test_buildings_roof.py`
+  - `tests/test_buildings_materials.py`
+  - `tests/test_buildings_extrude.py`
+  - `tests/test_buildings_cityjson.py`
+- 3D Tiles:
+  - `tests/test_3dtiles_parse.py`
+  - `tests/test_3dtiles_sse.py`
+- Labels and viewer IPC:
+  - `tests/test_labels_pybindings.py`
+  - `tests/test_api_contracts.py` section `TestLabelBindings`
+  - `tests/test_viewer_ipc.py`
+- Bundles:
+  - `tests/test_bundle_roundtrip.py`
+  - `tests/test_bundle_render.py`
+  - `tests/test_bundle_cli.py`
+- CRS:
+  - `tests/test_crs_reproject.py`
+  - `tests/test_crs_auto.py`
+- VT:
+  - `tests/test_tv20_virtual_texturing.py`
+- Pro gating:
+  - `tests/test_pro_gating.py`
+  - `tests/test_license.py`
+  - `tests/conftest.py` fixture `pro_license`
+
+### Fixtures and assets
+
+- `tests/fixtures/mapbox_streets_v8.json`
+- `assets/geojson/sample_buildings.city.json`
+- `assets/geojson/10-270-592.city.json`
+- `assets/geojson/mount_fuji_buildings.geojson`
+- `assets/fonts/default_atlas.json`
+- `assets/tif/Mount_Fuji_30m.tif`
+- `assets/tif/dem_rainier.tif`
+- `assets/tif/switzerland_dem.tif`
+- `assets/tif/switzerland_land_cover.tif`
+- `assets/lidar/MtStHelens.laz`
+- `python/forge3d/data/sample_boundaries.geojson`
+- `tests/golden/terrain/*`
+
+## 3. Existing Docs and Examples Relevant To This Feature
+
+- `README.md` documents labels, overlays, Pro workflow, Pro-gated building imports, Mapbox-style import, and scene bundles.
+- `docs/guides/feature_map.md` lists terrain, overlays, labels, device/memory diagnostics, and Pro workflows for buildings, Mapbox-style import, map plates, export, and bundles.
+- `docs/guides/data_and_scene_workflows.md` documents viewer overlays/labels, style translation, buildings, and lower-level 3D Tiles parsing/traversal.
+- `docs/guides/rendering_and_analysis.md` includes existing diagnostics/device utility guidance.
+- `docs/viewer/index.md` documents raw/advanced viewer IPC use.
+- `docs/terrain/offline-render-quality.md` documents offline render quality and fallback behavior for denoise.
+- `docs/tutorials/python-track/04-scene-bundles.md`
+- `docs/tutorials/gis-track/03-build-a-map-plate.md`
+- `docs/tutorials/gis-track/04-3d-buildings.md`
+- `docs/gallery/02-mount-fuji-labels.md`
+- `docs/gallery/05-3d-buildings.md`
+- `docs/gallery/08-vector-export.md`
+- `docs/gallery/10-map-plate.md`
+- Examples:
+  - `examples/fuji_labels_demo.py`
+  - `examples/style_viewer_interactive.py`
+  - `examples/buildings_viewer_interactive.py`
+  - `examples/terrain_viewer_interactive.py`
+  - `examples/pointcloud_viewer_interactive.py`
+  - `examples/sample_style.json`
+
+No dedicated diagnostics reference or support matrices for style, labels, buildings, 3D Tiles, VT, or the PRD taxonomy were found during this inventory. This is uncertain until docs outside the searched paths are reviewed.
+
+## 4. Native/Rust Paths Relevant To This Feature
+
+- Diagnostics/device/memory:
+  - `src/py_module/functions/diagnostics.rs`
+  - `src/core/memory_tracker/*`
+  - `src/core/virtual_texture/*`
+  - `src/core/render_bundles.rs`
+  - `src/core/render_bundles_types.rs`
+- PyO3 registration:
+  - `src/lib.rs`
+  - `src/py_module/classes.rs`
+  - `src/py_module/functions.rs`
+  - `src/py_module/functions/io_import.rs`
+- Labels:
+  - `src/labels/mod.rs`
+  - `src/labels/types.rs`
+  - `src/labels/py_bindings.rs`
+  - `src/labels/layer.rs`
+  - `src/labels/declutter.rs`
+  - `src/labels/line_label.rs`
+  - `src/labels/curved.rs`
+  - `src/labels/rtree.rs`
+  - `src/labels/typography.rs`
+  - `src/labels/projection.rs`
+  - `src/viewer/cmd/labels_command.rs`
+  - `src/viewer/ipc/protocol/response.rs`
+- Style:
+  - `src/style/converters.rs`
+- Buildings:
+  - `src/import/osm_buildings.rs`
+  - `src/import/building_materials.rs`
+  - `src/import/cityjson.rs`
+  - `src/import/cityjson/bindings.rs`
+  - `src/import/cityjson/parser.rs`
+  - `src/import/cityjson/geometry.rs`
+  - `src/import/cityjson/types.rs`
+- 3D Tiles:
+  - `src/tiles3d/mod.rs`
+  - `src/tiles3d/b3dm.rs`
+  - `src/tiles3d/pnts.rs`
+  - `src/tiles3d/tileset.rs`
+  - `src/tiles3d/tile.rs`
+  - `src/tiles3d/traversal.rs`
+  - `src/tiles3d/sse.rs`
+  - `src/tiles3d/renderer.rs`
+  - `src/tiles3d/error.rs`
+- VT:
+  - `src/terrain/render_params/native_vt.rs`
+  - `src/terrain/renderer/virtual_texture.rs`
+- Bundles/review state:
+  - `src/bundle/mod.rs`
+  - `src/bundle/manifest.rs`
+  - `src/viewer/scene_review.rs`
+  - `src/viewer/ipc/protocol/request.rs`
+  - `src/viewer/ipc/protocol/payloads.rs`
+  - `src/viewer/ipc/protocol/translate/scene_review.rs`
+
+## 5. Python Public API Paths Relevant To This Feature
+
+- `python/forge3d/__init__.py`
+- `python/forge3d/__init__.pyi`
+- `python/forge3d/_license.py`
+- `python/forge3d/_gpu.py`
+- `python/forge3d/mem.py`
+- `python/forge3d/style.py`
+- `python/forge3d/style_expressions.py`
+- `python/forge3d/buildings.py`
+- `python/forge3d/tiles3d.py`
+- `python/forge3d/bundle.py`
+- `python/forge3d/crs.py`
+- `python/forge3d/terrain_params.py`
+- `python/forge3d/viewer.py`
+- `python/forge3d/viewer.pyi`
+- `python/forge3d/viewer_ipc.py`
+- `python/forge3d/datasets.py`
+
+Not found as implemented public APIs outside specs/docs/state: `MapScene`, `SceneRecipe`, `LabelPlan`, `ValidationReport`, `Diagnostic`, public Python `LabelLayer`, public Python `Tiles3DLayer`, `SupportMatrixEntry`, `RenderFailurePolicy`, and `SeverityPolicy`.
+
+## 6. Suspected Placeholder, Fallback, or No-Op Paths
+
+- `python/forge3d/buildings.py`
+  - GeoJSON fallback creates placeholder buildings with zero positions and zero indices.
+  - CityJSON fallback creates placeholder buildings with zero positions and zero indices.
+  - `add_buildings_3dtiles()` returns an empty `BuildingLayer` after metadata validation.
+- `python/forge3d/tiles3d.py`
+  - `decode_b3dm()` raises `NotImplementedError` after validating embedded GLB presence.
+  - `decode_pnts()` defaults to zero positions if `POSITION` is absent.
+- `python/forge3d/style.py`
+  - `_parse_layer()` only preserves known paint/layout keys; unsupported fields are likely dropped without a structured diagnostic.
+  - `apply_style()` only applies `fill`, `line`, and `circle`; unsupported layer types and supported-but-non-vector `symbol` layers do not emit structured diagnostics.
+- `src/viewer/cmd/labels_command.rs`
+  - `SetLabelTypography` prints an update message and returns `true` while inspected arguments are ignored.
+  - `SetDeclutterAlgorithm` prints the selected algorithm and returns `true` while inspected settings are not wired to placement.
+  - `AddCurvedLabel` is routed as a line label with `LineLabelPlacement::Along`.
+- `src/labels/mod.rs`
+  - Line labels compute placements, but glyph rendering does not apply line-label rotation.
+- `python/forge3d/terrain_params.py`, `src/terrain/render_params/native_vt.rs`, and `src/terrain/renderer/virtual_texture.rs`
+  - `normal` and `mask` VT families are accepted as forward-compatible placeholders while native runtime pages only `albedo`.
+  - Non-albedo VT registration logs a warning rather than returning a structured map-scene diagnostic.
+- `python/forge3d/bundle.py`
+  - Existing bundle state has no explicit diagnostics payload field; preserving PRD diagnostics may require schema extension or a separate bundle-ready metadata path.
+
+## 7. Pro-Gated Paths
+
+- `python/forge3d/_license.py`
+  - `LicenseError`, `set_license_key()`, and `_check_pro_access()`.
+- `python/forge3d/style.py`
+  - `load_style()` gates "Mapbox style loading".
+  - `apply_style()` gates "Mapbox style application".
+- `python/forge3d/buildings.py`
+  - `add_buildings()` gates "GeoJSON building import".
+  - `add_buildings_cityjson()` gates "CityJSON building import".
+  - `add_buildings_3dtiles()` gates "3D Tiles building import".
+- `python/forge3d/bundle.py`
+  - `save_bundle()` gates "Scene bundle save".
+  - `load_bundle()` gates "Scene bundle load".
+- Pro-gating tests exist in `tests/test_pro_gating.py`, and Pro test execution uses the deterministic `pro_license` fixture in `tests/conftest.py`.
+- `README.md`, `docs/guides/feature_map.md`, `docs/gallery/05-3d-buildings.md`, `docs/gallery/08-vector-export.md`, `docs/gallery/10-map-plate.md`, `docs/tutorials/python-track/04-scene-bundles.md`, and `docs/tutorials/gis-track/04-3d-buildings.md` mention Pro requirements.
+
+## 8. Unknowns That Need Verification
+
+- Whether feature `001` should introduce product diagnostics in a new module such as `python/forge3d/diagnostics.py`, fold them into future `MapScene`, or both. The spec defines behavior but no implemented product model exists yet.
+- Whether bundle diagnostics should be added to `SceneState`, `BundleManifest`, a new sidecar file, or a bundle-ready validation structure that later `MapScene` writes.
+- Exact support matrix source of truth: docs location and file names are not yet established for style, labels, buildings, 3D Tiles, VT, diagnostics, and competitive positioning.
+- Exact list of supported and unsupported style paint/layout fields. Current `PaintProps`/`LayoutProps` reveal known fields, but unsupported-field detection needs a deliberate field inventory.
+- Whether `background` and `symbol` style layers should be classified as supported for parsing only, underdeveloped for render/application, or unsupported for vector overlay output in feature `001`.
+- Whether `parse_style()` should remain usable without Pro while `load_style()`/`apply_style()` are Pro-gated, and how diagnostics should report Pro-gated style application.
+- Whether building native paths are always present in the open wheel or packaging-dependent. Current Python checks probe native symbols after Pro access succeeds.
+- Whether zero-geometry building fallback is still intentional behavior or should be converted to typed diagnostics immediately in feature `001`.
+- Whether native Rust 3D Tiles renderer APIs are intentionally not exposed to Python yet, or whether a registration path exists that was missed.
+- Whether `estimated_gpu_memory` should use existing `python/forge3d/mem.py`, native `global_memory_metrics`, VT residency stats, 3D Tiles cache stats, or only static estimates for feature `001`.
+- Whether missing glyph diagnostics can read `assets/fonts/default_atlas.json` directly or must integrate with native `MsdfAtlas` metrics.
+- Whether `LabelLayer` should be public only later; native `src/labels/layer.rs` exists, but no public Python `LabelLayer` was found.
+- Whether docs under `docs/_build/` should be ignored as generated output for support-matrix audits.
+
+## Commands Used For Inspection
+
+```powershell
+Get-Content -Raw docs/superpowers/plans/prd.md
+Get-Content -Raw .specify/memory/constitution.md
+Get-Content -Raw specs/001-diagnostics-support-matrices/spec.md
+git status --short --branch
+Get-ChildItem specs/001-diagnostics-support-matrices -Force | Select-Object Name,Length,LastWriteTime
+Get-Content -Raw docs/superpowers/state/current-context-pack.md
+Get-Content -Raw docs/superpowers/state/implementation-ledger.md
+Get-Content -Raw docs/superpowers/state/requirements-verification-matrix.md
+Get-Content -Raw docs/superpowers/state/open-blockers.md
+rg -n "class (Diagnostic|ValidationReport|LayerSummary|SupportMatrix|MapScene|SceneRecipe|LabelPlan)|def (validate|render|save_bundle|to_dict|from_dict)|Diagnostic\(|ValidationReport\(|support_level|unsupported_style|missing_glyph|crs_mismatch|estimated_gpu_memory|placeholder_fallback|pro_gated_path|vt_unsupported_family|python_public_3dtiles_incomplete|label_rejection_summary" python src tests docs examples specs/001-diagnostics-support-matrices
+rg -n "class .*Style|def .*style|layers|paint|layout|fill|line|circle|unsupported|Mapbox|MVT|vector" python/forge3d/style.py python/forge3d/style_expressions.py tests docs examples
+rg -n "class .*Building|def .*building|load_building|CityJSON|GeoJSON|fallback|_native|_forge3d|pro|Pro|zero|empty|placeholder|height" python/forge3d/buildings.py src tests docs examples
+rg -n "tiles3d|3D Tiles|B3DM|GLB|class .*Tile|def .*tile|unsupported|fallback|cache|LOD|screen" python/forge3d/tiles3d.py src/tiles3d tests docs examples
+rg -n "virtual_texture|VirtualTexture|albedo|normal|mask|family|vt_|page|unsupported" python/forge3d/terrain_params.py src/terrain tests docs examples
+rg -n "^(class|def) |^@dataclass|_check_pro_access|fallback|placeholder|not implemented|Unsupported|warnings.warn|return .*(empty|None)|np.zeros|raise ValueError" python/forge3d/style.py python/forge3d/style_expressions.py python/forge3d/buildings.py python/forge3d/tiles3d.py python/forge3d/bundle.py python/forge3d/viewer_ipc.py python/forge3d/viewer.py python/forge3d/crs.py
+rg -n "^(pub struct|pub enum|impl |pub fn|fn |#\[pyclass\]|#\[pymethods\]|#\[pyfunction\])|TODO|not implemented|Unsupported|fallback|ignore|warn|warning" src/labels src/viewer src/tiles3d src/import src/bundle src/terrain/render_params/native_vt.rs src/terrain/renderer/virtual_texture.rs src/lib.rs
+rg --files tests | rg "(style|building|tiles3d|tile|label|glyph|bundle|crs|virtual|vt|diagnostic|support|matrix|validation|viewer_ipc|mapscene|scene)"
+rg --files docs examples | rg "(style|building|tiles3d|tile|label|glyph|bundle|crs|virtual|vt|diagnostic|support|matrix|offline|map|viewer)"
+rg -n "MapScene|SceneRecipe|LabelPlan|ValidationReport|Diagnostic|LayerSummary|SupportMatrixEntry|RenderFailurePolicy|SeverityPolicy|LabelLayer|Tiles3DLayer|BuildingLayer|RasterOverlay|VectorOverlay|OutputSpec|OrbitCamera|LightingPreset" python src tests docs examples specs
+rg -n "def test_|class Test|pytest|add_buildings|BuildingLayer|placeholder|np.zeros|_check_pro_access|skip|raises|xfail" tests/test_buildings_roof.py tests/test_buildings_materials.py tests/test_buildings_extrude.py tests/test_buildings_cityjson.py
+rg -n "def test_|class Test|parse_style|load_style|apply_style|fill|line|circle|symbol|unsupported|Mapbox|_check_pro_access|raises|xfail" tests/test_style_parser.py tests/test_style_render.py tests/test_style_visual.py tests/test_style_pixel_diff.py
+rg -n "def test_|class Test|Tileset|load_tileset|decode_b3dm|decode_pnts|SSE|cache|unsupported|raises|xfail" tests/test_3dtiles_parse.py tests/test_3dtiles_sse.py
+rg -n "def test_|class Test|Label|glyph|style|typography|declutter|line_label|curved|add_label|viewer_ipc|raises|xfail" tests/test_labels_pybindings.py tests/test_viewer_ipc.py
+rg -n "def test_|class Test|Bundle|manifest|SceneState|RasterOverlaySpec|ReviewLayer|SceneVariant|label|vector|diagnostic|metadata|roundtrip|raises|xfail" tests/test_bundle_roundtrip.py tests/test_bundle_render.py tests/test_bundle_cli.py
+rg -n "def test_|class Test|VTLayerFamily|TerrainVTSettings|normal|mask|albedo|virtual|unsupported|skip|raises|xfail" tests/test_tv20_virtual_texturing.py tests/test_crs_reproject.py tests/test_crs_auto.py
+rg -n "class TestLabelBindings|PyLabelStyle|PyLabelFlags|LabelStyle|LabelFlags|EXPECTED_CLASSES|EXPECTED_FUNCTIONS|MapScene|LabelPlan|Diagnostic|ValidationReport" tests/test_api_contracts.py python/forge3d/__init__.py python/forge3d/__init__.pyi src/lib.rs
+rg --files | rg "(fixtures|data|assets|sample|golden).*(geojson|cityjson|json|b3dm|pnts|glb|png|tif|laz|las)$|\.(geojson|cityjson|b3dm|pnts|glb|laz|las)$"
+rg -n "diagnostic|support matrix|support status|Mapbox|style|building|3D Tiles|Virtual Texturing|labels|scene bundle|Pro|fallback|experimental|unsupported|offline 3D map" docs/guides docs/tutorials docs/gallery docs/terrain docs/viewer examples README.md pyproject.toml
+rg -n "pub fn .*_py|m\.add_function|m\.add_class|building|cityjson|b3dm|pnts|tiles3d|label|bundle|material|vt|style" src/lib.rs src/import src/tiles3d src/labels src/bundle
+rg -n "__all__|from \\.|import .*buildings|import .*tiles3d|BuildingLayer|load_tileset|add_buildings|bundle|style|crs|VTLayerFamily|TerrainVTSettings" python/forge3d/__init__.py python/forge3d/__init__.pyi
+rg -n "SetLabelTypography|SetDeclutterAlgorithm|AddCurvedLabel|AddCallout|AddLabel|AddLineLabel|success|IpcResponse|TODO|placeholder|not implemented|ack" src/viewer/cmd/labels_command.rs src/viewer/ipc/protocol/response.rs python/forge3d/viewer_ipc.py
+```
+
+## Phase 0 Planning Decisions
+
+- Decision: Define product diagnostics as typed Python objects first, with native/Rust hooks used only where existing substrate already exposes device, memory, label, VT, building, or tile facts.
+  Rationale: The repository has diagnostic-adjacent substrate but no product-level `Diagnostic` or `ValidationReport`; a Python wrapper keeps MVP workflows typed and serializable without raw IPC.
+  Alternatives considered: Rust-first diagnostic model, rejected for planning because several required inputs are currently Python public wrappers or docs/support classifications.
+
+- Decision: Treat support matrices as documentation plus testable diagnostic inventory, not as implementation claims.
+  Rationale: The PRD requires support honesty across underdeveloped, Pro-gated, placeholder/fallback, experimental, unsupported, and non-goal paths.
+  Alternatives considered: Mark paths supported when a low-level substrate exists, rejected because it would overclaim buildings, 3D Tiles, VT normal/mask, and line/curved labels.
+
+- Decision: Deterministic ordering is part of the validation/report contract.
+  Rationale: Bundle-ready reports and review evidence must compare exactly for fixed inputs.
+  Alternatives considered: Preserve discovery order, rejected because dict/set/filesystem/native enumeration can drift.

--- a/specs/001-diagnostics-support-matrices/spec.md
+++ b/specs/001-diagnostics-support-matrices/spec.md
@@ -1,0 +1,209 @@
+# Feature Specification: Diagnostics and Support Matrices
+
+**Feature Branch**: `001-diagnostics-support-matrices`
+**Created**: 2026-05-14
+**Status**: Draft
+**Input**: User description: "Create feature 001-diagnostics-support-matrices for forge3d offline 3D map rendering."
+**Source of Truth**: `docs/superpowers/plans/prd.md` and `.specify/memory/constitution.md`
+**PRD Coverage**: P0-R5, P0-R6, Section 13, Section 16, Appendix B, Milestone 0
+**MVP Blocking**: Yes - P0 diagnostics and support-matrix honesty are release-blocking unless a documented human decision reclassifies them
+
+## Clarifications
+
+### Session 2026-05-14
+
+- Safe default: Error and fatal diagnostics always block successful render completion; warning diagnostics block only when fail-on-warning behavior is selected; informational diagnostics never block by themselves.
+- Safe default: CRS mismatches without an explicit transform are diagnosed as `crs_mismatch`; this feature does not decide the minimum supported CRS transform set for later render workflows.
+- Safe default: Building, 3D Tiles, VT, and label paths are classified from observable public workflow behavior: existing but incomplete workflows are `underdeveloped`, native-only requirements are `Pro-gated`, non-renderable fallback output is `placeholder/fallback`, unverified APIs are `experimental`, and unavailable product capability is `unsupported` or `missing` according to Appendix B.
+- Safe default: Bundle-ready diagnostics must be serializable without information loss and must be included by any scene bundle path that accepts validation metadata; full bundle round-trip remains outside this feature.
+- Safe default: Validation diagnostics, layer summaries, supported feature summaries, and unsupported feature summaries must use deterministic ordering for fixed inputs so review bundles and tests are reproducible.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Validate Before Render (Priority: P1)
+
+A geospatial Python user validates an offline 3D map-rendering workflow before rendering and receives a structured report that identifies unsupported, risky, incomplete, or fallback paths.
+
+**Why this priority**: This is the primary user-visible value of P0-R5. Users must know before render when output would be incomplete, misleading, or unsupported.
+
+**Independent Test**: Can be fully tested by validating scenes or bundle-ready scene descriptions that contain known CRS, glyph, style, Pro-gated, placeholder/fallback, experimental, VT, 3D Tiles, memory, and label-rejection conditions, then inspecting structured diagnostics.
+
+**Acceptance Scenarios**:
+
+1. **Given** a map-rendering workflow with a layer CRS that differs from the scene or terrain CRS and no transform is provided, **When** validation runs, **Then** the report includes a `crs_mismatch` diagnostic with severity, affected layer ID where known, and remediation.
+2. **Given** labels containing glyphs absent from the active atlas, **When** validation runs, **Then** the report includes `missing_glyphs` diagnostics before render instead of relying on printed warnings or visual failure.
+3. **Given** a workflow that requests a Pro-gated or placeholder/fallback path, **When** validation runs, **Then** the report includes `pro_gated_path` or `placeholder_fallback` diagnostics and does not describe the path as supported.
+
+---
+
+### User Story 2 - Configure Render Failure Policy (Priority: P1)
+
+A production user chooses whether rendering should stop on warnings or continue while preserving diagnostics for review.
+
+**Why this priority**: P0-R5 requires configurable render behavior so strict production runs can fail early while exploratory workflows can continue honestly.
+
+**Independent Test**: Can be tested with a workflow that produces at least one warning-level diagnostic and verifying both fail-on-warning and continue-on-warning outcomes.
+
+**Acceptance Scenarios**:
+
+1. **Given** validation produces warnings and render policy is fail-on-warning, **When** render is requested, **Then** rendering stops before output is treated as successful and returns the blocking diagnostics.
+2. **Given** validation produces warnings and render policy is continue-on-warning, **When** render is requested, **Then** rendering may proceed while the report and bundle-ready metadata retain the warnings.
+
+---
+
+### User Story 3 - Understand Style Support (Priority: P1)
+
+A developer or map author checks style support and sees which local/provided feature styling paths are supported, which fields or layer types are unsupported, and that streamed MVT rendering is not claimed.
+
+**Why this priority**: P0-R6 prevents users from mistaking limited offline feature styling for full Mapbox Style Specification or streamed vector-tile support.
+
+**Independent Test**: Can be tested by reviewing the support matrix and validating style inputs with supported and unsupported layer types and fields.
+
+**Acceptance Scenarios**:
+
+1. **Given** documentation for style support, **When** a user reads it, **Then** it states that P0 support applies to local/provided features and not streamed MVT tiles.
+2. **Given** a style using supported `fill`, `line`, or `circle` layer types as confirmed by the implementation audit, **When** support is documented, **Then** the support matrix explicitly lists those layer types and their supported fields.
+3. **Given** a style using an unsupported layer type or unsupported paint/layout field, **When** validation runs, **Then** diagnostics identify `unsupported_style_layer_type` or `unsupported_style_field` with affected style layer ID where known.
+
+---
+
+### User Story 4 - Audit Public Support Claims (Priority: P2)
+
+An internal forge3d developer reviews docs and release materials to ensure map-rendering support is classified using the PRD taxonomy.
+
+**Why this priority**: Milestone 0 requires support matrix cleanup so users and future contributors do not overclaim incomplete substrate.
+
+**Independent Test**: Can be tested by auditing required documentation and release-facing support tables against Appendix B classifications and the diagnostics reference.
+
+**Acceptance Scenarios**:
+
+1. **Given** public documentation for labels, buildings, 3D Tiles, virtual texturing, diagnostics, and style support, **When** reviewed, **Then** it distinguishes `supported`, `underdeveloped`, `missing`, `Pro-gated`, `placeholder/fallback`, `experimental`, `unsupported`, and `non-goal` paths.
+2. **Given** docs or support matrices mention 3D Tiles, buildings, VT normal/mask, line or curved labels, or Pro-gated paths, **When** reviewed, **Then** they do not describe incomplete or gated paths as fully supported.
+
+### Edge Cases
+
+- Validation receives a condition with no known layer or object ID: the diagnostic still exists and records unknown affected IDs without blocking serialization.
+- Multiple diagnostics apply to the same layer or object: all diagnostics are preserved in deterministic, reviewable order.
+- A diagnostic is informational but render policy is fail-on-warning: informational diagnostics do not block by themselves.
+- Validation produces error or fatal diagnostics while continue-on-warning is selected: render completion is still blocked because the policy only changes warning behavior.
+- Unsupported style fields appear inside otherwise supported layer types: the layer is not silently accepted as fully supported.
+- A style layer has an ID but the affected feature object does not: the diagnostic includes the layer ID and leaves object ID unset.
+- Memory cannot be estimated because required inputs are absent: validation reports the unavailable estimate honestly rather than inventing precision.
+- Bundle-ready validation data contains diagnostics from paths whose final rendering implementation belongs to later features: the diagnostic still records support level and remediation without claiming render support.
+
+### Support-Level Classification *(mandatory)*
+
+Use the PRD Appendix B terms exactly: `supported`, `underdeveloped`, `missing`, `Pro-gated`, `placeholder/fallback`, `experimental`, `unsupported`, and `non-goal`.
+
+- **Supported in this feature**: structured diagnostics, severity classification, affected ID reporting where known, bundle-ready diagnostic serialization, render warning policy, style support matrix, diagnostics reference, and support-level documentation cleanup.
+- **Underdeveloped**: existing label, 3D Tiles, building, style, and VT substrate where public workflow, integration, diagnostics, or end-to-end rendering is incomplete.
+- **Missing**: product capabilities that do not yet exist for the scoped map-rendering workflow, including deterministic `LabelPlan`, typed `MapScene` recipe, and VT normal/mask runtime support until implemented by their owning features.
+- **Pro-gated**: capabilities that require native/Pro symbols or packaging and therefore cannot be presented as public/open supported paths.
+- **Placeholder/fallback**: any fallback path that would return zero geometry, non-renderable geometry, placeholder output, or incomplete output while appearing successful.
+- **Experimental**: APIs or substrate that exist but are incomplete, unverified, or not safe to present as production-ready, including line/curved label behavior until proven by feature `002`.
+- **Unsupported**: product inputs or workflows that cannot be rendered or validated as requested in PRD-scoped workflows.
+- **Non-goal**: streamed MVT rendering, full Mapbox Style Specification parity, full MapScene rendering in this feature, label placement implementation, building implementation, production 3D Tiles runtime, VT normal/mask runtime implementation, browser delivery, hosted tile services, general DCC, and game/editor tooling.
+
+### Diagnostics & Failure Behavior *(mandatory)*
+
+- **Diagnostic objects**: Diagnostics must include code, severity, message, remediation, support level where applicable, affected layer ID where known, affected object ID where known, and bundle-ready serialization data.
+- **Required diagnostic codes**: `crs_mismatch`, `missing_glyphs`, `unsupported_style_field`, `unsupported_style_layer_type`, `pro_gated_path`, `placeholder_fallback`, `experimental_feature`, `vt_unsupported_family`, `python_public_3dtiles_incomplete`, `estimated_gpu_memory`, and `label_rejection_summary`.
+- **Severity behavior**: Allowed severity values are `info`, `warning`, `error`, and `fatal`. Validation reports must expose the highest applicable status across diagnostics. Error and fatal diagnostics always prevent successful render completion; warning diagnostics prevent successful render completion only when fail-on-warning behavior is selected; informational diagnostics never block by themselves.
+- **Severity floors**: `crs_mismatch` without transform, unsupported style layer types, Pro-gated required paths, placeholder/fallback required paths, VT unsupported families, incomplete public 3D Tiles paths, and unsupported product inputs must be at least `error` when they affect requested output. `missing_glyphs`, unsupported style fields, experimental features, estimated GPU memory budget risk, and label rejection summaries must be at least `warning` when they can affect output. Pure inventory or summary diagnostics may be `info` only when they do not affect requested output.
+- **Pre-render validation**: Validation must detect PRD-scoped unsupported, experimental, Pro-gated, placeholder/fallback, style, glyph, CRS, VT, 3D Tiles, memory, and label rejection conditions before render where enough input information exists.
+- **No-op prevention**: Unsupported features must produce typed diagnostics or typed failure behavior; they must not be silently ignored or represented only by logs, printed strings, or successful no-op outcomes.
+- **Bundle readiness**: Diagnostics must have a serializable representation suitable for scene bundles and bundle-ready structures. Any bundle path that records validation metadata must preserve diagnostics without information loss; full bundle load/render round-trip remains outside this feature.
+- **Determinism**: For fixed inputs, diagnostics and support summaries must be stable for serialized comparison, documentation evidence, and bundle review. Ordering must be deterministic by severity rank, diagnostic code, affected layer ID, affected object ID, and message or equivalent stable tie-breakers.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001 [PRD: P0-R5-AC1]**: The system MUST return diagnostics as structured objects for PRD-scoped map-rendering workflows, not only as printed strings, log lines, or warnings.
+- **FR-002 [PRD: P0-R5-AC2]**: Each diagnostic MUST include one of the severity values `info`, `warning`, `error`, or `fatal`.
+- **FR-003 [PRD: P0-R5-AC3]**: Each diagnostic MUST include affected layer and object identifiers where the workflow input makes them knowable.
+- **FR-004 [PRD: P0-R5-AC4]**: Diagnostic reports MUST be serializable in scene bundles or bundle-ready structures without losing code, severity, affected IDs, remediation, or support-level information.
+- **FR-005 [PRD: P0-R5-AC5]**: Users MUST be able to choose render behavior that either fails on warning-level diagnostics or continues while preserving diagnostics; this choice MUST NOT allow error or fatal diagnostics to be treated as successful render completion.
+- **FR-006 [PRD: P0-R5-AC6]**: PRD-scoped unsupported features MUST never be silently ignored; validation or render preparation must return structured diagnostics or typed failure behavior.
+- **FR-007 [PRD: Section 13]**: Validation reports MUST expose an overall status, diagnostics, layer summaries, GPU memory estimate when known, supported feature summary, and unsupported feature summary.
+- **FR-008 [PRD: Section 13]**: The diagnostic inventory MUST include `crs_mismatch`, `missing_glyphs`, `unsupported_style_field`, `unsupported_style_layer_type`, `pro_gated_path`, `placeholder_fallback`, `experimental_feature`, `vt_unsupported_family`, `python_public_3dtiles_incomplete`, `estimated_gpu_memory`, and `label_rejection_summary`.
+- **FR-009 [PRD: P0-R6-AC1]**: Documentation MUST state that P0 style support applies to local or provided features, not streamed MVT tiles.
+- **FR-010 [PRD: P0-R6-AC2]**: Documentation MUST explicitly list supported style layer types.
+- **FR-011 [PRD: P0-R6-AC3]**: The support matrix MUST include `fill`, `line`, and `circle` layers when the implementation audit confirms they are supported.
+- **FR-012 [PRD: P0-R6-AC4]**: Unsupported style layer types and unsupported paint or layout fields MUST produce `unsupported_style_layer_type` or `unsupported_style_field` diagnostics.
+- **FR-013 [PRD: P0-R6-AC5]**: Style application outputs MUST be defined in a way that can feed `VectorOverlay` workflows and future `LabelLayer` workflows without claiming streamed MVT support.
+- **FR-014 [PRD: P0-R6-AC6]**: Public documentation MUST NOT claim full Mapbox Style Specification support.
+- **FR-015 [PRD: Section 16]**: Documentation MUST include or update the Offline 3D Map Rendering Quickstart, LabelPlan Guide references, Style Support Matrix, Building Layer Support Matrix, 3D Tiles Support Matrix, Virtual Texturing Support Matrix, Diagnostics Reference, and Competitive Positioning Note as needed for this feature's scope.
+- **FR-016 [PRD: Appendix B]**: Support classifications in specs, docs, diagnostics, release notes, and support matrices MUST use only `supported`, `underdeveloped`, `missing`, `Pro-gated`, `placeholder/fallback`, `experimental`, `unsupported`, and `non-goal`.
+- **FR-017 [PRD: Milestone 0]**: Public support matrices MUST distinguish supported, underdeveloped, missing, Pro-gated, placeholder/fallback, experimental, unsupported, and non-goal map-rendering features.
+- **FR-018 [PRD: P0-R5-AC6]**: Diagnostics for Pro-gated, placeholder/fallback, experimental, VT unsupported family, incomplete public 3D Tiles, missing glyph, CRS mismatch, GPU memory, and label rejection paths MUST be represented even when final render implementations belong to later features.
+- **FR-019 [PRD: Constitution IV]**: Validation reports, diagnostics, layer summaries, supported feature summaries, unsupported feature summaries, and serialized diagnostic payloads MUST be deterministic for fixed inputs.
+- **FR-020 [PRD: Section 16, Appendix B]**: Required documentation MUST avoid umbrella wording such as "partial support" unless it is paired with the exact PRD classification and a concrete diagnostic or limitation.
+
+### Key Entities *(include if feature involves data)*
+
+- **ValidationReport**: A structured validation result for a map-rendering workflow. Key attributes are overall status, diagnostics, layer summaries, estimated GPU memory when known, supported feature summary, and unsupported feature summary.
+- **Diagnostic**: A structured validation finding. Key attributes are code, severity, message, remediation, support level where applicable, affected layer ID where known, affected object ID where known, and serialization-ready data.
+- **LayerSummary**: A per-layer validation summary that records layer identity, support status, relevant feature support, and diagnostic references.
+- **SupportMatrixEntry**: A documentation and review entry for a feature, layer type, style field, or workflow path. Key attributes are support classification, scope, limitations, diagnostics emitted, and remediation or next step.
+- **RenderFailurePolicy**: User-selected behavior for warning-level diagnostics, distinguishing fail-on-warning from continue-with-diagnostics.
+- **SeverityPolicy**: User-visible blocking rules that determine report status and render completion behavior from diagnostic severities.
+- **Public API contract**: This feature defines behavior for `ValidationReport` and `Diagnostic` and their bundle-ready use by `MapScene`, `SceneRecipe`, `LabelPlan`, and `Bundle`; it does not implement the full render path.
+
+## PRD Traceability & Evidence *(mandatory)*
+
+| PRD AC ID | Requirement in this spec | Evidence required | Verification target |
+|---|---|---|---|
+| P0-R5-AC1 | FR-001 | Diagnostic data model and tests asserting object fields | Diagnostic object tests |
+| P0-R5-AC2 | FR-002 | Severity coverage for `info`, `warning`, `error`, `fatal` | Severity validation tests |
+| P0-R5-AC3 | FR-003 | Fixtures showing layer and object ID propagation where possible | Affected ID diagnostics tests |
+| P0-R5-AC4 | FR-004 | Scene-bundle and bundle-ready serialization evidence preserving diagnostic fields | Serialization and bundle persistence tests |
+| P0-R5-AC5 | FR-005 | Fail-on-warning and continue-on-warning behavior evidence | Render policy tests |
+| P0-R5-AC6 | FR-006, FR-018 | Negative tests proving unsupported paths are not silently ignored | Unsupported/fallback diagnostic tests |
+| P0-R6-AC1 | FR-009 | Style docs state local/provided feature scope and exclude streamed MVT | Style support docs audit |
+| P0-R6-AC2 | FR-010 | Supported layer types are listed | Style support matrix audit |
+| P0-R6-AC3 | FR-011 | `fill`, `line`, and `circle` status is audited and documented | Style support matrix plus implementation audit |
+| P0-R6-AC4 | FR-012 | Unsupported style type and field fixtures emit diagnostics | Style diagnostics tests |
+| P0-R6-AC5 | FR-013 | Style output contract is consumable by vector workflows and future labels | Style workflow contract tests or review |
+| P0-R6-AC6 | FR-014 | Public docs do not claim full Mapbox Style Specification support | Docs wording audit |
+| Section 13 | FR-007, FR-008 | Validation report fields and required diagnostic inventory | Validation report contract tests |
+| Section 16 | FR-015 | Required docs and wording discipline updates | Docs review checklist |
+| Appendix B | FR-016, FR-020 | Support classifications use only PRD terms and avoid ambiguous umbrella wording | Support taxonomy audit |
+| Milestone 0 | FR-017 | Support matrices and diagnostics taxonomy exist | Milestone exit review |
+| Constitution IV | FR-019 | Stable report ordering and serialized diagnostic comparison evidence | Determinism tests or review |
+
+## Explicit Non-Goals *(mandatory)*
+
+- Implementing the full `MapScene` render path.
+- Implementing a streamed vector-tile renderer.
+- Implementing label placement.
+- Implementing buildings, 3D Tiles, or VT normal/mask runtime.
+- Implementing full Mapbox Style Specification support.
+- Implementing deterministic `LabelPlan` placement or label rendering/export behavior.
+- Implementing browser delivery, hosted tile services, general DCC workflows, game/editor tooling, or non-map rendering features.
+- Treating Pro-gated, placeholder/fallback, experimental, or underdeveloped paths as public supported features.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of P0-R5 and P0-R6 acceptance criteria have explicit requirements, evidence expectations, and verification targets in this specification.
+- **SC-002**: 100% of required MVP diagnostic codes are represented in the validation/reporting contract and diagnostics reference scope.
+- **SC-003**: Validation for known unsupported or incomplete map-rendering inputs returns structured diagnostics with code, severity, remediation, and affected IDs where known.
+- **SC-004**: Render policy can be demonstrated in both fail-on-warning and continue-on-warning modes for the same warning-producing workflow.
+- **SC-005**: Public style documentation distinguishes local/provided feature styling from streamed MVT and contains no full Mapbox Style Specification support claim.
+- **SC-006**: Support matrices cover style, labels, buildings, 3D Tiles, virtual texturing, and diagnostics taxonomy using only PRD-approved support classifications.
+- **SC-007**: Diagnostic serialization preserves all required diagnostic fields in scene-bundle or bundle-ready review data.
+- **SC-008**: Documentation review finds zero overclaims that classify underdeveloped, Pro-gated, placeholder/fallback, experimental, unsupported, or non-goal paths as supported.
+- **SC-009**: Repeated validation of the same fixed workflow produces the same diagnostic codes, severities, affected IDs, support summaries, and serialized ordering.
+- **SC-010**: Every support matrix entry that is not `supported` includes the exact PRD classification, diagnostic behavior, and user-facing limitation or remediation.
+
+## Assumptions
+
+- This feature may define bundle-ready diagnostic structures before full bundle round-trip behavior is implemented by later features.
+- CRS transform implementation scope belongs to later `MapScene` work; this feature requires honest `crs_mismatch` diagnostics when a mismatch is detectable and no transform is provided.
+- The minimum supported CRS transform set remains a later product decision; until it is decided, the safe behavior is to diagnose mismatches rather than silently transform or silently continue.
+- Style support for `fill`, `line`, and `circle` must be documented according to the actual implementation audit rather than assumed universally supported.
+- Label placement, buildings, 3D Tiles, and VT runtime work remain outside this feature, but their incomplete or unsupported paths must be diagnosable and documented.
+- Public/open versus Pro-gated building packaging remains a later product decision; this feature classifies paths by observable availability and whether native/Pro capability is required.
+- Existing dirty workspace changes are user-owned and are not part of this feature unless explicitly touched by this specification workflow.

--- a/specs/001-diagnostics-support-matrices/tasks.md
+++ b/specs/001-diagnostics-support-matrices/tasks.md
@@ -1,0 +1,435 @@
+# Tasks: Diagnostics and Support Matrices
+
+**Input**: `specs/001-diagnostics-support-matrices/plan.md`, `spec.md`, `research.md`, `data-model.md`, `quickstart.md`, and `contracts/diagnostics-contract.md`
+
+**Scope**: P0-R5, P0-R6, PRD Sections 13 and 16, Appendix B, Milestone 0, and required continuity state updates.
+
+**Required task format**: Every task below includes ID, title, PRD tags, files, action, verification, done evidence, and dependencies. The first checklist line preserves the Spec Kit task ID and `[P]` marker where work can be safely parallelized.
+
+**Execution rule**: Write or update tests before or alongside implementation. This feature defines diagnostics/support contracts only; it must not implement `LabelPlan`, `MapScene`, building rendering, 3D Tiles rendering, or VT normal/mask runtime.
+
+## Phase 1: Contract and Path Gates
+
+- [X] T001 [PRD: P0-R5-AC1, P0-R5-AC4, P0-R5-AC6] Inspect diagnostics ownership paths before source edits.
+  - ID: T001
+  - Title: Inspect diagnostics ownership paths
+  - PRD tags: [P0-R5-AC1] [P0-R5-AC4] [P0-R5-AC6]
+  - Files: `python/forge3d/__init__.py`, `python/forge3d/__init__.pyi`, expected `python/forge3d/diagnostics.py`, `tests/`, `docs/superpowers/state/implementation-ledger.md`
+  - Action: Confirm the diagnostics module path, export conventions, and test naming; if a different path is required, update `specs/001-diagnostics-support-matrices/plan.md`, `contracts/diagnostics-contract.md`, and this `tasks.md` before implementation.
+  - Verification: `rg -n "Diagnostic|ValidationReport|RenderFailurePolicy|SeverityPolicy" python tests docs/superpowers/state`
+  - Done evidence: Ledger records the chosen source/test/docs paths and no implementation has started on an unrecorded path.
+  - Dependencies: None
+
+- [X] T002 [P] [PRD: P0-R5-AC1, P0-R5-AC2, P0-R5-AC3, P0-R5-AC5] Add diagnostics object and policy contract tests.
+  - ID: T002
+  - Title: Add diagnostics object and policy tests
+  - PRD tags: [P0-R5-AC1] [P0-R5-AC2] [P0-R5-AC3] [P0-R5-AC5]
+  - Files: `tests/test_diagnostics_contract.py`, expected `python/forge3d/diagnostics.py`
+  - Action: Add tests for `Diagnostic`, `ValidationReport`, `LayerSummary`, `SupportMatrixEntry`, severity values, affected layer/object IDs, status calculation, unknown severity/support rejection, and warning/error/fatal render blocking policy.
+  - Verification: `pytest tests/test_diagnostics_contract.py -q`
+  - Done evidence: Tests fail before the contract exists and pass only with structured diagnostic objects and policy behavior.
+  - Dependencies: T001
+
+- [X] T003 [PRD: P0-R5-AC1, P0-R5-AC2, P0-R5-AC3, P0-R5-AC5] Implement diagnostics data models and exports.
+  - ID: T003
+  - Title: Implement diagnostics data models
+  - PRD tags: [P0-R5-AC1] [P0-R5-AC2] [P0-R5-AC3] [P0-R5-AC5]
+  - Files: `python/forge3d/diagnostics.py`, `python/forge3d/__init__.py`, `python/forge3d/__init__.pyi`
+  - Action: Implement the public diagnostics classes, validation helpers, severity policy, render policy, deterministic ordering keys, and package exports.
+  - Verification: `pytest tests/test_diagnostics_contract.py -q`
+  - Done evidence: Contract tests pass and public imports work from `forge3d`.
+  - Dependencies: T002
+
+- [X] T004 [P] [PRD: P0-R5-AC4, P0-R5-AC1] Add bundle-ready serialization and determinism tests.
+  - ID: T004
+  - Title: Add diagnostic serialization tests
+  - PRD tags: [P0-R5-AC4] [P0-R5-AC1]
+  - Files: `tests/test_diagnostics_bundle_serialization.py`, expected `python/forge3d/diagnostics.py`, inspect `python/forge3d/bundle.py`
+  - Action: Add tests for `to_dict()`, `from_dict()`, sorted JSON serialization, lossless bundle-ready payloads, deterministic diagnostic ordering, and repeated byte-for-byte serialization.
+  - Verification: `pytest tests/test_diagnostics_bundle_serialization.py -q`
+  - Done evidence: Fixed reports serialize identically across repeated runs and preserve code, severity, IDs, support level, remediation, and details.
+  - Dependencies: T001
+
+- [X] T005 [PRD: P0-R5-AC4, P0-R5-AC1] Implement deterministic diagnostic serialization.
+  - ID: T005
+  - Title: Implement diagnostic serialization
+  - PRD tags: [P0-R5-AC4] [P0-R5-AC1]
+  - Files: `python/forge3d/diagnostics.py`
+  - Action: Implement deterministic `to_dict()` and `from_dict()` for diagnostic objects and reports with sorted details and stable list ordering.
+  - Verification: `pytest tests/test_diagnostics_contract.py tests/test_diagnostics_bundle_serialization.py -q`
+  - Done evidence: Contract and serialization tests pass with byte-stable payloads.
+  - Dependencies: T003, T004
+
+## Phase 2: Unsupported Path Diagnostics
+
+- [X] T006 [P] [PRD: P0-R5-AC6, P0-R5-AC3, P0-R5-AC2] Add required diagnostic inventory negative tests.
+  - ID: T006
+  - Title: Add required diagnostic inventory tests
+  - PRD tags: [P0-R5-AC6] [P0-R5-AC3] [P0-R5-AC2]
+  - Files: `tests/test_diagnostics_support_paths.py`, inspect `python/forge3d/buildings.py`, `python/forge3d/tiles3d.py`, `python/forge3d/terrain_params.py`, `python/forge3d/viewer_ipc.py`, `src/terrain/renderer/virtual_texture.rs`, `src/viewer/cmd/labels_command.rs`
+  - Action: Add negative tests for `crs_mismatch`, `missing_glyphs`, `pro_gated_path`, `placeholder_fallback`, `experimental_feature`, `vt_unsupported_family`, `python_public_3dtiles_incomplete`, `estimated_gpu_memory`, and `label_rejection_summary`, including affected IDs where knowable.
+  - Verification: `pytest tests/test_diagnostics_support_paths.py -q`
+  - Done evidence: Tests fail on silent ignore, log-only warnings, placeholder success, and missing affected-ID propagation.
+  - Dependencies: T003
+
+- [X] T007 [PRD: P0-R5-AC6, P0-R5-AC3, P0-R5-AC2] Implement diagnostic factories for known unsupported paths.
+  - ID: T007
+  - Title: Implement unsupported path diagnostic factories
+  - PRD tags: [P0-R5-AC6] [P0-R5-AC3] [P0-R5-AC2]
+  - Files: `python/forge3d/diagnostics.py`, inspect `python/forge3d/buildings.py`, `python/forge3d/tiles3d.py`, `python/forge3d/terrain_params.py`, `python/forge3d/mem.py`
+  - Action: Add reusable diagnostic constructors or validation helpers for the required inventory without reclassifying unavailable render paths as supported.
+  - Verification: `pytest tests/test_diagnostics_support_paths.py -q`
+  - Done evidence: Required inventory diagnostics are structured, severity-bearing, and support-level classified.
+  - Dependencies: T006
+
+- [X] T008 [P] [PRD: P0-R5-AC6, P0-R5-AC5] Add no-op and render-policy regression tests.
+  - ID: T008
+  - Title: Add no-op and render-policy regression tests
+  - PRD tags: [P0-R5-AC6] [P0-R5-AC5]
+  - Files: `tests/test_diagnostics_no_op_policy.py`, expected `python/forge3d/diagnostics.py`
+  - Action: Add tests proving warning diagnostics continue by default, fail under fail-on-warning, errors/fatals block always, and placeholder/fallback diagnostics cannot produce successful render-prep status.
+  - Verification: `pytest tests/test_diagnostics_no_op_policy.py -q`
+  - Done evidence: Tests demonstrate no unsupported, experimental, Pro-gated, placeholder/fallback, or no-op path can be marked successful by policy.
+  - Dependencies: T003
+
+- [X] T009 [PRD: P0-R5-AC5, P0-R5-AC6] Wire report blocking behavior to policies.
+  - ID: T009
+  - Title: Implement report blocking behavior
+  - PRD tags: [P0-R5-AC5] [P0-R5-AC6]
+  - Files: `python/forge3d/diagnostics.py`
+  - Action: Implement `ValidationReport.render_blocked(...)`, `has_errors`, and status derivation so fail-on-warning and error/fatal behavior are deterministic.
+  - Verification: `pytest tests/test_diagnostics_contract.py tests/test_diagnostics_no_op_policy.py -q`
+  - Done evidence: Policy and no-op tests pass.
+  - Dependencies: T008
+
+## Phase 3: Style Honesty and Support Matrices
+
+- [X] T010 [P] [PRD: P0-R6-AC1, P0-R6-AC2, P0-R6-AC3, P0-R6-AC4, P0-R6-AC5] Add style support diagnostic tests.
+  - ID: T010
+  - Title: Add style support diagnostic tests
+  - PRD tags: [P0-R6-AC1] [P0-R6-AC2] [P0-R6-AC3] [P0-R6-AC4] [P0-R6-AC5]
+  - Files: `tests/test_diagnostics_style_support.py`, `python/forge3d/style.py`, expected `python/forge3d/diagnostics.py`
+  - Action: Add tests for local/provided feature style scope, audited `fill`, `line`, and `circle` support, unsupported layer types, unsupported paint/layout fields, and style output shape consumable by `VectorOverlay` and future `LabelLayer`.
+  - Verification: `pytest tests/test_diagnostics_style_support.py -q`
+  - Done evidence: Tests produce `unsupported_style_layer_type` and `unsupported_style_field` diagnostics instead of silently dropping unsupported inputs.
+  - Dependencies: T003
+
+- [X] T011 [PRD: P0-R6-AC3, P0-R6-AC4, P0-R6-AC5, P0-R5-AC6] Implement style support diagnostics.
+  - ID: T011
+  - Title: Implement style support diagnostics
+  - PRD tags: [P0-R6-AC3] [P0-R6-AC4] [P0-R6-AC5] [P0-R5-AC6]
+  - Files: `python/forge3d/style.py`, `python/forge3d/diagnostics.py`, `python/forge3d/__init__.pyi`
+  - Action: Add style audit/validation helpers that preserve supported local feature styling while emitting structured diagnostics for unsupported style fields and layer types.
+  - Verification: `pytest tests/test_diagnostics_style_support.py -q`
+  - Done evidence: Style diagnostics tests pass and no streamed MVT support is implied by the API.
+  - Dependencies: T010
+
+- [X] T012 [P] [PRD: P0-R6-AC1, P0-R6-AC2, P0-R6-AC3, P0-R6-AC6] Add docs support-matrix audit tests.
+  - ID: T012
+  - Title: Add support-matrix docs audit tests
+  - PRD tags: [P0-R6-AC1] [P0-R6-AC2] [P0-R6-AC3] [P0-R6-AC6]
+  - Files: `tests/test_support_matrices_docs.py`, `docs/guides/style_support_matrix.md`, `docs/guides/label_support_matrix.md`, `docs/guides/building_support_matrix.md`, `docs/guides/tiles3d_support_matrix.md`, `docs/guides/virtual_texturing_support_matrix.md`, `docs/guides/diagnostics_reference.md`
+  - Action: Add audit tests requiring exact PRD support-level vocabulary, supported style layer listings, local/provided feature scope, and no full Mapbox, Cesium, VT normal/mask, textured PBR, or production line/curved label overclaims.
+  - Verification: `pytest tests/test_support_matrices_docs.py -q`
+  - Done evidence: Docs audit fails until required matrices exist and forbidden wording is absent.
+  - Dependencies: T001
+
+- [X] T013 [PRD: P0-R6-AC1, P0-R6-AC2, P0-R6-AC3, P0-R6-AC4, P0-R6-AC5, P0-R6-AC6, P0-R5-AC1] Add diagnostics and support-matrix documentation.
+  - ID: T013
+  - Title: Add diagnostics and support-matrix docs
+  - PRD tags: [P0-R6-AC1] [P0-R6-AC2] [P0-R6-AC3] [P0-R6-AC4] [P0-R6-AC5] [P0-R6-AC6] [P0-R5-AC1]
+  - Files: `docs/guides/offline_3d_map_rendering.md`, `docs/guides/diagnostics_reference.md`, `docs/guides/style_support_matrix.md`, `docs/guides/label_support_matrix.md`, `docs/guides/building_support_matrix.md`, `docs/guides/tiles3d_support_matrix.md`, `docs/guides/virtual_texturing_support_matrix.md`, `docs/guides/competitive_positioning.md`, `docs/index.rst`
+  - Action: Create or update docs with exact diagnostic codes, severity/remediation guidance, support classifications, local/provided style scope, and matrix entries for style, labels, buildings, 3D Tiles, VT, and competitive positioning.
+  - Verification: `pytest tests/test_support_matrices_docs.py -q`
+  - Done evidence: Docs audit passes and `docs/index.rst` references new source docs that should be built.
+  - Dependencies: T012
+
+## Phase 4: Validation, Continuity, and Coverage
+
+- [X] T014 [P] [PRD: P0-R5-AC1, P0-R5-AC4, P0-R5-AC6] Add quickstart validation tests.
+  - ID: T014
+  - Title: Add diagnostics quickstart validation tests
+  - PRD tags: [P0-R5-AC1] [P0-R5-AC4] [P0-R5-AC6]
+  - Files: `tests/test_diagnostics_quickstart.py`, `specs/001-diagnostics-support-matrices/quickstart.md`, expected `python/forge3d/diagnostics.py`
+  - Action: Add automated checks for the quickstart scenarios: style support validation, render warning policy, bundle-ready serialization, and negative path diagnostics.
+  - Verification: `pytest tests/test_diagnostics_quickstart.py -q`
+  - Done evidence: Quickstart scenarios are executable and produce structured diagnostics.
+  - Dependencies: T005, T007, T009, T011
+
+- [X] T015 [PRD: P0-R5-AC1, P0-R5-AC2, P0-R5-AC3, P0-R5-AC4, P0-R5-AC5, P0-R5-AC6, P0-R6-AC1, P0-R6-AC2, P0-R6-AC3, P0-R6-AC4, P0-R6-AC5, P0-R6-AC6] Run full feature verification.
+  - ID: T015
+  - Title: Run full diagnostics feature verification
+  - PRD tags: [P0-R5-AC1] [P0-R5-AC2] [P0-R5-AC3] [P0-R5-AC4] [P0-R5-AC5] [P0-R5-AC6] [P0-R6-AC1] [P0-R6-AC2] [P0-R6-AC3] [P0-R6-AC4] [P0-R6-AC5] [P0-R6-AC6]
+  - Files: `tests/test_diagnostics_contract.py`, `tests/test_diagnostics_bundle_serialization.py`, `tests/test_diagnostics_support_paths.py`, `tests/test_diagnostics_no_op_policy.py`, `tests/test_diagnostics_style_support.py`, `tests/test_support_matrices_docs.py`, `tests/test_diagnostics_quickstart.py`
+  - Action: Run the full feature test set and record observed output summary without changing requirement status beyond available evidence.
+  - Verification: `pytest tests/test_diagnostics_contract.py tests/test_diagnostics_bundle_serialization.py tests/test_diagnostics_support_paths.py tests/test_diagnostics_no_op_policy.py tests/test_diagnostics_style_support.py tests/test_support_matrices_docs.py tests/test_diagnostics_quickstart.py -q`
+  - Done evidence: All feature tests pass or blockers are recorded with exact failing command output.
+  - Dependencies: T014
+
+- [X] T016 [PRD: P0-R5-AC1, P0-R5-AC2, P0-R5-AC3, P0-R5-AC4, P0-R5-AC5, P0-R5-AC6, P0-R6-AC1, P0-R6-AC2, P0-R6-AC3, P0-R6-AC4, P0-R6-AC5, P0-R6-AC6] Update requirements verification matrix.
+  - ID: T016
+  - Title: Update requirements verification matrix
+  - PRD tags: [P0-R5-AC1] [P0-R5-AC2] [P0-R5-AC3] [P0-R5-AC4] [P0-R5-AC5] [P0-R5-AC6] [P0-R6-AC1] [P0-R6-AC2] [P0-R6-AC3] [P0-R6-AC4] [P0-R6-AC5] [P0-R6-AC6]
+  - Files: `docs/superpowers/state/requirements-verification-matrix.md`
+  - Action: Update rows for P0-R5 and P0-R6 with exact source, test, docs, diagnostics, and command evidence; do not mark `Verified` unless verification was run and evidence is present.
+  - Verification: `rg -n "P0-R5-AC[1-6]|P0-R6-AC[1-6]|001-diagnostics-support-matrices|tests/test_diagnostics" docs/superpowers/state/requirements-verification-matrix.md`
+  - Done evidence: Matrix rows reference concrete artifacts and statuses match actual evidence.
+  - Dependencies: T015
+
+- [X] T017 [PRD: P0-R5-AC4, P0-R5-AC6, P0-R6-AC6] Update implementation ledger and current context pack.
+  - ID: T017
+  - Title: Update continuity state
+  - PRD tags: [P0-R5-AC4] [P0-R5-AC6] [P0-R6-AC6]
+  - Files: `docs/superpowers/state/implementation-ledger.md`, `docs/superpowers/state/current-context-pack.md`
+  - Action: Record completed diagnostics tasks, verification commands, docs/support-matrix evidence, unsupported-path decisions, and residual blockers for future sessions.
+  - Verification: `rg -n "001-diagnostics-support-matrices|P0-R5|P0-R6|unsupported_style_field|vt_unsupported_family|placeholder_fallback" docs/superpowers/state/implementation-ledger.md docs/superpowers/state/current-context-pack.md`
+  - Done evidence: Ledger and context pack contain current task outcomes and no unverified success claims.
+  - Dependencies: T016
+
+## Phase 5: Strict Audit Gap Remediation
+
+- [X] T018 [PRD: P0-R5-AC4] Add scene-bundle diagnostic persistence tests.
+  - ID: T018
+  - Title: Add scene-bundle diagnostic persistence tests
+  - PRD tags: [P0-R5-AC4]
+  - Files: `tests/test_bundle_roundtrip.py`, `python/forge3d/bundle.py`, `python/forge3d/diagnostics.py`
+  - Action: Add a failing test proving a `ValidationReport` can be saved in a scene bundle, loaded back, and preserved without losing diagnostic fields.
+  - Verification: `pytest tests/test_bundle_roundtrip.py tests/test_diagnostics_bundle_serialization.py -q`
+  - Done evidence: Test fails before bundle integration and passes after diagnostics are persisted in `scene/state.json`.
+  - Dependencies: T017
+
+- [X] T019 [PRD: P0-R5-AC4] Implement scene-bundle diagnostic persistence.
+  - ID: T019
+  - Title: Implement scene-bundle diagnostic persistence
+  - PRD tags: [P0-R5-AC4]
+  - Files: `python/forge3d/bundle.py`
+  - Action: Add `ValidationReport` preservation to `SceneState`, `LoadedBundle`, `save_bundle()`, and `load_bundle()` without changing older bundle compatibility.
+  - Verification: `pytest tests/test_bundle_roundtrip.py tests/test_diagnostics_bundle_serialization.py -q`
+  - Done evidence: Bundle save/load tests preserve `ValidationReport.to_dict()` exactly.
+  - Dependencies: T018
+
+- [X] T020 [PRD: P0-R5-AC6, P0-R5-AC3] Add non-style workflow diagnostic wiring tests.
+  - ID: T020
+  - Title: Add non-style workflow diagnostic wiring tests
+  - PRD tags: [P0-R5-AC6] [P0-R5-AC3]
+  - Files: `tests/test_diagnostics_support_paths.py`, `python/forge3d/buildings.py`, `python/forge3d/tiles3d.py`, `python/forge3d/terrain_params.py`, `python/forge3d/diagnostics.py`
+  - Action: Add failing tests proving building placeholder/fallback, public Python 3D Tiles incompleteness, VT non-albedo families, and experimental label paths expose public `ValidationReport` helpers.
+  - Verification: `pytest tests/test_diagnostics_support_paths.py -q`
+  - Done evidence: Non-style validators return structured diagnostics with affected IDs and blocking status.
+  - Dependencies: T019
+
+- [X] T021 [PRD: P0-R5-AC6, P0-R5-AC3] Implement non-style workflow diagnostic helpers.
+  - ID: T021
+  - Title: Implement non-style workflow diagnostic helpers
+  - PRD tags: [P0-R5-AC6] [P0-R5-AC3]
+  - Files: `python/forge3d/buildings.py`, `python/forge3d/tiles3d.py`, `python/forge3d/terrain_params.py`, `python/forge3d/diagnostics.py`, `python/forge3d/__init__.py`, `python/forge3d/__init__.pyi`
+  - Action: Wire diagnostics into public validation helpers for known non-style unsupported, placeholder/fallback, experimental, and VT paths without claiming render support.
+  - Verification: `pytest tests/test_diagnostics_support_paths.py -q`
+  - Done evidence: Validators return typed diagnostics rather than requiring callers to instantiate factories manually.
+  - Dependencies: T020
+
+- [X] T022 [PRD: P0-R6-AC5] Add style output workflow compatibility tests.
+  - ID: T022
+  - Title: Add style output workflow compatibility tests
+  - PRD tags: [P0-R6-AC5]
+  - Files: `tests/test_diagnostics_style_support.py`, `python/forge3d/style.py`, `python/forge3d/terrain_params.py`
+  - Action: Add failing tests proving supported style output can become `VectorOverlayConfig` payloads and symbol layers can produce future `LabelLayer` contract payloads without streamed MVT claims.
+  - Verification: `pytest tests/test_diagnostics_style_support.py -q`
+  - Done evidence: Tests prove style output is not just a support summary; it feeds typed vector and label-contract shapes.
+  - Dependencies: T021
+
+- [X] T023 [PRD: P0-R6-AC5] Implement style output workflow helpers.
+  - ID: T023
+  - Title: Implement style output workflow helpers
+  - PRD tags: [P0-R6-AC5]
+  - Files: `python/forge3d/style.py`, `python/forge3d/__init__.py`, `python/forge3d/__init__.pyi`
+  - Action: Implement local/provided feature helpers that convert supported fill, line, and circle style output to `VectorOverlayConfig` and symbol layers to a future `LabelLayer` contract payload.
+  - Verification: `pytest tests/test_diagnostics_style_support.py -q`
+  - Done evidence: Style compatibility tests pass and no streamed MVT support is implied.
+  - Dependencies: T022
+
+- [X] T024 [PRD: P0-R5-AC4, P0-R5-AC6, P0-R6-AC5] Run strict audit remediation verification and update matrix.
+  - ID: T024
+  - Title: Run remediation verification and update matrix
+  - PRD tags: [P0-R5-AC4] [P0-R5-AC6] [P0-R6-AC5]
+  - Files: `docs/superpowers/state/requirements-verification-matrix.md`
+  - Action: Run focused and full feature verification, then update matrix evidence for the remediated acceptance criteria only when command output supports it.
+  - Verification: `pytest tests/test_bundle_roundtrip.py tests/test_diagnostics_bundle_serialization.py tests/test_diagnostics_support_paths.py tests/test_diagnostics_style_support.py tests/test_diagnostics_contract.py tests/test_diagnostics_no_op_policy.py tests/test_support_matrices_docs.py tests/test_diagnostics_quickstart.py -q`
+  - Done evidence: Matrix rows cite bundle persistence, non-style validators, style workflow helpers, and passing command output.
+  - Dependencies: T023
+
+- [X] T025 [PRD: P0-R5-AC4, P0-R5-AC6, P0-R6-AC5] Update blockers, ledger, and context pack.
+  - ID: T025
+  - Title: Update continuity state after remediation
+  - PRD tags: [P0-R5-AC4] [P0-R5-AC6] [P0-R6-AC5]
+  - Files: `docs/superpowers/state/open-blockers.md`, `docs/superpowers/state/implementation-ledger.md`, `docs/superpowers/state/current-context-pack.md`, `specs/001-diagnostics-support-matrices/tasks.md`
+  - Action: Mark T018-T025 complete as evidence supports them, close or update R-015 through R-017, and record commands/results without claiming full feature completion before analysis.
+  - Verification: `rg -n "T018|T019|T020|T021|T022|T023|T024|T025|R-015|R-016|R-017|P0-R5-AC4|P0-R5-AC6|P0-R6-AC5" specs/001-diagnostics-support-matrices/tasks.md docs/superpowers/state/open-blockers.md docs/superpowers/state/implementation-ledger.md docs/superpowers/state/current-context-pack.md docs/superpowers/state/requirements-verification-matrix.md`
+  - Done evidence: Continuity artifacts record remediated evidence, `/speckit.analyze` pass metrics, and any remaining downstream non-feature gaps.
+  - Dependencies: T024
+
+## Phase 6: Follow-Up Audit Gap Remediation
+
+- [X] T026 [PRD: P0-R6-AC4] Add parsed-style unsupported field regression test.
+  - ID: T026
+  - Title: Add parsed-style unsupported field regression test
+  - PRD tags: [P0-R6-AC4]
+  - Files: `tests/test_diagnostics_style_support.py`, `python/forge3d/style.py`
+  - Action: Add a failing regression test proving `validate_style_support(parse_style(raw_style))` still emits `unsupported_style_field` diagnostics for unsupported paint and layout keys.
+  - Verification: `pytest tests/test_diagnostics_style_support.py -q`
+  - Done evidence: Test fails before unsupported field metadata is retained on parsed `StyleLayer` objects and passes after implementation.
+  - Dependencies: T025
+
+- [X] T027 [PRD: P0-R6-AC4] Preserve unsupported style fields through parsing.
+  - ID: T027
+  - Title: Preserve unsupported style fields through parsing
+  - PRD tags: [P0-R6-AC4]
+  - Files: `python/forge3d/style.py`
+  - Action: Preserve unsupported paint/layout field names on parsed style layers and have validation use that metadata when raw dictionaries are not available.
+  - Verification: `pytest tests/test_diagnostics_style_support.py -q`
+  - Done evidence: Parsed-style validation emits typed `unsupported_style_field` diagnostics without requiring the original raw style dict.
+  - Dependencies: T026
+
+- [X] T028 [PRD: P0-R6-AC6] Add public style API overclaim audit test.
+  - ID: T028
+  - Title: Add public style API overclaim audit test
+  - PRD tags: [P0-R6-AC6]
+  - Files: `tests/test_support_matrices_docs.py`, `python/forge3d/style.py`
+  - Action: Add a failing docs/API audit test that scans public style source docstrings for full/complete Mapbox support overclaims.
+  - Verification: `pytest tests/test_support_matrices_docs.py -q`
+  - Done evidence: Test fails on existing overclaim wording and passes only when public API docs stay within local/provided feature scope.
+  - Dependencies: T025
+
+- [X] T029 [PRD: P0-R6-AC6] Reword public style API docstrings.
+  - ID: T029
+  - Title: Reword public style API docstrings
+  - PRD tags: [P0-R6-AC6]
+  - Files: `python/forge3d/style.py`
+  - Action: Replace public style docstrings that imply complete/full Mapbox support with subset/local-feature wording consistent with the support matrix.
+  - Verification: `pytest tests/test_support_matrices_docs.py -q`
+  - Done evidence: Docs/API audit passes and no public source docstring claims complete/full Mapbox Style support.
+  - Dependencies: T028
+
+- [X] T030 [PRD: P0-R6-AC4, P0-R6-AC6] Run follow-up remediation verification and update matrix.
+  - ID: T030
+  - Title: Run follow-up remediation verification and update matrix
+  - PRD tags: [P0-R6-AC4] [P0-R6-AC6]
+  - Files: `docs/superpowers/state/requirements-verification-matrix.md`
+  - Action: Run focused and full feature verification, then update P0-R6-AC4 and P0-R6-AC6 matrix evidence only when command output supports it.
+  - Verification: `pytest tests/test_bundle_roundtrip.py tests/test_diagnostics_bundle_serialization.py tests/test_diagnostics_support_paths.py tests/test_diagnostics_style_support.py tests/test_diagnostics_contract.py tests/test_diagnostics_no_op_policy.py tests/test_support_matrices_docs.py tests/test_diagnostics_quickstart.py -q`
+  - Done evidence: Matrix rows cite parsed-style unsupported-field diagnostics, public API overclaim audit, and passing command output.
+  - Dependencies: T027, T029
+
+- [X] T031 [PRD: P0-R6-AC4, P0-R6-AC6] Update blockers, ledger, and context pack after follow-up remediation.
+  - ID: T031
+  - Title: Update continuity state after follow-up remediation
+  - PRD tags: [P0-R6-AC4] [P0-R6-AC6]
+  - Files: `docs/superpowers/state/open-blockers.md`, `docs/superpowers/state/implementation-ledger.md`, `docs/superpowers/state/current-context-pack.md`, `specs/001-diagnostics-support-matrices/tasks.md`
+  - Action: Close or update R-018 and R-019, mark T026-T031 complete only when evidence supports them, and record commands/results without claiming feature completion before analysis.
+  - Verification: `rg -n "T026|T027|T028|T029|T030|T031|R-018|R-019|P0-R6-AC4|P0-R6-AC6" specs/001-diagnostics-support-matrices/tasks.md docs/superpowers/state/open-blockers.md docs/superpowers/state/implementation-ledger.md docs/superpowers/state/current-context-pack.md docs/superpowers/state/requirements-verification-matrix.md`
+  - Done evidence: Continuity artifacts record remediated evidence, any `/speckit.analyze` outcome, and any remaining downstream non-feature gaps.
+  - Dependencies: T030
+
+## Phase 7: Completion Review Fixes
+
+- [X] T032 [PRD: P0-R5-AC3, P0-R5-AC6, P0-R6-AC4, P0-R6-AC5, P0-R6-AC6] Add completion-review regression tests.
+  - ID: T032
+  - Title: Add completion-review regression tests
+  - PRD tags: [P0-R5-AC3] [P0-R5-AC6] [P0-R6-AC4] [P0-R6-AC5] [P0-R6-AC6]
+  - Files: `tests/test_diagnostics_contract.py`, `tests/test_diagnostics_support_paths.py`, `tests/test_diagnostics_style_support.py`, `tests/test_support_matrices_docs.py`
+  - Action: Add failing tests for support-summary vocabulary rejection, per-label missing-glyph object IDs, symbol style underdeveloped truth, markdown support-matrix row validation, and Git visibility for required evidence files.
+  - Verification: `pytest tests/test_diagnostics_contract.py::test_validation_report_rejects_unknown_support_summary_levels tests/test_diagnostics_support_paths.py::test_label_validator_preserves_missing_glyph_object_ids_per_label tests/test_diagnostics_style_support.py::test_symbol_style_support_matches_underdeveloped_matrix_truth tests/test_support_matrices_docs.py::test_required_evidence_files_are_not_git_ignored tests/test_support_matrices_docs.py::test_support_matrix_rows_use_prd_terms_and_remediation_columns -q`
+  - Done evidence: Red run failed on the support-summary, missing-glyph object ID, symbol support, and Git visibility gaps before implementation.
+  - Dependencies: T031
+
+- [X] T033 [PRD: P0-R5-AC3, P0-R5-AC6, P0-R6-AC4, P0-R6-AC5] Implement completion-review behavior fixes.
+  - ID: T033
+  - Title: Implement completion-review behavior fixes
+  - PRD tags: [P0-R5-AC3] [P0-R5-AC6] [P0-R6-AC4] [P0-R6-AC5]
+  - Files: `python/forge3d/diagnostics.py`, `python/forge3d/style.py`, `tests/test_bundle_roundtrip.py`, `tests/test_diagnostics_bundle_serialization.py`
+  - Action: Validate support-summary values against PRD support levels, emit one missing-glyph diagnostic per affected label object, classify `symbol` style layers as `underdeveloped` with `experimental_feature`, and update fixtures to use support-level values.
+  - Verification: Same focused command as T032.
+  - Done evidence: Focused command reported `5 passed`.
+  - Dependencies: T032
+
+- [X] T034 [PRD: P0-R6-AC6, Constitution VII, Constitution X] Make feature evidence Git-visible and restore unrelated historical docs.
+  - ID: T034
+  - Title: Make evidence visible and restore unrelated docs
+  - PRD tags: [P0-R6-AC6] [Constitution VII] [Constitution X]
+  - Files: `.gitignore`, `docs/superpowers/plans/2026-04-25-khumbu-sentinel-timelapse-implementation.md`, `docs/superpowers/plans/2026-05-05-khumbu-smooth-orbit-light-render-implementation.md`, `docs/superpowers/plans/3d-map-rendering-gaps-assessment.md`
+  - Action: Remove broad ignores for `.specify/`, `.agents/`, `specs/`, `docs/guides`, and `docs/superpowers`; restore the unrelated historical plan files that had appeared as deleted.
+  - Verification: `git check-ignore -v specs/001-diagnostics-support-matrices/tasks.md docs/guides/diagnostics_reference.md docs/guides/style_support_matrix.md docs/guides/label_support_matrix.md docs/guides/building_support_matrix.md docs/guides/tiles3d_support_matrix.md docs/guides/virtual_texturing_support_matrix.md docs/superpowers/state/requirements-verification-matrix.md docs/superpowers/state/implementation-ledger.md docs/superpowers/state/current-context-pack.md .specify/memory/constitution.md`
+  - Done evidence: `git check-ignore` returned exit code 1 with no ignored evidence output; targeted historical plan paths show no deletion diff.
+  - Dependencies: T033
+
+- [X] T035 [PRD: P0-R5-AC1 through P0-R5-AC6, P0-R6-AC1 through P0-R6-AC6] Run completion-review verification and update continuity state.
+  - ID: T035
+  - Title: Run completion-review verification
+  - PRD tags: [P0-R5-AC1] [P0-R5-AC2] [P0-R5-AC3] [P0-R5-AC4] [P0-R5-AC5] [P0-R5-AC6] [P0-R6-AC1] [P0-R6-AC2] [P0-R6-AC3] [P0-R6-AC4] [P0-R6-AC5] [P0-R6-AC6]
+  - Files: `docs/superpowers/state/requirements-verification-matrix.md`, `docs/superpowers/state/implementation-ledger.md`, `docs/superpowers/state/current-context-pack.md`, `docs/superpowers/state/open-blockers.md`, `specs/001-diagnostics-support-matrices/tasks.md`
+  - Action: Run the required full feature suite and update continuity artifacts with the new evidence while keeping R-011 open for unrelated remaining workspace changes.
+  - Verification: `pytest tests/test_bundle_roundtrip.py tests/test_diagnostics_bundle_serialization.py tests/test_diagnostics_support_paths.py tests/test_diagnostics_style_support.py tests/test_diagnostics_contract.py tests/test_diagnostics_no_op_policy.py tests/test_support_matrices_docs.py tests/test_diagnostics_quickstart.py -q`
+  - Done evidence: Full feature command reported `63 passed`; targeted `git status` showed `001` docs/spec/state files visible to Git and no deletion diff for restored historical plan files.
+  - Dependencies: T034
+
+## Dependencies and Execution Order
+
+- Phase 1 gates source path ownership and diagnostics contract tests.
+- T002, T004, T006, T008, T010, T012, and T014 can be authored in parallel once T001 completes because they target separate test files.
+- Source implementation tasks depend on their corresponding tests: T003 after T002, T005 after T004, T007 after T006, T009 after T008, T011 after T010, and T013 after T012.
+- Continuity updates T016 and T017 happen after verification evidence exists.
+- Follow-up remediation must run after T025: T026 before T027, T028 before T029, T030 after T027 and T029, then T031.
+- Completion-review fixes run after T031: T032 before T033, T034 after behavior fixes, then T035 after verification and Git visibility evidence.
+
+## PRD Coverage Check
+
+- P0-R5-AC1: T001, T002, T003, T004, T005, T013, T014, T015, T016
+- P0-R5-AC2: T002, T003, T006, T007, T015, T016
+- P0-R5-AC3: T002, T003, T006, T007, T015, T016, T020, T021, T032, T033, T035
+- P0-R5-AC4: T001, T004, T005, T014, T015, T016, T017, T018, T019, T024, T025
+- P0-R5-AC5: T002, T003, T008, T009, T015, T016
+- P0-R5-AC6: T001, T006, T007, T008, T009, T011, T014, T015, T016, T017, T020, T021, T024, T025, T032, T033, T035
+- P0-R6-AC1: T010, T012, T013, T015, T016
+- P0-R6-AC2: T010, T012, T013, T015, T016
+- P0-R6-AC3: T010, T011, T012, T013, T015, T016
+- P0-R6-AC4: T010, T011, T013, T015, T016, T026, T027, T030, T031, T032, T033, T035
+- P0-R6-AC5: T010, T011, T013, T015, T016, T022, T023, T024, T025, T032, T033, T035
+- P0-R6-AC6: T012, T013, T015, T016, T017, T028, T029, T030, T031, T032, T034, T035
+- Section 13 validation report and diagnostic inventory: T002, T003, T006, T007, T014, T015, T016, T020, T021
+- Section 16 documentation: T012, T013, T014, T015, T016, T017, T024, T025
+- Appendix B support classification discipline: T012, T013, T016, T017, T024, T025, T032, T033, T034, T035
+- Milestone 0 support matrix cleanup: T012, T013, T015, T016, T017, T024, T025, T032, T034, T035
+- Constitution IV deterministic evidence: T004, T005, T014, T015, T018, T019
+
+## Detailed Pre-Implementation Coverage Audit Table
+
+| PRD requirement | Acceptance criterion | Task IDs covering it | Test task IDs | Docs task IDs | Verification command | Risk if omitted |
+|---|---|---|---|---|---|---|
+| P0-R5 Production Diagnostics | P0-R5-AC1 structured diagnostic objects | T001, T002, T003, T004, T005, T013, T014, T015, T016 | T002, T004, T014 | T013, T016, T017 | `pytest tests/test_diagnostics_contract.py tests/test_diagnostics_bundle_serialization.py tests/test_diagnostics_quickstart.py -q` | Diagnostics degrade to logs, warnings, or ad hoc dictionaries that cannot support validation or bundles. |
+| P0-R5 Production Diagnostics | P0-R5-AC2 severity values | T002, T003, T006, T007, T015, T016 | T002, T006 | T016 | `pytest tests/test_diagnostics_contract.py tests/test_diagnostics_support_paths.py -q` | Render policy cannot distinguish info, warning, error, and fatal states. |
+| P0-R5 Production Diagnostics | P0-R5-AC3 affected layer/object IDs | T002, T003, T006, T007, T015, T016, T020, T021, T032, T033, T035 | T002, T006, T020, T032 | T016, T035 | `pytest tests/test_diagnostics_contract.py tests/test_diagnostics_support_paths.py -q` | Users cannot identify which layer or object needs remediation. |
+| P0-R5 Production Diagnostics | P0-R5-AC4 bundle-serializable diagnostics | T001, T004, T005, T014, T015, T016, T017, T018, T019, T024, T025 | T004, T014, T018 | T013, T016, T017, T024, T025 | `pytest tests/test_bundle_roundtrip.py tests/test_diagnostics_bundle_serialization.py -q` | Review bundles lose diagnostic evidence and cannot reproduce validation state. |
+| P0-R5 Production Diagnostics | P0-R5-AC5 fail-on-warning policy | T002, T003, T008, T009, T015, T016 | T002, T008 | T016 | `pytest tests/test_diagnostics_contract.py tests/test_diagnostics_no_op_policy.py -q` | Render workflows cannot enforce conservative validation behavior. |
+| P0-R5 Production Diagnostics | P0-R5-AC6 unsupported never silently ignored | T001, T006, T007, T008, T009, T011, T014, T015, T016, T017, T020, T021, T024, T025, T032, T033, T035 | T006, T008, T014, T020, T032 | T013, T016, T017, T024, T025, T035 | `pytest tests/test_diagnostics_support_paths.py tests/test_diagnostics_no_op_policy.py tests/test_diagnostics_quickstart.py -q` | Unsupported, Pro-gated, placeholder, or experimental paths can pass as successful work. |
+| P0-R6 Style Honesty | P0-R6-AC1 local/provided feature scope | T010, T012, T013, T015, T016 | T010, T012 | T012, T013, T016 | `pytest tests/test_diagnostics_style_support.py tests/test_support_matrices_docs.py -q` | Users can mistake local feature styling for streamed MVT support. |
+| P0-R6 Style Honesty | P0-R6-AC2 supported layer list | T010, T012, T013, T015, T016 | T010, T012 | T012, T013, T016 | `pytest tests/test_diagnostics_style_support.py tests/test_support_matrices_docs.py -q` | Public docs cannot prove which style layers are supported. |
+| P0-R6 Style Honesty | P0-R6-AC3 fill, line, and circle support where implemented | T010, T011, T012, T013, T015, T016 | T010, T012 | T012, T013, T016 | `pytest tests/test_diagnostics_style_support.py tests/test_support_matrices_docs.py -q` | Existing style capability can be overclaimed, underdocumented, or disconnected from overlays. |
+| P0-R6 Style Honesty | P0-R6-AC4 unsupported style diagnostics | T010, T011, T013, T015, T016, T026, T027, T030, T031, T032, T033, T035 | T010, T026, T032 | T013, T016, T030, T031, T035 | `pytest tests/test_diagnostics_style_support.py -q` | Unsupported style fields or layer types can disappear silently, including after parsing. |
+| P0-R6 Style Honesty | P0-R6-AC5 style output feeds vector and label workflows | T010, T011, T013, T015, T016, T022, T023, T024, T025, T032, T033, T035 | T010, T022, T032 | T013, T016, T024, T025, T035 | `pytest tests/test_diagnostics_style_support.py -q` | Style support remains isolated from typed overlay and future label workflows. |
+| P0-R6 Style Honesty | P0-R6-AC6 no full Mapbox support claim | T012, T013, T015, T016, T017, T028, T029, T030, T031, T032, T034, T035 | T012, T028, T032 | T012, T013, T016, T017, T030, T031, T034, T035 | `pytest tests/test_support_matrices_docs.py -q` | Docs or public API docstrings overclaim full Mapbox Style or streamed vector-tile parity. |
+
+## Audit Rerun Result
+
+- PASS: Every P0-R5 and P0-R6 acceptance criterion has at least one task, one verification path, and test or diagnostic proof.
+- PASS: Public diagnostics and style-support tasks are paired with docs/support-matrix wording tasks T012, T013, T016, and T017.
+- PASS: Diagnostic requirements require structured objects, bundle serialization, severity, affected IDs, and no-op/unsupported-path negative tests rather than printed text only.
+- PASS: Completion-review fixes T032-T035 added regression coverage for support-summary taxonomy, per-object missing glyph diagnostics, `symbol` style truth, support-matrix row audits, and Git-visible evidence; full feature verification reported `63 passed`.
+
+## Extension Hooks
+
+**Optional Hook**: git
+Command: `/speckit.git.commit`
+Description: Auto-commit after task generation
+
+Prompt: Commit task changes?
+To execute: `/speckit.git.commit`

--- a/tests/test_bundle_roundtrip.py
+++ b/tests/test_bundle_roundtrip.py
@@ -23,6 +23,11 @@ from forge3d.bundle import (
     load_bundle,
     save_bundle,
 )
+from forge3d.diagnostics import (
+    ValidationReport,
+    missing_glyphs_diagnostic,
+    unsupported_style_field_diagnostic,
+)
 
 pytestmark = pytest.mark.usefixtures("pro_license")
 
@@ -283,6 +288,31 @@ def test_scene_state_v2_roundtrip_preserves_variants_and_assets(tmp_path: Path):
     assert effective.preset == {"exposure": 3.0}
     assert len(effective.labels) == 2
     assert len(effective.raster_overlays) == 1
+
+
+def test_scene_bundle_roundtrip_preserves_validation_report(tmp_path: Path):
+    """Validation diagnostics persist in scene/state.json and load back losslessly."""
+    bundle_path = tmp_path / "diagnostics_state.forge3d"
+    report = ValidationReport(
+        diagnostics=[
+            missing_glyphs_diagnostic(["é"], layer_id="labels", object_id="city-1"),
+            unsupported_style_field_diagnostic("roads", ["line-gradient"], section="paint"),
+        ],
+        supported_features={"diagnostics": "supported"},
+        unsupported_features={"style.full_mapbox_spec": "unsupported"},
+    )
+
+    save_bundle(bundle_path, name="diagnostics_state", validation_report=report)
+
+    with (bundle_path / "scene" / "state.json").open(encoding="utf-8") as handle:
+        raw_state = json.load(handle)
+    assert raw_state["validation_report"] == report.to_dict()
+
+    loaded = load_bundle(bundle_path)
+    assert loaded.scene_state.validation_report is not None
+    assert loaded.scene_state.validation_report.to_dict() == report.to_dict()
+    assert loaded.validation_report is not None
+    assert loaded.validation_report.to_dict() == report.to_dict()
 
 
 def test_effective_scene_state_respects_variant_layers_and_manual_overrides(tmp_path: Path):

--- a/tests/test_diagnostics_bundle_serialization.py
+++ b/tests/test_diagnostics_bundle_serialization.py
@@ -1,0 +1,140 @@
+import json
+
+import pytest
+
+from forge3d.diagnostics import Diagnostic, LayerSummary, ValidationReport
+
+
+def _diagnostic(code, severity, layer_id=None, object_id=None, details=None):
+    return Diagnostic(
+        code=code,
+        severity=severity,
+        message=f"{code} message",
+        remediation=f"{code} remediation",
+        support_level="unsupported" if severity in {"error", "fatal"} else "underdeveloped",
+        layer_id=layer_id,
+        object_id=object_id,
+        details=details or {},
+    )
+
+
+def test_diagnostic_from_dict_roundtrip_preserves_bundle_ready_fields():
+    payload = {
+        "code": "unsupported_style_field",
+        "severity": "warning",
+        "message": "Unsupported paint fields were ignored by older paths.",
+        "remediation": "Remove unsupported fields or use a supported style subset.",
+        "support_level": "unsupported",
+        "layer_id": "style.roads",
+        "object_id": None,
+        "details": {"fields": ["line-gradient"], "source": {"kind": "paint"}},
+    }
+
+    diag = Diagnostic.from_dict(payload)
+
+    assert diag.to_dict() == payload
+
+
+def test_validation_report_serialization_is_lossless_and_deterministic():
+    report = ValidationReport(
+        diagnostics=[
+            _diagnostic("missing_glyphs", "warning", "labels", "city-2"),
+            _diagnostic("crs_mismatch", "error", "roads", None),
+            _diagnostic("experimental_feature", "warning", "labels", "line-1"),
+            _diagnostic("diagnostic_inventory", "info", None, None),
+        ],
+        layer_summaries=[
+            LayerSummary(
+                layer_id="labels",
+                layer_type="labels",
+                support_level="underdeveloped",
+                diagnostic_codes=["experimental_feature", "missing_glyphs"],
+                object_count=2,
+                details={"source": "fixture"},
+            ),
+            LayerSummary(
+                layer_id="roads",
+                layer_type="vector",
+                support_level="unsupported",
+                diagnostic_codes=["crs_mismatch"],
+                object_count=1,
+            ),
+        ],
+        estimated_gpu_memory_bytes=2048,
+        supported_features={"diagnostics": "supported"},
+        unsupported_features={"streamed_mvt": "non-goal", "vt_mask": "missing"},
+    )
+
+    payload = report.to_dict()
+    restored = ValidationReport.from_dict(payload)
+
+    assert restored.to_dict() == payload
+    assert json.dumps(payload, sort_keys=True, separators=(",", ":")) == json.dumps(
+        restored.to_dict(),
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def test_validation_report_orders_diagnostics_by_stable_sort_key():
+    report = ValidationReport(
+        diagnostics=[
+            _diagnostic("missing_glyphs", "warning", "z-labels", "2"),
+            _diagnostic("missing_glyphs", "warning", "a-labels", "1"),
+            _diagnostic("crs_mismatch", "error", "roads", None),
+            _diagnostic("fatal_path", "fatal", "terrain", None),
+            _diagnostic("diagnostic_inventory", "info", None, None),
+        ]
+    )
+
+    assert [
+        (diag["severity"], diag["code"], diag["layer_id"], diag["object_id"])
+        for diag in report.to_dict()["diagnostics"]
+    ] == [
+        ("fatal", "fatal_path", "terrain", None),
+        ("error", "crs_mismatch", "roads", None),
+        ("warning", "missing_glyphs", "a-labels", "1"),
+        ("warning", "missing_glyphs", "z-labels", "2"),
+        ("info", "diagnostic_inventory", None, None),
+    ]
+
+
+def test_diagnostic_details_are_json_serializable_and_sorted():
+    diag = Diagnostic(
+        code="label_rejection_summary",
+        severity="warning",
+        message="Labels were rejected during placement.",
+        remediation="Inspect rejected label reasons.",
+        support_level="underdeveloped",
+        details={"z": [{"b": 2, "a": 1}], "a": {"y": 2, "x": 1}},
+    )
+
+    details = diag.to_dict()["details"]
+    assert list(details.keys()) == ["a", "z"]
+    assert list(details["a"].keys()) == ["x", "y"]
+    assert list(details["z"][0].keys()) == ["a", "b"]
+
+    with pytest.raises(TypeError, match="details must be JSON-serializable"):
+        Diagnostic(
+            code="bad_details",
+            severity="info",
+            message="bad details",
+            remediation="Use JSON-serializable details.",
+            details={"bad": object()},
+        )
+
+
+def test_empty_report_is_bundle_ready_ok_status():
+    report = ValidationReport()
+
+    assert report.status == "ok"
+    assert report.render_blocked() is False
+    assert report.to_dict() == {
+        "status": "ok",
+        "diagnostics": [],
+        "layer_summaries": [],
+        "estimated_gpu_memory_bytes": None,
+        "supported_features": {},
+        "unsupported_features": {},
+        "render_blocked": False,
+    }

--- a/tests/test_diagnostics_contract.py
+++ b/tests/test_diagnostics_contract.py
@@ -1,0 +1,185 @@
+import pytest
+
+import forge3d as f3d
+from forge3d.diagnostics import (
+    Diagnostic,
+    LayerSummary,
+    RenderFailurePolicy,
+    SeverityPolicy,
+    SupportMatrixEntry,
+    ValidationReport,
+)
+
+
+def test_diagnostic_preserves_required_fields():
+    diag = Diagnostic(
+        code="missing_glyphs",
+        severity="warning",
+        message="2 glyphs are missing from the active atlas.",
+        remediation="Load an atlas with the missing glyphs or change label text.",
+        support_level="underdeveloped",
+        layer_id="labels.cities",
+        object_id="label:zurich",
+        details={"missing_glyphs": ["e_acute", "sharp_s"], "count": 2},
+    )
+
+    assert diag.code == "missing_glyphs"
+    assert diag.severity == "warning"
+    assert diag.layer_id == "labels.cities"
+    assert diag.object_id == "label:zurich"
+    assert diag.to_dict() == {
+        "code": "missing_glyphs",
+        "severity": "warning",
+        "message": "2 glyphs are missing from the active atlas.",
+        "remediation": "Load an atlas with the missing glyphs or change label text.",
+        "support_level": "underdeveloped",
+        "layer_id": "labels.cities",
+        "object_id": "label:zurich",
+        "details": {"count": 2, "missing_glyphs": ["e_acute", "sharp_s"]},
+    }
+
+
+@pytest.mark.parametrize("severity", ["info", "warning", "error", "fatal"])
+def test_diagnostic_accepts_required_severities(severity):
+    diag = Diagnostic(
+        code="diagnostic_inventory",
+        severity=severity,
+        message="inventory entry",
+        remediation="No action required.",
+    )
+
+    assert diag.severity == severity
+
+
+@pytest.mark.parametrize("support_level", [
+    "supported",
+    "underdeveloped",
+    "missing",
+    "Pro-gated",
+    "placeholder/fallback",
+    "experimental",
+    "unsupported",
+    "non-goal",
+])
+def test_diagnostic_accepts_prd_support_levels(support_level):
+    diag = Diagnostic(
+        code="support_status",
+        severity="info",
+        message="support classification",
+        remediation="Read the support matrix.",
+        support_level=support_level,
+    )
+
+    assert diag.support_level == support_level
+
+
+def test_diagnostic_rejects_unknown_severity_and_support_level():
+    with pytest.raises(ValueError, match="Unknown diagnostic severity"):
+        Diagnostic(
+            code="bad",
+            severity="debug",
+            message="bad severity",
+            remediation="Use a supported severity.",
+        )
+
+    with pytest.raises(ValueError, match="Unknown support level"):
+        Diagnostic(
+            code="bad",
+            severity="warning",
+            message="bad support level",
+            remediation="Use PRD Appendix B terms.",
+            support_level="partial",
+        )
+
+
+def test_validation_report_rejects_unknown_support_summary_levels():
+    with pytest.raises(ValueError, match="Unknown support level"):
+        ValidationReport(supported_features={"diagnostics": "partial"})
+
+    with pytest.raises(ValueError, match="Unknown support level"):
+        ValidationReport(unsupported_features={"style.full_mapbox_spec": "mostly"})
+
+
+def test_validation_report_derives_status_and_policy_blocking():
+    warning_report = ValidationReport(
+        diagnostics=[
+            Diagnostic(
+                code="missing_glyphs",
+                severity="warning",
+                message="Missing glyphs can affect label output.",
+                remediation="Load an atlas with the missing glyphs.",
+            )
+        ]
+    )
+
+    assert warning_report.status == "warning"
+    assert warning_report.has_errors is False
+    assert warning_report.render_blocked(RenderFailurePolicy.CONTINUE_ON_WARNING) is False
+    assert warning_report.render_blocked(RenderFailurePolicy.FAIL_ON_WARNING) is True
+
+    error_report = ValidationReport(
+        diagnostics=[
+            Diagnostic(
+                code="crs_mismatch",
+                severity="error",
+                message="Layer CRS differs from scene CRS.",
+                remediation="Provide a transform or matching CRS.",
+                support_level="unsupported",
+                layer_id="roads",
+            )
+        ]
+    )
+
+    assert error_report.status == "error"
+    assert error_report.has_errors is True
+    assert error_report.render_blocked(RenderFailurePolicy.CONTINUE_ON_WARNING) is True
+    assert error_report.render_blocked(RenderFailurePolicy.FAIL_ON_WARNING) is True
+
+
+def test_layer_summary_and_support_matrix_entry_contracts():
+    layer = LayerSummary(
+        layer_id="roads",
+        layer_type="vector",
+        support_level="underdeveloped",
+        diagnostic_codes=["unsupported_style_field", "missing_glyphs"],
+        object_count=12,
+        bounds=(0.0, 1.0, 2.0, 3.0),
+        memory_estimate_bytes=4096,
+        details={"source": "roads.geojson"},
+    )
+    matrix_entry = SupportMatrixEntry(
+        area="style",
+        capability="line layers",
+        support_level="supported",
+        scope="local/provided features",
+        limitations=["No streamed MVT rendering"],
+        diagnostic_codes=["unsupported_style_field"],
+        remediation="Use supported paint/layout fields.",
+        evidence=["tests/test_diagnostics_style_support.py"],
+    )
+
+    assert layer.to_dict()["diagnostic_codes"] == [
+        "missing_glyphs",
+        "unsupported_style_field",
+    ]
+    assert matrix_entry.to_dict()["support_level"] == "supported"
+    assert matrix_entry.to_dict()["scope"] == "local/provided features"
+
+
+def test_severity_policy_and_public_exports():
+    assert SeverityPolicy.status_for([]) == "ok"
+    assert SeverityPolicy.status_for(["info", "warning"]) == "warning"
+    assert SeverityPolicy.status_for(["warning", "error"]) == "error"
+    assert SeverityPolicy.status_for(["fatal", "warning"]) == "fatal"
+
+    assert f3d.Diagnostic is Diagnostic
+    assert f3d.ValidationReport is ValidationReport
+    for export_name in [
+        "Diagnostic",
+        "ValidationReport",
+        "LayerSummary",
+        "SupportMatrixEntry",
+        "RenderFailurePolicy",
+        "SeverityPolicy",
+    ]:
+        assert export_name in f3d.__all__

--- a/tests/test_diagnostics_no_op_policy.py
+++ b/tests/test_diagnostics_no_op_policy.py
@@ -1,0 +1,31 @@
+from forge3d.diagnostics import (
+    RenderFailurePolicy,
+    ValidationReport,
+    experimental_feature_diagnostic,
+    placeholder_fallback_diagnostic,
+    pro_gated_path_diagnostic,
+)
+
+
+def test_warning_policy_does_not_turn_errors_into_success():
+    report = ValidationReport(
+        diagnostics=[
+            pro_gated_path_diagnostic("native building import", layer_id="buildings"),
+            placeholder_fallback_diagnostic("zero geometry fallback", layer_id="buildings"),
+        ]
+    )
+
+    assert report.status == "error"
+    assert report.has_errors is True
+    assert report.render_blocked(RenderFailurePolicy.CONTINUE_ON_WARNING) is True
+    assert report.render_blocked(RenderFailurePolicy.FAIL_ON_WARNING) is True
+
+
+def test_experimental_warning_can_continue_or_block_by_policy():
+    report = ValidationReport(
+        diagnostics=[experimental_feature_diagnostic("line labels", layer_id="labels")]
+    )
+
+    assert report.status == "warning"
+    assert report.render_blocked(RenderFailurePolicy.CONTINUE_ON_WARNING) is False
+    assert report.render_blocked(RenderFailurePolicy.FAIL_ON_WARNING) is True

--- a/tests/test_diagnostics_quickstart.py
+++ b/tests/test_diagnostics_quickstart.py
@@ -1,0 +1,72 @@
+import json
+
+from forge3d.diagnostics import (
+    RenderFailurePolicy,
+    ValidationReport,
+    crs_mismatch_diagnostic,
+    estimated_gpu_memory_diagnostic,
+    experimental_feature_diagnostic,
+    label_rejection_summary_diagnostic,
+    missing_glyphs_diagnostic,
+    placeholder_fallback_diagnostic,
+    pro_gated_path_diagnostic,
+    python_public_3dtiles_incomplete_diagnostic,
+    unsupported_style_field_diagnostic,
+    unsupported_style_layer_type_diagnostic,
+    vt_unsupported_family_diagnostic,
+)
+from forge3d.style import validate_style_support
+
+
+def test_quickstart_warning_policy_scenario_is_executable():
+    report = ValidationReport(
+        diagnostics=[missing_glyphs_diagnostic(["é"], layer_id="labels")]
+    )
+
+    assert report.render_blocked(RenderFailurePolicy.CONTINUE_ON_WARNING) is False
+    assert report.render_blocked(RenderFailurePolicy.FAIL_ON_WARNING) is True
+
+
+def test_quickstart_required_inventory_serializes_stably():
+    report = ValidationReport(
+        diagnostics=[
+            crs_mismatch_diagnostic("EPSG:4326", "EPSG:3857", layer_id="roads"),
+            missing_glyphs_diagnostic(["é"], layer_id="labels"),
+            unsupported_style_field_diagnostic("roads", ["line-gradient"]),
+            unsupported_style_layer_type_diagnostic("heat", "heatmap"),
+            pro_gated_path_diagnostic("native CityJSON import", layer_id="buildings"),
+            placeholder_fallback_diagnostic("zero geometry fallback", layer_id="buildings"),
+            experimental_feature_diagnostic("curved labels", layer_id="labels"),
+            vt_unsupported_family_diagnostic("normal", layer_id="terrain.vt"),
+            python_public_3dtiles_incomplete_diagnostic(layer_id="tiles.3d"),
+            estimated_gpu_memory_diagnostic(4096, 2048, layer_id="terrain"),
+            label_rejection_summary_diagnostic({"collision": 1}, layer_id="labels"),
+        ]
+    )
+
+    payload = report.to_dict()
+    restored = ValidationReport.from_dict(payload).to_dict()
+
+    assert restored == payload
+    assert json.dumps(payload, sort_keys=True, separators=(",", ":")) == json.dumps(
+        restored,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+
+
+def test_quickstart_style_validation_scenario_emits_structured_diagnostics():
+    report = validate_style_support(
+        {
+            "version": 8,
+            "layers": [
+                {"id": "roads", "type": "line", "paint": {"line-gradient": ["get", "speed"]}},
+                {"id": "heat", "type": "heatmap"},
+            ],
+        }
+    )
+
+    assert [diag.code for diag in report.diagnostics] == [
+        "unsupported_style_layer_type",
+        "unsupported_style_field",
+    ]

--- a/tests/test_diagnostics_style_support.py
+++ b/tests/test_diagnostics_style_support.py
@@ -1,0 +1,193 @@
+from forge3d.style import parse_style, validate_style_support
+from forge3d.terrain_params import PrimitiveType, VectorOverlayConfig
+
+
+def test_style_support_accepts_local_fill_line_and_circle_layers():
+    style = {
+        "version": 8,
+        "layers": [
+            {"id": "land", "type": "fill", "paint": {"fill-color": "#447744"}},
+            {"id": "roads", "type": "line", "paint": {"line-color": "#ffffff", "line-width": 2}},
+            {"id": "cities", "type": "circle", "paint": {"circle-color": "#ff0000", "circle-radius": 4}},
+        ],
+    }
+
+    report = validate_style_support(style)
+
+    assert report.status == "ok"
+    assert report.render_blocked() is False
+    assert report.supported_features == {
+        "style.layer.circle": "supported",
+        "style.layer.fill": "supported",
+        "style.layer.line": "supported",
+        "style.local_provided_features": "supported",
+    }
+
+
+def test_style_support_reports_unsupported_layer_types_and_fields():
+    style = {
+        "version": 8,
+        "layers": [
+            {
+                "id": "roads",
+                "type": "line",
+                "paint": {"line-color": "#ffffff", "line-gradient": ["get", "speed"]},
+                "layout": {"line-sort-key": 10},
+            },
+            {"id": "heat", "type": "heatmap", "paint": {"heatmap-radius": 12}},
+        ],
+    }
+
+    report = validate_style_support(style)
+    payloads = [diag.to_dict() for diag in report.diagnostics]
+
+    assert report.status == "error"
+    assert [payload["code"] for payload in payloads] == [
+        "unsupported_style_layer_type",
+        "unsupported_style_field",
+        "unsupported_style_field",
+    ]
+    assert payloads[0]["layer_id"] == "heat"
+    assert payloads[0]["details"]["layer_type"] == "heatmap"
+    assert payloads[1]["layer_id"] == "roads"
+    assert payloads[1]["details"]["fields"] == ["line-gradient"]
+    assert payloads[2]["details"]["fields"] == ["line-sort-key"]
+
+
+def test_style_support_accepts_parsed_style_spec_without_claiming_mvt():
+    parsed = parse_style(
+        {
+            "version": 8,
+            "layers": [
+                {"id": "water", "type": "fill", "paint": {"fill-opacity": 0.5}},
+            ],
+        }
+    )
+
+    report = validate_style_support(parsed)
+
+    assert report.status == "ok"
+    assert report.supported_features["style.local_provided_features"] == "supported"
+    assert report.unsupported_features["style.streamed_mvt"] == "non-goal"
+
+
+def test_parsed_style_support_reports_preserved_unsupported_fields():
+    parsed = parse_style(
+        {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "roads",
+                    "type": "line",
+                    "paint": {"line-color": "#ffffff", "line-gradient": ["get", "speed"]},
+                    "layout": {"visibility": "visible", "line-sort-key": 10},
+                },
+            ],
+        }
+    )
+
+    report = validate_style_support(parsed)
+    payloads = [diag.to_dict() for diag in report.diagnostics]
+
+    assert report.status == "warning"
+    assert [payload["code"] for payload in payloads] == [
+        "unsupported_style_field",
+        "unsupported_style_field",
+    ]
+    assert payloads[0]["layer_id"] == "roads"
+    assert payloads[0]["details"] == {"fields": ["line-gradient"], "section": "paint"}
+    assert payloads[1]["layer_id"] == "roads"
+    assert payloads[1]["details"] == {"fields": ["line-sort-key"], "section": "layout"}
+
+
+def test_symbol_style_support_matches_underdeveloped_matrix_truth():
+    report = validate_style_support(
+        {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "place-labels",
+                    "type": "symbol",
+                    "source-layer": "place_label",
+                    "layout": {"text-field": "{name}", "text-size": 14},
+                    "paint": {"text-color": "#333333"},
+                }
+            ],
+        }
+    )
+
+    assert report.status == "warning"
+    assert [(diag.code, diag.support_level, diag.layer_id, diag.details["feature"]) for diag in report.diagnostics] == [
+        ("experimental_feature", "experimental", "place-labels", "symbol text layer")
+    ]
+    assert report.layer_summaries[0].support_level == "underdeveloped"
+    assert report.unsupported_features["style.layer.symbol"] == "underdeveloped"
+
+
+def test_supported_style_output_feeds_vector_overlay_config():
+    from forge3d.style import vector_overlay_configs_from_style
+
+    style = {
+        "version": 8,
+        "layers": [
+            {"id": "roads", "type": "line", "paint": {"line-color": "#ff0000", "line-width": 3}},
+            {"id": "cities", "type": "circle", "paint": {"circle-color": "#00ff00", "circle-radius": 5}},
+        ],
+    }
+    features = [
+        {
+            "type": "Feature",
+            "properties": {"kind": "road"},
+            "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 1]]},
+        },
+        {
+            "type": "Feature",
+            "properties": {"kind": "city"},
+            "geometry": {"type": "Point", "coordinates": [3, 4]},
+        },
+    ]
+
+    overlays = vector_overlay_configs_from_style(style, features, name_prefix="styled")
+
+    assert all(isinstance(overlay, VectorOverlayConfig) for overlay in overlays)
+    assert [overlay.primitive for overlay in overlays] == [PrimitiveType.LINES, PrimitiveType.POINTS]
+    assert overlays[0].line_width == 3.0
+    assert overlays[0].vertices[0].r == 1.0
+    assert overlays[1].point_size == 10.0
+    assert overlays[1].vertices[0].g == 1.0
+    assert overlays[0].to_ipc_dict()["cmd"] == "add_vector_overlay"
+
+
+def test_symbol_style_output_feeds_future_label_layer_contract():
+    from forge3d.style import label_layer_contracts_from_style
+
+    contracts = label_layer_contracts_from_style(
+        {
+            "version": 8,
+            "layers": [
+                {
+                    "id": "place-labels",
+                    "type": "symbol",
+                    "source-layer": "place_label",
+                    "layout": {"text-field": "{name}", "text-size": 14},
+                    "paint": {"text-color": "#333333", "text-halo-color": "#ffffff"},
+                }
+            ],
+        }
+    )
+
+    assert contracts == [
+        {
+            "layer_id": "place-labels",
+            "source_layer": "place_label",
+            "text_field": "{name}",
+            "support_level": "underdeveloped",
+            "label_style": {
+                "size": 14.0,
+                "color": (0.2, 0.2, 0.2, 1.0),
+                "halo_color": (1.0, 1.0, 1.0, 1.0),
+                "halo_width": 1.5,
+                "offset": (0.0, 0.0),
+            },
+        }
+    ]

--- a/tests/test_diagnostics_support_paths.py
+++ b/tests/test_diagnostics_support_paths.py
@@ -1,0 +1,172 @@
+from forge3d.diagnostics import (
+    REQUIRED_DIAGNOSTIC_CODES,
+    ValidationReport,
+    crs_mismatch_diagnostic,
+    estimated_gpu_memory_diagnostic,
+    experimental_feature_diagnostic,
+    label_rejection_summary_diagnostic,
+    missing_glyphs_diagnostic,
+    placeholder_fallback_diagnostic,
+    pro_gated_path_diagnostic,
+    python_public_3dtiles_incomplete_diagnostic,
+    vt_unsupported_family_diagnostic,
+)
+
+
+def test_required_diagnostic_factories_cover_inventory_with_severity_and_ids():
+    diagnostics = [
+        crs_mismatch_diagnostic("EPSG:4326", "EPSG:3857", layer_id="roads"),
+        missing_glyphs_diagnostic(["Å", "ß"], layer_id="labels", object_id="city-1"),
+        pro_gated_path_diagnostic("CityJSON building import", layer_id="buildings"),
+        placeholder_fallback_diagnostic("GeoJSON building fallback", layer_id="buildings"),
+        experimental_feature_diagnostic("curved labels", layer_id="labels", object_id="line-7"),
+        vt_unsupported_family_diagnostic("normal", layer_id="terrain.vt"),
+        python_public_3dtiles_incomplete_diagnostic(layer_id="tiles.3d"),
+        estimated_gpu_memory_diagnostic(estimated_bytes=4096, budget_bytes=2048, layer_id="terrain"),
+        label_rejection_summary_diagnostic(
+            {"collision": 2, "missing_glyph": 1},
+            layer_id="labels",
+        ),
+    ]
+
+    by_code = {diag.code: diag for diag in diagnostics}
+
+    for code in REQUIRED_DIAGNOSTIC_CODES - {"unsupported_style_field", "unsupported_style_layer_type"}:
+        assert code in by_code
+        assert by_code[code].severity in {"warning", "error"}
+        assert by_code[code].remediation
+
+    assert by_code["crs_mismatch"].severity == "error"
+    assert by_code["crs_mismatch"].layer_id == "roads"
+    assert by_code["missing_glyphs"].object_id == "city-1"
+    assert by_code["vt_unsupported_family"].support_level == "unsupported"
+    assert by_code["placeholder_fallback"].support_level == "placeholder/fallback"
+
+
+def test_required_diagnostic_inventory_report_blocks_output_affecting_errors():
+    report = ValidationReport(
+        diagnostics=[
+            placeholder_fallback_diagnostic("3D Tiles placeholder", layer_id="buildings"),
+            vt_unsupported_family_diagnostic("mask", layer_id="terrain.vt"),
+        ]
+    )
+
+    assert report.status == "error"
+    assert report.render_blocked("continue_on_warning") is True
+    assert report.render_blocked("fail_on_warning") is True
+
+
+def test_building_layer_validator_reports_placeholder_fallback():
+    from forge3d.buildings import Building, BuildingLayer, validate_building_layer_support
+    import numpy as np
+
+    layer = BuildingLayer(
+        name="public-buildings",
+        buildings=[
+            Building(
+                id="b1",
+                positions=np.zeros((0, 3), dtype=np.float32),
+                indices=np.zeros(0, dtype=np.uint32),
+            )
+        ],
+        source_format="geojson",
+    )
+
+    report = validate_building_layer_support(layer, layer_id="buildings.public")
+
+    assert report.status == "error"
+    assert [diag.code for diag in report.diagnostics] == ["placeholder_fallback"]
+    assert report.diagnostics[0].layer_id == "buildings.public"
+    assert report.diagnostics[0].object_id == "b1"
+
+
+def test_public_tiles3d_validator_reports_incomplete_render_workflow(tmp_path):
+    from forge3d.tiles3d import load_tileset, validate_tiles3d_support
+    import json
+
+    tileset_path = tmp_path / "tileset.json"
+    tileset_path.write_text(
+        json.dumps(
+            {
+                "asset": {"version": "1.0"},
+                "geometricError": 10.0,
+                "root": {
+                    "boundingVolume": {"sphere": [0, 0, 0, 1]},
+                    "geometricError": 1.0,
+                    "content": {"uri": "tile.b3dm"},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    tileset = load_tileset(tileset_path)
+
+    report = validate_tiles3d_support(tileset, layer_id="tiles.local")
+
+    assert report.status == "error"
+    assert [diag.code for diag in report.diagnostics] == ["python_public_3dtiles_incomplete"]
+    assert report.diagnostics[0].layer_id == "tiles.local"
+    assert report.layer_summaries[0].details["tile_count"] == 1
+
+
+def test_terrain_vt_validator_reports_non_albedo_families():
+    from forge3d.terrain_params import (
+        TerrainVTSettings,
+        VTLayerFamily,
+        validate_terrain_vt_support,
+    )
+
+    settings = TerrainVTSettings(
+        enabled=True,
+        layers=[VTLayerFamily("albedo"), VTLayerFamily("normal"), VTLayerFamily("mask")],
+    )
+
+    report = validate_terrain_vt_support(settings, layer_id="terrain.vt")
+
+    assert report.status == "error"
+    assert [diag.code for diag in report.diagnostics] == [
+        "vt_unsupported_family",
+        "vt_unsupported_family",
+    ]
+    assert [diag.details["family"] for diag in report.diagnostics] == ["mask", "normal"]
+
+
+def test_label_validator_reports_experimental_paths_and_missing_glyphs():
+    from forge3d.diagnostics import validate_label_support
+
+    report = validate_label_support(
+        [
+            {"id": "road-1", "kind": "line", "text": "A1"},
+            {"id": "bend-1", "kind": "curved", "text": "Bé"},
+        ],
+        atlas_glyphs=set("AB1"),
+        layer_id="labels.transport",
+    )
+
+    assert report.status == "warning"
+    assert [diag.code for diag in report.diagnostics] == [
+        "experimental_feature",
+        "experimental_feature",
+        "missing_glyphs",
+    ]
+    assert report.diagnostics[0].object_id == "bend-1"
+    assert report.diagnostics[2].details["missing_glyphs"] == ["é"]
+
+
+def test_label_validator_preserves_missing_glyph_object_ids_per_label():
+    from forge3d.diagnostics import validate_label_support
+
+    report = validate_label_support(
+        [
+            {"id": "city-a", "kind": "point", "text": "Aé"},
+            {"id": "city-b", "kind": "point", "text": "Bß"},
+        ],
+        atlas_glyphs=set("AB"),
+        layer_id="labels.cities",
+    )
+
+    assert report.status == "warning"
+    assert [(diag.code, diag.object_id, diag.details["missing_glyphs"]) for diag in report.diagnostics] == [
+        ("missing_glyphs", "city-a", ["é"]),
+        ("missing_glyphs", "city-b", ["ß"]),
+    ]

--- a/tests/test_support_matrices_docs.py
+++ b/tests/test_support_matrices_docs.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+import subprocess
+
+
+DOCS = {
+    "docs/guides/offline_3d_map_rendering.md",
+    "docs/guides/diagnostics_reference.md",
+    "docs/guides/style_support_matrix.md",
+    "docs/guides/label_support_matrix.md",
+    "docs/guides/building_support_matrix.md",
+    "docs/guides/tiles3d_support_matrix.md",
+    "docs/guides/virtual_texturing_support_matrix.md",
+    "docs/guides/competitive_positioning.md",
+}
+
+GIT_VISIBLE_EVIDENCE = {
+    "specs/001-diagnostics-support-matrices/tasks.md",
+    "docs/guides/diagnostics_reference.md",
+    "docs/guides/style_support_matrix.md",
+    "docs/guides/label_support_matrix.md",
+    "docs/guides/building_support_matrix.md",
+    "docs/guides/tiles3d_support_matrix.md",
+    "docs/guides/virtual_texturing_support_matrix.md",
+    "docs/superpowers/state/requirements-verification-matrix.md",
+    "docs/superpowers/state/implementation-ledger.md",
+    "docs/superpowers/state/current-context-pack.md",
+}
+
+SUPPORT_MATRIX_DOCS = {
+    "docs/guides/style_support_matrix.md",
+    "docs/guides/label_support_matrix.md",
+    "docs/guides/building_support_matrix.md",
+    "docs/guides/tiles3d_support_matrix.md",
+    "docs/guides/virtual_texturing_support_matrix.md",
+}
+
+SUPPORT_TERMS = {
+    "supported",
+    "underdeveloped",
+    "missing",
+    "Pro-gated",
+    "placeholder/fallback",
+    "experimental",
+    "unsupported",
+    "non-goal",
+}
+
+DIAGNOSTIC_CODES = {
+    "crs_mismatch",
+    "missing_glyphs",
+    "unsupported_style_field",
+    "unsupported_style_layer_type",
+    "pro_gated_path",
+    "placeholder_fallback",
+    "experimental_feature",
+    "vt_unsupported_family",
+    "python_public_3dtiles_incomplete",
+    "estimated_gpu_memory",
+    "label_rejection_summary",
+}
+
+
+def _markdown_table_rows(path: Path):
+    lines = path.read_text(encoding="utf-8").splitlines()
+    for index, line in enumerate(lines):
+        if not line.startswith("|") or "---" in line:
+            continue
+        cells = [cell.strip() for cell in line.strip("|").split("|")]
+        if cells and cells[0] == "Capability":
+            continue
+        if len(cells) >= 4:
+            yield index + 1, cells
+
+
+def test_required_evidence_files_are_not_git_ignored():
+    result = subprocess.run(
+        ["git", "check-ignore", "-v", *sorted(GIT_VISIBLE_EVIDENCE)],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1, result.stdout
+
+
+def test_required_support_matrix_docs_exist_and_use_prd_terms():
+    for doc in DOCS:
+        path = Path(doc)
+        assert path.exists(), f"missing required doc: {doc}"
+        text = path.read_text(encoding="utf-8")
+        assert any(term in text for term in SUPPORT_TERMS), doc
+        assert "partial support" not in text.lower()
+
+
+def test_support_matrix_rows_use_prd_terms_and_remediation_columns():
+    for doc in sorted(SUPPORT_MATRIX_DOCS):
+        rows = list(_markdown_table_rows(Path(doc)))
+        assert rows, f"missing support matrix rows: {doc}"
+        for line_number, cells in rows:
+            capability, support_level, _scope, diagnostics = cells[:4]
+            assert support_level.strip("`") in SUPPORT_TERMS, f"{doc}:{line_number} {capability}"
+            if support_level.strip("`") != "supported":
+                diagnostic_text = diagnostics.lower()
+                assert diagnostics and (
+                    any(code in diagnostics for code in DIAGNOSTIC_CODES)
+                    or "diagnostic" in diagnostic_text
+                    or "documentation boundary" in diagnostic_text
+                    or "future" in diagnostic_text
+                ), f"{doc}:{line_number} {capability}"
+
+
+def test_diagnostics_reference_lists_required_codes_and_fields():
+    text = Path("docs/guides/diagnostics_reference.md").read_text(encoding="utf-8")
+
+    for code in sorted(DIAGNOSTIC_CODES):
+        assert code in text
+    for field in ["code", "severity", "message", "remediation", "support_level", "layer_id", "object_id"]:
+        assert field in text
+
+
+def test_style_support_matrix_states_local_scope_and_layers_without_overclaim():
+    text = Path("docs/guides/style_support_matrix.md").read_text(encoding="utf-8")
+
+    assert "local/provided features" in text
+    assert "streamed MVT" in text
+    assert "`fill`" in text
+    assert "`line`" in text
+    assert "`circle`" in text
+    assert "full Mapbox Style Specification support" not in text
+
+
+def test_public_style_api_docstrings_do_not_overclaim_mapbox_parity():
+    text = Path("python/forge3d/style.py").read_text(encoding="utf-8")
+
+    forbidden_claims = [
+        "Complete Mapbox GL Style specification",
+        "complete Mapbox GL Style specification",
+        "full Mapbox Style Specification support",
+    ]
+
+    for claim in forbidden_claims:
+        assert claim not in text


### PR DESCRIPTION
## Summary
- Adds the structured diagnostics contract and support-matrix docs for feature 001.
- Wires diagnostics into style, building, VT, 3D Tiles, and bundle validation paths.
- Adds focused pytest coverage and Spec Kit artifacts for `001-diagnostics-support-matrices`.

## Verification
- `python -m pytest tests/test_diagnostics_contract.py tests/test_diagnostics_style_support.py tests/test_diagnostics_support_paths.py tests/test_diagnostics_bundle_serialization.py tests/test_diagnostics_no_op_policy.py tests/test_diagnostics_quickstart.py tests/test_support_matrices_docs.py` -> 48 passed
- `python -m pytest tests/test_bundle_roundtrip.py::test_scene_bundle_roundtrip_preserves_validation_report` -> 1 passed
- commit hook `cargo clippy` -> passed
