### PR TITLE
G-002c C1 vector metadata/read foundation

### DIFF
--- a/python/forge3d/gis.py
+++ b/python/forge3d/gis.py
@@ -15,6 +15,11 @@ if _native is not None and hasattr(_native, "RasterInfo"):
 else:  # pragma: no cover - exercised only without the compiled extension
     RasterInfo = None
 
+if _native is not None and hasattr(_native, "VectorInfo"):
+    VectorInfo = _native.VectorInfo
+else:  # pragma: no cover - exercised only without the compiled extension
+    VectorInfo = None
+
 if _native is not None and hasattr(_native, "AffineTransform"):
     AffineTransform = _native.AffineTransform
 else:  # pragma: no cover - exercised only without the compiled extension
@@ -58,6 +63,53 @@ def read_raster(
         window=window,
         masked=masked,
     )
+
+
+def read_vector(
+    path: os.PathLike[str] | str,
+    *,
+    layer: str | None = None,
+    columns: list[str] | tuple[str, ...] | None = None,
+    bbox: tuple[float, float, float, float] | None = None,
+    limit: int | None = None,
+):
+    """Read a local GeoJSON vector source and return a FeatureCollection-like dict."""
+    return _require_native().read_vector(
+        os.fspath(path),
+        layer=layer,
+        columns=columns,
+        bbox=bbox,
+        limit=limit,
+    )
+
+
+def geometry_type(source: os.PathLike[str] | str | Any, *, layer: str | None = None) -> str:
+    """Return a stable geometry type string for a vector source or GeoJSON-like object."""
+    return _require_native().geometry_type(_path_or_self(source), layer=layer)
+
+
+def vector_schema(source: os.PathLike[str] | str | Any, *, layer: str | None = None):
+    """Return vector field schema metadata."""
+    return _require_native().vector_schema(_path_or_self(source), layer=layer)
+
+
+def feature_count(source: os.PathLike[str] | str | Any, *, layer: str | None = None) -> int:
+    """Return the feature count for a vector source or FeatureCollection-like dict."""
+    return _require_native().feature_count(_path_or_self(source), layer=layer)
+
+
+def vector_crs(source: os.PathLike[str] | str | Any, *, layer: str | None = None):
+    """Return CRS metadata for a vector source without guessing missing CRS."""
+    return _require_native().vector_crs(_path_or_self(source), layer=layer)
+
+
+def vector_bounds(
+    source: os.PathLike[str] | str | Any,
+    *,
+    layer: str | None = None,
+) -> tuple[float, float, float, float]:
+    """Return vector bounds as (left, bottom, right, top)."""
+    return _require_native().vector_bounds(_path_or_self(source), layer=layer)
 
 
 def _path_or_self(value: Any):
@@ -353,11 +405,18 @@ def web_mercator_bounds(
 
 __all__ = [
     "RasterInfo",
+    "VectorInfo",
     "AffineTransform",
     "CrsTransform",
     "RasterReadResult",
     "read_raster_info",
     "read_raster",
+    "read_vector",
+    "geometry_type",
+    "vector_schema",
+    "feature_count",
+    "vector_crs",
+    "vector_bounds",
     "write_raster",
     "parse_crs",
     "inspect_crs",

--- a/python/forge3d/gis.pyi
+++ b/python/forge3d/gis.pyi
@@ -44,6 +44,34 @@ class RasterInfo:
     def as_dict(self) -> dict[str, Any]: ...
 
 
+class VectorInfo:
+    @property
+    def path(self) -> str: ...
+    @property
+    def driver(self) -> str: ...
+    @property
+    def layer_name(self) -> str | None: ...
+    @property
+    def layer_count(self) -> int: ...
+    @property
+    def geometry_type(self) -> str: ...
+    @property
+    def feature_count(self) -> int: ...
+    @property
+    def schema(self) -> list[dict[str, Any]]: ...
+    @property
+    def crs_wkt(self) -> str | None: ...
+    @property
+    def crs_authority(self) -> dict[str, str] | None: ...
+    @property
+    def bounds(self) -> tuple[float, float, float, float] | None: ...
+    @property
+    def is_georeferenced(self) -> bool: ...
+    @property
+    def warnings(self) -> list[dict[str, str | None]]: ...
+    def as_dict(self) -> dict[str, Any]: ...
+
+
 class AffineTransform:
     def __init__(self, a: float, b: float, c: float, d: float, e: float, f: float) -> None: ...
     @property
@@ -100,6 +128,51 @@ def read_raster(
     window: tuple[int, int, int, int] | dict[str, int] | None = ...,
     masked: bool = ...,
 ) -> RasterReadResult: ...
+
+
+def read_vector(
+    path: os.PathLike[str] | str,
+    *,
+    layer: str | None = ...,
+    columns: list[str] | tuple[str, ...] | None = ...,
+    bbox: tuple[float, float, float, float] | None = ...,
+    limit: int | None = ...,
+) -> dict[str, Any]: ...
+
+
+def geometry_type(
+    source: os.PathLike[str] | str | VectorInfo | dict[str, Any],
+    *,
+    layer: str | None = ...,
+) -> str: ...
+
+
+def vector_schema(
+    source: os.PathLike[str] | str | VectorInfo | dict[str, Any],
+    *,
+    layer: str | None = ...,
+) -> list[dict[str, Any]]: ...
+
+
+def feature_count(
+    source: os.PathLike[str] | str | VectorInfo | dict[str, Any],
+    *,
+    layer: str | None = ...,
+) -> int: ...
+
+
+def vector_crs(
+    source: os.PathLike[str] | str | VectorInfo | dict[str, Any],
+    *,
+    layer: str | None = ...,
+) -> dict[str, Any]: ...
+
+
+def vector_bounds(
+    source: os.PathLike[str] | str | VectorInfo | dict[str, Any],
+    *,
+    layer: str | None = ...,
+) -> tuple[float, float, float, float]: ...
 
 
 def write_raster(

--- a/src/gis/mod.rs
+++ b/src/gis/mod.rs
@@ -4,6 +4,7 @@ pub mod error;
 pub mod raster_info;
 pub mod raster_write;
 pub mod types;
+pub mod vector;
 pub mod warp;
 
 pub use affine::{window_from_bounds, PixelWindow, RasterWindow};
@@ -14,6 +15,12 @@ pub use raster_write::{
     write_raster, CreationOptions, CrsSpec, RasterArray, RasterData, WriteRasterOptions,
 };
 pub use types::{AffineTransform, RasterBounds, RasterDType, RasterInfo, RasterWarning};
+#[cfg(feature = "extension-module")]
+pub use vector::{
+    feature_count_py, geometry_type_py, read_vector_py, vector_bounds_py, vector_crs_py,
+    vector_schema_py,
+};
+pub use vector::{read_vector, read_vector_info, VectorInfo, VectorReadOptions, VectorReadResult};
 pub use warp::{align_raster_to, assign_crs, reproject_raster, resample_array, resample_raster};
 
 #[cfg(feature = "extension-module")]

--- a/src/gis/vector.rs
+++ b/src/gis/vector.rs
@@ -1,0 +1,1101 @@
+use std::collections::{BTreeMap, BTreeSet, HashMap};
+use std::fs;
+use std::path::Path;
+
+use serde_json::{Map, Value};
+
+use crate::gis::affine::validate_bounds_tuple;
+use crate::gis::crs;
+use crate::gis::error::{GisError, GisResult};
+use crate::gis::raster_write::CrsSpec;
+use crate::gis::types::{RasterBounds, RasterWarning, WARNING_MISSING_CRS};
+
+pub const WARNING_EMPTY_FEATURE_SET: &str = "empty_feature_set";
+pub const WARNING_INVALID_GEOMETRY: &str = "invalid_geometry";
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct SchemaField {
+    pub name: String,
+    pub field_type: String,
+    pub nullable: Option<bool>,
+    pub width: Option<u32>,
+    pub precision: Option<u32>,
+}
+
+#[cfg_attr(
+    feature = "extension-module",
+    pyo3::pyclass(module = "forge3d._forge3d", name = "VectorInfo")
+)]
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorInfo {
+    pub path: String,
+    pub driver: String,
+    pub layer_name: Option<String>,
+    pub layer_count: u32,
+    pub geometry_type: String,
+    pub feature_count: u64,
+    pub schema: Vec<SchemaField>,
+    pub crs_wkt: Option<String>,
+    pub crs_authority: Option<HashMap<String, String>>,
+    pub bounds: Option<(f64, f64, f64, f64)>,
+    pub is_georeferenced: bool,
+    pub warnings: Vec<RasterWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorReadOptions {
+    pub layer: Option<String>,
+    pub columns: Option<Vec<String>>,
+    pub bbox: Option<(f64, f64, f64, f64)>,
+    pub limit: Option<usize>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorReadResult {
+    pub features: Vec<Value>,
+    pub info: VectorInfo,
+    pub warnings: Vec<RasterWarning>,
+}
+
+pub fn read_vector(
+    path: impl AsRef<Path>,
+    options: VectorReadOptions,
+) -> GisResult<VectorReadResult> {
+    let path = path.as_ref();
+    if !path.exists() {
+        return Err(GisError::NotFound(path.to_path_buf()));
+    }
+    validate_vector_path(path)?;
+
+    let text = fs::read_to_string(path)?;
+    let root: Value = serde_json::from_str(&text).map_err(|err| {
+        GisError::InvalidArgument(format!("invalid_geometry: invalid GeoJSON document: {err}"))
+    })?;
+    let layer_name = geojson_layer_name(path, &root);
+    if let Some(layer) = options.layer.as_deref() {
+        if Some(layer) != layer_name.as_deref() {
+            return Err(GisError::InvalidArgument(format!(
+                "missing_layer: GeoJSON source has layer {:?}, not {layer:?}",
+                layer_name
+            )));
+        }
+    }
+
+    let mut warnings = Vec::new();
+    let mut features = normalize_features(&root)?;
+    let crs = geojson_crs(&root)?;
+
+    if let Some(bbox) = options.bbox {
+        let bbox = validate_bounds_tuple(bbox, false)?;
+        features.retain(|feature| {
+            feature_bounds(feature).is_some_and(|bounds| bounds_intersects(bounds, bbox))
+        });
+    }
+    if let Some(limit) = options.limit {
+        features.truncate(limit);
+    }
+    if let Some(columns) = options.columns.as_ref() {
+        features = filter_columns(features, columns);
+    }
+
+    let geometry_type = geometry_type_for_features(&features);
+    let bounds = bounds_for_features(&features).map(RasterBounds::tuple);
+    if features.is_empty() {
+        warnings.push(RasterWarning::new(
+            WARNING_EMPTY_FEATURE_SET,
+            "vector source or filtered result has zero features",
+            Some("features"),
+        ));
+    }
+    let (crs_wkt, crs_authority) = match crs {
+        Some(spec) => (spec.wkt.clone(), crs::authority_map(&spec)),
+        None => {
+            warnings.push(RasterWarning::new(
+                WARNING_MISSING_CRS,
+                "vector source has no CRS metadata",
+                Some("crs_wkt"),
+            ));
+            (None, None)
+        }
+    };
+
+    let is_georeferenced = bounds.is_some() && (crs_wkt.is_some() || crs_authority.is_some());
+    let info = VectorInfo {
+        path: path.to_string_lossy().to_string(),
+        driver: "GeoJSON".to_string(),
+        layer_name,
+        layer_count: 1,
+        geometry_type,
+        feature_count: features.len() as u64,
+        schema: infer_schema(&features),
+        crs_wkt,
+        crs_authority,
+        bounds,
+        is_georeferenced,
+        warnings: warnings.clone(),
+    };
+    Ok(VectorReadResult {
+        features,
+        info,
+        warnings,
+    })
+}
+
+pub fn read_vector_info(path: impl AsRef<Path>, layer: Option<String>) -> GisResult<VectorInfo> {
+    Ok(read_vector(
+        path,
+        VectorReadOptions {
+            layer,
+            columns: None,
+            bbox: None,
+            limit: None,
+        },
+    )?
+    .info)
+}
+
+fn validate_vector_path(path: &Path) -> GisResult<()> {
+    match path
+        .extension()
+        .and_then(|extension| extension.to_str())
+        .map(str::to_ascii_lowercase)
+        .as_deref()
+    {
+        Some("geojson" | "json") => Ok(()),
+        Some("gpkg" | "shp" | "fgb" | "flatgeobuf") => Err(GisError::BackendUnavailable(
+            "backend_unavailable: gdal-vector feature required for this vector driver".to_string(),
+        )),
+        _ => Err(GisError::UnsupportedDriver(format!(
+            "unsupported_driver: C1 vector IO supports local GeoJSON only: {}",
+            path.display()
+        ))),
+    }
+}
+
+fn geojson_layer_name(path: &Path, root: &Value) -> Option<String> {
+    root.get("name")
+        .and_then(Value::as_str)
+        .map(str::to_string)
+        .or_else(|| path.file_stem()?.to_str().map(str::to_string))
+}
+
+fn geojson_crs(root: &Value) -> GisResult<Option<CrsSpec>> {
+    let Some(crs_value) = root.get("crs") else {
+        return Ok(None);
+    };
+    let Some(properties) = crs_value.get("properties").and_then(Value::as_object) else {
+        return Ok(None);
+    };
+    let Some(name) = properties.get("name").and_then(Value::as_str) else {
+        return Ok(None);
+    };
+    if let Some(spec) = crs_name_to_spec(name)? {
+        return Ok(Some(spec));
+    }
+    Ok(None)
+}
+
+fn crs_name_to_spec(name: &str) -> GisResult<Option<CrsSpec>> {
+    let trimmed = name.trim();
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    if trimmed.to_ascii_uppercase().starts_with("EPSG:") {
+        return parse_vector_crs_spec(trimmed);
+    }
+    for marker in ["EPSG::", "EPSG/0/", "EPSG/"] {
+        if let Some((_, code)) = trimmed.rsplit_once(marker) {
+            if code.chars().all(|ch| ch.is_ascii_digit()) {
+                return parse_vector_crs_spec(&format!("EPSG:{code}"));
+            }
+        }
+    }
+    Err(GisError::InvalidCrs(format!(
+        "invalid_crs: unsupported GeoJSON CRS name {trimmed:?}"
+    )))
+}
+
+fn parse_vector_crs_spec(value: &str) -> GisResult<Option<CrsSpec>> {
+    CrsSpec::from_string(value.to_string())
+        .map(Some)
+        .map_err(|err| GisError::InvalidCrs(format!("invalid_crs: {}", err.message())))
+}
+
+fn normalize_features(root: &Value) -> GisResult<Vec<Value>> {
+    match root.get("type").and_then(Value::as_str) {
+        Some("FeatureCollection") => {
+            let features = root
+                .get("features")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    GisError::InvalidArgument(
+                        "invalid_geometry: FeatureCollection requires a features array".to_string(),
+                    )
+                })?;
+            features.iter().map(normalize_feature).collect()
+        }
+        Some("Feature") => normalize_feature(root).map(|feature| vec![feature]),
+        Some(_) => geometry_to_feature(root).map(|feature| vec![feature]),
+        None => Err(GisError::InvalidArgument(
+            "invalid_geometry: GeoJSON object requires a type string".to_string(),
+        )),
+    }
+}
+
+fn normalize_feature(value: &Value) -> GisResult<Value> {
+    let object = value.as_object().ok_or_else(|| {
+        GisError::InvalidArgument("invalid_geometry: feature must be an object".to_string())
+    })?;
+    if object.get("type").and_then(Value::as_str) != Some("Feature") {
+        return Err(GisError::InvalidArgument(
+            "invalid_geometry: features array entries must be Feature objects".to_string(),
+        ));
+    }
+    let mut out = object.clone();
+    if !out.get("properties").is_some_and(Value::is_object) {
+        out.insert("properties".to_string(), Value::Object(Map::new()));
+    }
+    if !out.contains_key("geometry") {
+        out.insert("geometry".to_string(), Value::Null);
+    }
+    Ok(Value::Object(out))
+}
+
+fn geometry_to_feature(value: &Value) -> GisResult<Value> {
+    if !value.is_object() {
+        return Err(GisError::InvalidArgument(
+            "invalid_geometry: geometry must be an object".to_string(),
+        ));
+    }
+    let mut feature = Map::new();
+    feature.insert("type".to_string(), Value::String("Feature".to_string()));
+    feature.insert("geometry".to_string(), value.clone());
+    feature.insert("properties".to_string(), Value::Object(Map::new()));
+    Ok(Value::Object(feature))
+}
+
+fn filter_columns(features: Vec<Value>, columns: &[String]) -> Vec<Value> {
+    let wanted = columns.iter().collect::<BTreeSet<_>>();
+    features
+        .into_iter()
+        .map(|feature| {
+            let mut object = match feature.as_object() {
+                Some(object) => object.clone(),
+                None => return feature,
+            };
+            let properties = object
+                .get("properties")
+                .and_then(Value::as_object)
+                .map(|properties| {
+                    properties
+                        .iter()
+                        .filter(|(key, _)| wanted.contains(key))
+                        .map(|(key, value)| (key.clone(), value.clone()))
+                        .collect::<Map<String, Value>>()
+                })
+                .unwrap_or_default();
+            object.insert("properties".to_string(), Value::Object(properties));
+            Value::Object(object)
+        })
+        .collect()
+}
+
+fn infer_schema(features: &[Value]) -> Vec<SchemaField> {
+    #[derive(Default)]
+    struct State {
+        present: usize,
+        nullable: bool,
+        types: BTreeSet<&'static str>,
+    }
+
+    let mut states = BTreeMap::<String, State>::new();
+    for feature in features {
+        let Some(properties) = feature.get("properties").and_then(Value::as_object) else {
+            continue;
+        };
+        for (name, value) in properties {
+            let state = states.entry(name.clone()).or_default();
+            state.present += 1;
+            if value.is_null() {
+                state.nullable = true;
+            } else {
+                state.types.insert(json_type_name(value));
+            }
+        }
+    }
+
+    states
+        .into_iter()
+        .map(|(name, state)| SchemaField {
+            name,
+            field_type: public_field_type(&state.types).to_string(),
+            nullable: Some(state.nullable || state.present < features.len()),
+            width: None,
+            precision: None,
+        })
+        .collect()
+}
+
+fn json_type_name(value: &Value) -> &'static str {
+    match value {
+        Value::Bool(_) => "boolean",
+        Value::Number(number) if number.is_i64() || number.is_u64() => "integer",
+        Value::Number(_) => "float",
+        Value::String(_) => "string",
+        Value::Array(_) => "array",
+        Value::Object(_) => "object",
+        Value::Null => "null",
+    }
+}
+
+fn public_field_type(types: &BTreeSet<&'static str>) -> &'static str {
+    if types.is_empty() {
+        "null"
+    } else if types.len() == 1 {
+        types.iter().next().copied().unwrap_or("unknown")
+    } else if types.len() == 2 && types.contains("integer") && types.contains("float") {
+        "float"
+    } else {
+        "mixed"
+    }
+}
+
+fn geometry_type_for_features(features: &[Value]) -> String {
+    if features.is_empty() {
+        return "Empty".to_string();
+    }
+    let types = features
+        .iter()
+        .map(feature_geometry_type)
+        .collect::<BTreeSet<_>>();
+    if types.len() == 1 {
+        types
+            .into_iter()
+            .next()
+            .unwrap_or_else(|| "Unknown".to_string())
+    } else {
+        "Mixed".to_string()
+    }
+}
+
+fn feature_geometry_type(feature: &Value) -> String {
+    feature
+        .get("geometry")
+        .map(geometry_type_from_value)
+        .unwrap_or_else(|| "Empty".to_string())
+}
+
+fn geometry_type_from_value(value: &Value) -> String {
+    if value.is_null() {
+        return "Empty".to_string();
+    }
+    let Some(kind) = value.get("type").and_then(Value::as_str) else {
+        return "Unknown".to_string();
+    };
+    match kind {
+        "Point" | "LineString" | "Polygon" | "MultiPoint" | "MultiLineString" | "MultiPolygon" => {
+            if value.get("coordinates").is_none_or(coordinates_are_empty) {
+                "Empty".to_string()
+            } else {
+                kind.to_string()
+            }
+        }
+        "GeometryCollection" => {
+            if value
+                .get("geometries")
+                .and_then(Value::as_array)
+                .is_none_or(Vec::is_empty)
+            {
+                "Empty".to_string()
+            } else {
+                "GeometryCollection".to_string()
+            }
+        }
+        _ => "Unknown".to_string(),
+    }
+}
+
+fn coordinates_are_empty(value: &Value) -> bool {
+    value.as_array().is_none_or(Vec::is_empty)
+}
+
+fn bounds_for_features(features: &[Value]) -> Option<RasterBounds> {
+    let mut out: Option<RasterBounds> = None;
+    for bounds in features.iter().filter_map(feature_bounds) {
+        out = Some(match out {
+            Some(current) => RasterBounds {
+                left: current.left.min(bounds.left),
+                bottom: current.bottom.min(bounds.bottom),
+                right: current.right.max(bounds.right),
+                top: current.top.max(bounds.top),
+            },
+            None => bounds,
+        });
+    }
+    out
+}
+
+fn feature_bounds(feature: &Value) -> Option<RasterBounds> {
+    geometry_bounds(feature.get("geometry")?)
+}
+
+fn geometry_bounds(geometry: &Value) -> Option<RasterBounds> {
+    if geometry.is_null() {
+        return None;
+    }
+    if geometry.get("type").and_then(Value::as_str) == Some("GeometryCollection") {
+        let mut out: Option<RasterBounds> = None;
+        for geometry in geometry.get("geometries")?.as_array()? {
+            if let Some(bounds) = geometry_bounds(geometry) {
+                out = Some(match out {
+                    Some(current) => RasterBounds {
+                        left: current.left.min(bounds.left),
+                        bottom: current.bottom.min(bounds.bottom),
+                        right: current.right.max(bounds.right),
+                        top: current.top.max(bounds.top),
+                    },
+                    None => bounds,
+                });
+            }
+        }
+        return out;
+    }
+    let mut out = None;
+    collect_coordinate_bounds(geometry.get("coordinates")?, &mut out);
+    out
+}
+
+fn collect_coordinate_bounds(value: &Value, out: &mut Option<RasterBounds>) {
+    let Some(items) = value.as_array() else {
+        return;
+    };
+    if items.len() >= 2 {
+        if let (Some(x), Some(y)) = (items[0].as_f64(), items[1].as_f64()) {
+            if x.is_finite() && y.is_finite() {
+                let point = RasterBounds {
+                    left: x,
+                    bottom: y,
+                    right: x,
+                    top: y,
+                };
+                *out = Some(match out {
+                    Some(current) => RasterBounds {
+                        left: current.left.min(point.left),
+                        bottom: current.bottom.min(point.bottom),
+                        right: current.right.max(point.right),
+                        top: current.top.max(point.top),
+                    },
+                    None => point,
+                });
+            }
+            return;
+        }
+    }
+    for item in items {
+        collect_coordinate_bounds(item, out);
+    }
+}
+
+fn bounds_intersects(left: RasterBounds, right: RasterBounds) -> bool {
+    left.left <= right.right
+        && left.right >= right.left
+        && left.bottom <= right.top
+        && left.top >= right.bottom
+}
+
+#[cfg(feature = "extension-module")]
+mod py {
+    use super::*;
+    use pyo3::prelude::*;
+    use pyo3::types::{PyAny, PyDict, PyDictMethods, PyList, PyTuple};
+    use pyo3::IntoPy;
+
+    #[pyo3::pymethods]
+    impl VectorInfo {
+        #[getter]
+        fn path(&self) -> String {
+            self.path.clone()
+        }
+
+        #[getter]
+        fn driver(&self) -> String {
+            self.driver.clone()
+        }
+
+        #[getter]
+        fn layer_name(&self) -> Option<String> {
+            self.layer_name.clone()
+        }
+
+        #[getter]
+        fn layer_count(&self) -> u32 {
+            self.layer_count
+        }
+
+        #[getter]
+        fn geometry_type(&self) -> String {
+            self.geometry_type.clone()
+        }
+
+        #[getter]
+        fn feature_count(&self) -> u64 {
+            self.feature_count
+        }
+
+        #[getter]
+        fn schema<'py>(&self, py: Python<'py>) -> PyResult<PyObject> {
+            schema_to_py(py, &self.schema)
+        }
+
+        #[getter]
+        fn crs_wkt(&self) -> Option<String> {
+            self.crs_wkt.clone()
+        }
+
+        #[getter]
+        fn crs_authority(&self) -> Option<HashMap<String, String>> {
+            self.crs_authority.clone()
+        }
+
+        #[getter]
+        fn bounds(&self) -> Option<(f64, f64, f64, f64)> {
+            self.bounds
+        }
+
+        #[getter]
+        fn is_georeferenced(&self) -> bool {
+            self.is_georeferenced
+        }
+
+        #[getter]
+        fn warnings<'py>(&self, py: Python<'py>) -> PyResult<PyObject> {
+            warnings_to_py(py, &self.warnings)
+        }
+
+        fn as_dict<'py>(&self, py: Python<'py>) -> PyResult<PyObject> {
+            vector_info_to_py_dict(py, self)
+        }
+
+        fn __repr__(&self) -> String {
+            format!(
+                "VectorInfo(path={:?}, driver={:?}, layer_name={:?}, feature_count={})",
+                self.path, self.driver, self.layer_name, self.feature_count
+            )
+        }
+    }
+
+    #[pyfunction(
+        name = "read_vector",
+        signature = (path, *, layer = None, columns = None, bbox = None, limit = None)
+    )]
+    pub fn read_vector_py(
+        py: Python<'_>,
+        path: String,
+        layer: Option<String>,
+        columns: Option<Vec<String>>,
+        bbox: Option<(f64, f64, f64, f64)>,
+        limit: Option<usize>,
+    ) -> PyResult<PyObject> {
+        let result = read_vector(
+            path,
+            VectorReadOptions {
+                layer,
+                columns,
+                bbox,
+                limit,
+            },
+        )?;
+        vector_read_result_to_py(py, &result)
+    }
+
+    #[pyfunction(name = "geometry_type", signature = (source, *, layer = None))]
+    pub fn geometry_type_py(source: &Bound<'_, PyAny>, layer: Option<String>) -> PyResult<String> {
+        if let Some(info) = vector_info_from_source(source, layer.clone())? {
+            return Ok(info.geometry_type);
+        }
+        let value = py_to_json(source)?;
+        Ok(geometry_type_for_source_json(&value))
+    }
+
+    #[pyfunction(name = "vector_schema", signature = (source, *, layer = None))]
+    pub fn vector_schema_py(
+        py: Python<'_>,
+        source: &Bound<'_, PyAny>,
+        layer: Option<String>,
+    ) -> PyResult<PyObject> {
+        if let Some(info) = vector_info_from_source(source, layer.clone())? {
+            return schema_to_py(py, &info.schema);
+        }
+        let value = py_to_json(source)?;
+        schema_to_py(py, &schema_for_source_json(&value))
+    }
+
+    #[pyfunction(name = "feature_count", signature = (source, *, layer = None))]
+    pub fn feature_count_py(source: &Bound<'_, PyAny>, layer: Option<String>) -> PyResult<u64> {
+        if let Some(info) = vector_info_from_source(source, layer.clone())? {
+            return Ok(info.feature_count);
+        }
+        let value = py_to_json(source)?;
+        Ok(feature_count_for_source_json(&value))
+    }
+
+    #[pyfunction(name = "vector_crs", signature = (source, *, layer = None))]
+    pub fn vector_crs_py(
+        py: Python<'_>,
+        source: &Bound<'_, PyAny>,
+        layer: Option<String>,
+    ) -> PyResult<PyObject> {
+        let info = vector_info_from_source(source, layer)?.unwrap_or_else(|| VectorInfo {
+            path: String::new(),
+            driver: "GeoJSON".to_string(),
+            layer_name: None,
+            layer_count: 1,
+            geometry_type: "Unknown".to_string(),
+            feature_count: 0,
+            schema: Vec::new(),
+            crs_wkt: None,
+            crs_authority: None,
+            bounds: None,
+            is_georeferenced: false,
+            warnings: vec![RasterWarning::new(
+                WARNING_MISSING_CRS,
+                "vector source has no CRS metadata",
+                Some("crs_wkt"),
+            )],
+        });
+        vector_crs_to_py(py, &info)
+    }
+
+    #[pyfunction(name = "vector_bounds", signature = (source, *, layer = None))]
+    pub fn vector_bounds_py(
+        source: &Bound<'_, PyAny>,
+        layer: Option<String>,
+    ) -> PyResult<(f64, f64, f64, f64)> {
+        if let Some(info) = vector_info_from_source(source, layer.clone())? {
+            return info.bounds.ok_or_else(|| {
+                GisError::InvalidArgument(
+                    "empty_feature_set: vector source has no feature bounds".to_string(),
+                )
+                .into()
+            });
+        }
+        let value = py_to_json(source)?;
+        bounds_for_source_json(&value)
+            .map(RasterBounds::tuple)
+            .ok_or_else(|| {
+                GisError::InvalidArgument(
+                    "empty_feature_set: vector source has no feature bounds".to_string(),
+                )
+                .into()
+            })
+    }
+
+    fn vector_read_result_to_py(py: Python<'_>, result: &VectorReadResult) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item("type", "FeatureCollection")?;
+        dict.set_item(
+            "features",
+            json_to_py(py, &Value::Array(result.features.clone()))?,
+        )?;
+        dict.set_item("info", vector_info_to_py_dict(py, &result.info)?)?;
+        dict.set_item("vector_info", Py::new(py, result.info.clone())?)?;
+        dict.set_item("warnings", warnings_to_py(py, &result.warnings)?)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn vector_info_to_py_dict(py: Python<'_>, info: &VectorInfo) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item("path", info.path.clone())?;
+        dict.set_item("driver", info.driver.clone())?;
+        dict.set_item("layer_name", info.layer_name.clone())?;
+        dict.set_item("layer_count", info.layer_count)?;
+        dict.set_item("geometry_type", info.geometry_type.clone())?;
+        dict.set_item("feature_count", info.feature_count)?;
+        dict.set_item("schema", schema_to_py(py, &info.schema)?)?;
+        dict.set_item("crs_wkt", info.crs_wkt.clone())?;
+        dict.set_item("crs_authority", info.crs_authority.clone())?;
+        dict.set_item("bounds", info.bounds)?;
+        dict.set_item("is_georeferenced", info.is_georeferenced)?;
+        dict.set_item("warnings", warnings_to_py(py, &info.warnings)?)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn vector_crs_to_py(py: Python<'_>, info: &VectorInfo) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item("source_kind", "vector")?;
+        dict.set_item(
+            "missing",
+            info.crs_wkt.is_none() && info.crs_authority.is_none(),
+        )?;
+        dict.set_item("wkt", info.crs_wkt.clone())?;
+        dict.set_item("authority", info.crs_authority.clone())?;
+        dict.set_item(
+            "axis_order",
+            info.crs_authority.as_ref().map(|_| "xy".to_string()),
+        )?;
+        dict.set_item("axis_order_policy", "traditional_gis_xy")?;
+        dict.set_item(
+            "warnings",
+            warnings_to_py(
+                py,
+                &info
+                    .warnings
+                    .iter()
+                    .filter(|warning| warning.code == WARNING_MISSING_CRS)
+                    .cloned()
+                    .collect::<Vec<_>>(),
+            )?,
+        )?;
+        Ok(dict.into_py(py))
+    }
+
+    fn vector_info_from_source(
+        source: &Bound<'_, PyAny>,
+        layer: Option<String>,
+    ) -> PyResult<Option<VectorInfo>> {
+        if let Ok(info) = source.extract::<PyRef<'_, VectorInfo>>() {
+            return Ok(Some(info.clone()));
+        }
+        if let Ok(path) = source.extract::<String>() {
+            return read_vector_info(path, layer).map(Some).map_err(Into::into);
+        }
+        let Ok(dict) = source.downcast::<PyDict>() else {
+            return Ok(None);
+        };
+        if let Some(vector_info) = dict.get_item("vector_info")? {
+            if let Ok(info) = vector_info.extract::<PyRef<'_, VectorInfo>>() {
+                return Ok(Some(info.clone()));
+            }
+        }
+        let info_value = if is_info_dict(dict)? {
+            Some(source.clone())
+        } else {
+            dict.get_item("info")?
+        };
+        match info_value {
+            Some(value) => vector_info_from_info_value(&value).map(Some),
+            None => Ok(None),
+        }
+    }
+
+    fn is_info_dict(dict: &Bound<'_, PyDict>) -> PyResult<bool> {
+        Ok(dict.contains("geometry_type")? && dict.contains("feature_count")?)
+    }
+
+    fn vector_info_from_info_value(value: &Bound<'_, PyAny>) -> PyResult<VectorInfo> {
+        if let Ok(info) = value.extract::<PyRef<'_, VectorInfo>>() {
+            return Ok(info.clone());
+        }
+        let dict = value.downcast::<PyDict>().map_err(|_| {
+            GisError::InvalidArgument("source info must be a VectorInfo or dict".to_string())
+        })?;
+        let schema = dict
+            .get_item("schema")?
+            .map(|value| schema_from_py(&value))
+            .transpose()?
+            .unwrap_or_default();
+        let warnings = dict
+            .get_item("warnings")?
+            .map(|value| warnings_from_py(&value))
+            .transpose()?
+            .unwrap_or_default();
+        Ok(VectorInfo {
+            path: dict_string(dict, "path")?.unwrap_or_default(),
+            driver: dict_string(dict, "driver")?.unwrap_or_else(|| "GeoJSON".to_string()),
+            layer_name: dict_string(dict, "layer_name")?,
+            layer_count: dict
+                .get_item("layer_count")?
+                .map(|value| value.extract::<u32>())
+                .transpose()?
+                .unwrap_or(1),
+            geometry_type: dict_string(dict, "geometry_type")?
+                .unwrap_or_else(|| "Unknown".to_string()),
+            feature_count: dict
+                .get_item("feature_count")?
+                .map(|value| value.extract::<u64>())
+                .transpose()?
+                .unwrap_or(0),
+            schema,
+            crs_wkt: dict_string(dict, "crs_wkt")?,
+            crs_authority: dict
+                .get_item("crs_authority")?
+                .map(|value| value.extract::<HashMap<String, String>>())
+                .transpose()?,
+            bounds: dict
+                .get_item("bounds")?
+                .map(|value| {
+                    if value.is_none() {
+                        Ok(None)
+                    } else {
+                        value.extract::<(f64, f64, f64, f64)>().map(Some)
+                    }
+                })
+                .transpose()?
+                .flatten(),
+            is_georeferenced: dict
+                .get_item("is_georeferenced")?
+                .map(|value| value.extract::<bool>())
+                .transpose()?
+                .unwrap_or(false),
+            warnings,
+        })
+    }
+
+    fn dict_string(dict: &Bound<'_, PyDict>, key: &'static str) -> PyResult<Option<String>> {
+        dict.get_item(key)?
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract::<String>().map(Some)
+                }
+            })
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn geometry_type_for_source_json(value: &Value) -> String {
+        match value.get("type").and_then(Value::as_str) {
+            Some("FeatureCollection") => value
+                .get("features")
+                .and_then(Value::as_array)
+                .map(|features| geometry_type_for_features(features))
+                .unwrap_or_else(|| "Unknown".to_string()),
+            Some("Feature") => feature_geometry_type(value),
+            Some(_) => geometry_type_from_value(value),
+            None => "Unknown".to_string(),
+        }
+    }
+
+    fn schema_for_source_json(value: &Value) -> Vec<SchemaField> {
+        match value.get("type").and_then(Value::as_str) {
+            Some("FeatureCollection") => value
+                .get("features")
+                .and_then(Value::as_array)
+                .map(|features| infer_schema(features))
+                .unwrap_or_default(),
+            Some("Feature") => infer_schema(std::slice::from_ref(value)),
+            _ => Vec::new(),
+        }
+    }
+
+    fn feature_count_for_source_json(value: &Value) -> u64 {
+        match value.get("type").and_then(Value::as_str) {
+            Some("FeatureCollection") => value
+                .get("features")
+                .and_then(Value::as_array)
+                .map(|features| features.len() as u64)
+                .unwrap_or(0),
+            Some("Feature") | Some(_) => 1,
+            None => 0,
+        }
+    }
+
+    fn bounds_for_source_json(value: &Value) -> Option<RasterBounds> {
+        match value.get("type").and_then(Value::as_str) {
+            Some("FeatureCollection") => value
+                .get("features")
+                .and_then(Value::as_array)
+                .and_then(|features| bounds_for_features(features)),
+            Some("Feature") => feature_bounds(value),
+            Some(_) => geometry_bounds(value),
+            None => None,
+        }
+    }
+
+    fn schema_to_py(py: Python<'_>, schema: &[SchemaField]) -> PyResult<PyObject> {
+        let mut items = Vec::with_capacity(schema.len());
+        for field in schema {
+            let dict = PyDict::new_bound(py);
+            dict.set_item("name", field.name.clone())?;
+            dict.set_item("type", field.field_type.clone())?;
+            dict.set_item("nullable", field.nullable)?;
+            dict.set_item("width", field.width)?;
+            dict.set_item("precision", field.precision)?;
+            items.push(dict.into_py(py));
+        }
+        Ok(PyList::new_bound(py, items).into_py(py))
+    }
+
+    fn warnings_to_py(py: Python<'_>, warnings: &[RasterWarning]) -> PyResult<PyObject> {
+        let mut items = Vec::with_capacity(warnings.len());
+        for warning in warnings {
+            let dict = PyDict::new_bound(py);
+            dict.set_item("code", warning.code.clone())?;
+            dict.set_item("message", warning.message.clone())?;
+            dict.set_item("field", warning.field.clone())?;
+            items.push(dict.into_py(py));
+        }
+        Ok(PyList::new_bound(py, items).into_py(py))
+    }
+
+    fn schema_from_py(value: &Bound<'_, PyAny>) -> PyResult<Vec<SchemaField>> {
+        let list = value.downcast::<PyList>().map_err(|_| {
+            GisError::InvalidArgument("schema must be a list of field dicts".to_string())
+        })?;
+        let mut out = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            let dict = item.downcast::<PyDict>().map_err(|_| {
+                GisError::InvalidArgument("schema entries must be dicts".to_string())
+            })?;
+            out.push(SchemaField {
+                name: required_string(dict, "name")?,
+                field_type: required_string(dict, "type")?,
+                nullable: dict
+                    .get_item("nullable")?
+                    .map(|value| {
+                        if value.is_none() {
+                            Ok(None)
+                        } else {
+                            value.extract::<bool>().map(Some)
+                        }
+                    })
+                    .transpose()?
+                    .flatten(),
+                width: dict
+                    .get_item("width")?
+                    .map(|value| {
+                        if value.is_none() {
+                            Ok(None)
+                        } else {
+                            value.extract::<u32>().map(Some)
+                        }
+                    })
+                    .transpose()?
+                    .flatten(),
+                precision: dict
+                    .get_item("precision")?
+                    .map(|value| {
+                        if value.is_none() {
+                            Ok(None)
+                        } else {
+                            value.extract::<u32>().map(Some)
+                        }
+                    })
+                    .transpose()?
+                    .flatten(),
+            });
+        }
+        Ok(out)
+    }
+
+    fn warnings_from_py(value: &Bound<'_, PyAny>) -> PyResult<Vec<RasterWarning>> {
+        let list = value.downcast::<PyList>().map_err(|_| {
+            GisError::InvalidArgument("warnings must be a list of warning dicts".to_string())
+        })?;
+        let mut out = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            let dict = item.downcast::<PyDict>().map_err(|_| {
+                GisError::InvalidArgument("warning entries must be dicts".to_string())
+            })?;
+            out.push(RasterWarning {
+                code: required_string(dict, "code")?,
+                message: required_string(dict, "message")?,
+                field: dict_string(dict, "field")?,
+            });
+        }
+        Ok(out)
+    }
+
+    fn required_string(dict: &Bound<'_, PyDict>, key: &'static str) -> PyResult<String> {
+        dict.get_item(key)?
+            .ok_or_else(|| GisError::InvalidArgument(format!("{key} is required")))?
+            .extract::<String>()
+            .map_err(Into::into)
+    }
+
+    fn py_to_json(value: &Bound<'_, PyAny>) -> PyResult<Value> {
+        if value.is_none() {
+            return Ok(Value::Null);
+        }
+        if let Ok(value) = value.extract::<bool>() {
+            return Ok(Value::Bool(value));
+        }
+        if let Ok(value) = value.extract::<i64>() {
+            return Ok(Value::Number(value.into()));
+        }
+        if let Ok(value) = value.extract::<u64>() {
+            return Ok(Value::Number(value.into()));
+        }
+        if let Ok(value) = value.extract::<f64>() {
+            return serde_json::Number::from_f64(value)
+                .map(Value::Number)
+                .ok_or_else(|| {
+                    GisError::InvalidArgument("JSON numbers must be finite".to_string()).into()
+                });
+        }
+        if let Ok(value) = value.extract::<String>() {
+            return Ok(Value::String(value));
+        }
+        if let Ok(dict) = value.downcast::<PyDict>() {
+            let mut out = Map::new();
+            for (key, item) in dict.iter() {
+                let key = key.extract::<String>().map_err(|_| {
+                    GisError::InvalidArgument("JSON object keys must be strings".to_string())
+                })?;
+                if key == "vector_info" {
+                    continue;
+                }
+                out.insert(key, py_to_json(&item)?);
+            }
+            return Ok(Value::Object(out));
+        }
+        if let Ok(list) = value.downcast::<PyList>() {
+            return list
+                .iter()
+                .map(|item| py_to_json(&item))
+                .collect::<PyResult<Vec<_>>>()
+                .map(Value::Array);
+        }
+        if let Ok(tuple) = value.downcast::<PyTuple>() {
+            return tuple
+                .iter()
+                .map(|item| py_to_json(&item))
+                .collect::<PyResult<Vec<_>>>()
+                .map(Value::Array);
+        }
+        Err(GisError::InvalidArgument(
+            "source must be a vector path, VectorInfo, or GeoJSON-like dict".to_string(),
+        )
+        .into())
+    }
+
+    fn json_to_py(py: Python<'_>, value: &Value) -> PyResult<PyObject> {
+        match value {
+            Value::Null => Ok(py.None()),
+            Value::Bool(value) => Ok(value.into_py(py)),
+            Value::Number(number) => {
+                if let Some(value) = number.as_i64() {
+                    Ok(value.into_py(py))
+                } else if let Some(value) = number.as_u64() {
+                    Ok(value.into_py(py))
+                } else if let Some(value) = number.as_f64() {
+                    Ok(value.into_py(py))
+                } else {
+                    Ok(py.None())
+                }
+            }
+            Value::String(value) => Ok(value.clone().into_py(py)),
+            Value::Array(items) => {
+                let items = items
+                    .iter()
+                    .map(|item| json_to_py(py, item))
+                    .collect::<PyResult<Vec<_>>>()?;
+                Ok(PyList::new_bound(py, items).into_py(py))
+            }
+            Value::Object(items) => {
+                let dict = PyDict::new_bound(py);
+                for (key, item) in items {
+                    dict.set_item(key, json_to_py(py, item)?)?;
+                }
+                Ok(dict.into_py(py))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "extension-module")]
+pub use py::{
+    feature_count_py, geometry_type_py, read_vector_py, vector_bounds_py, vector_crs_py,
+    vector_schema_py,
+};

--- a/src/py_module/classes.rs
+++ b/src/py_module/classes.rs
@@ -50,6 +50,7 @@ pub(crate) fn register_py_classes(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<crate::smoke::py::PySmokeStepSettings>()?;
     m.add_class::<crate::smoke::py::PySmokeRenderSettings>()?;
     m.add_class::<crate::gis::RasterInfo>()?;
+    m.add_class::<crate::gis::VectorInfo>()?;
     m.add_class::<crate::gis::AffineTransform>()?;
     m.add_class::<crate::gis::CrsTransform>()?;
     Ok(())

--- a/src/py_module/functions/gis.rs
+++ b/src/py_module/functions/gis.rs
@@ -5,6 +5,12 @@ pub(crate) fn register_gis_py_functions(m: &Bound<'_, PyModule>) -> PyResult<()>
     m.add_function(wrap_pyfunction!(crate::gis::read_raster_info_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::read_raster_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::write_raster_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::read_vector_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::geometry_type_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::vector_schema_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::feature_count_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::vector_crs_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::vector_bounds_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::parse_crs_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::inspect_crs_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::raster_crs_py, m)?)?;

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -87,6 +87,7 @@ class TestNativeModuleSymbols:
         "SmokeStepSettings",
         "SmokeRenderSettings",
         "RasterInfo",
+        "VectorInfo",
         "AffineTransform",
         "CrsTransform",
     ]
@@ -126,6 +127,12 @@ class TestNativeModuleSymbols:
         "read_raster_info",
         "read_raster",
         "write_raster",
+        "read_vector",
+        "geometry_type",
+        "vector_schema",
+        "feature_count",
+        "vector_crs",
+        "vector_bounds",
         # G-002b: Rust-backed GIS CRS/affine/warp operations
         "parse_crs",
         "inspect_crs",

--- a/tests/test_gis_raster.py
+++ b/tests/test_gis_raster.py
@@ -112,13 +112,21 @@ def test_public_gis_wrapper_surface():
     native = get_native_module()
 
     assert gis.RasterInfo is native.RasterInfo
+    assert gis.VectorInfo is native.VectorInfo
     assert set(gis.__all__) == {
         "RasterInfo",
+        "VectorInfo",
         "AffineTransform",
         "CrsTransform",
         "RasterReadResult",
         "read_raster_info",
         "read_raster",
+        "read_vector",
+        "geometry_type",
+        "vector_schema",
+        "feature_count",
+        "vector_crs",
+        "vector_bounds",
         "write_raster",
         "parse_crs",
         "inspect_crs",
@@ -153,6 +161,12 @@ def test_public_gis_wrapper_surface():
     }
     assert callable(gis.read_raster_info)
     assert callable(gis.read_raster)
+    assert callable(gis.read_vector)
+    assert callable(gis.geometry_type)
+    assert callable(gis.vector_schema)
+    assert callable(gis.feature_count)
+    assert callable(gis.vector_crs)
+    assert callable(gis.vector_bounds)
     assert callable(gis.write_raster)
     assert callable(gis.parse_crs)
     assert callable(gis.inspect_crs)

--- a/tests/test_gis_vector_io.py
+++ b/tests/test_gis_vector_io.py
@@ -1,0 +1,411 @@
+"""G-002c C1 vector metadata/read contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import forge3d.gis as gis
+from forge3d._native import NATIVE_AVAILABLE
+
+
+pytestmark = pytest.mark.skipif(
+    not NATIVE_AVAILABLE,
+    reason="GIS vector tests require the compiled _forge3d extension",
+)
+
+
+def _codes(items) -> set[str]:
+    return {item["code"] for item in items}
+
+
+def _write_geojson(
+    path: Path,
+    *,
+    features: list[dict],
+    crs: bool = True,
+    name: str = "sample_layer",
+):
+    payload = {
+        "type": "FeatureCollection",
+        "name": name,
+        "features": features,
+    }
+    if crs:
+        payload["crs"] = {"type": "name", "properties": {"name": "EPSG:4326"}}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _sample_features() -> list[dict]:
+    return [
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "alpha",
+                "population": 10,
+                "temperature": 21.5,
+                "active": True,
+            },
+            "geometry": {"type": "Point", "coordinates": [1.0, 2.0]},
+        },
+        {
+            "type": "Feature",
+            "properties": {
+                "name": "beta",
+                "population": 12,
+                "temperature": 19.25,
+                "active": False,
+            },
+            "geometry": {
+                "type": "Polygon",
+                "coordinates": [
+                    [
+                        [0.0, 0.0],
+                        [4.0, 0.0],
+                        [4.0, 5.0],
+                        [0.0, 5.0],
+                        [0.0, 0.0],
+                    ]
+                ],
+            },
+        },
+    ]
+
+
+def _feature(kind: str, coordinates):
+    return {
+        "type": "Feature",
+        "properties": {"kind": kind},
+        "geometry": {"type": kind, "coordinates": coordinates},
+    }
+
+
+def test_read_vector_geojson_happy_path_and_vector_info(tmp_path: Path):
+    path = _write_geojson(tmp_path / "sample.geojson", features=_sample_features())
+
+    result = gis.read_vector(path)
+
+    assert result["type"] == "FeatureCollection"
+    assert len(result["features"]) == 2
+    assert result["features"][0]["geometry"]["type"] == "Point"
+    assert result["info"]["driver"] == "GeoJSON"
+    assert result["info"]["layer_name"] == "sample_layer"
+    assert result["info"]["layer_count"] == 1
+    assert result["info"]["geometry_type"] == "Mixed"
+    assert result["info"]["feature_count"] == 2
+    assert result["info"]["bounds"] == pytest.approx((0.0, 0.0, 4.0, 5.0))
+    assert result["info"]["is_georeferenced"] is True
+    assert result["info"]["crs_authority"] == {"name": "EPSG", "code": "4326"}
+    assert result["warnings"] == []
+
+    vector_info = result["vector_info"]
+    assert isinstance(vector_info, gis.VectorInfo)
+    assert vector_info.path == str(path)
+    assert vector_info.driver == "GeoJSON"
+    assert vector_info.layer_name == "sample_layer"
+    assert vector_info.feature_count == 2
+    assert vector_info.bounds == pytest.approx((0.0, 0.0, 4.0, 5.0))
+    assert vector_info.as_dict().keys() == {
+        "path",
+        "driver",
+        "layer_name",
+        "layer_count",
+        "geometry_type",
+        "feature_count",
+        "schema",
+        "crs_wkt",
+        "crs_authority",
+        "bounds",
+        "is_georeferenced",
+        "warnings",
+    }
+    assert not {
+        "layers",
+        "columns",
+        "is_empty",
+        "invalid_geometry_count",
+    } & set(vector_info.as_dict())
+
+
+def test_vector_metadata_helpers_read_path_info_and_read_result(tmp_path: Path):
+    path = _write_geojson(tmp_path / "sample.geojson", features=_sample_features())
+    result = gis.read_vector(path)
+
+    assert gis.geometry_type(path) == "Mixed"
+    assert gis.geometry_type(result) == "Mixed"
+    assert gis.geometry_type({"type": "Point", "coordinates": [1.0, 2.0]}) == "Point"
+    assert gis.feature_count(path) == 2
+    assert gis.feature_count(result) == 2
+    assert gis.vector_bounds(path) == pytest.approx((0.0, 0.0, 4.0, 5.0))
+    assert gis.vector_bounds(result) == pytest.approx((0.0, 0.0, 4.0, 5.0))
+    assert gis.vector_crs(path)["authority"] == {"name": "EPSG", "code": "4326"}
+    assert gis.vector_crs(result)["authority"] == {"name": "EPSG", "code": "4326"}
+
+    schema = {field["name"]: field for field in gis.vector_schema(path)}
+    assert schema["name"]["type"] == "string"
+    assert schema["population"]["type"] == "integer"
+    assert schema["temperature"]["type"] == "float"
+    assert schema["active"]["type"] == "boolean"
+
+
+@pytest.mark.parametrize(
+    ("geometry", "expected"),
+    [
+        ({"type": "Point", "coordinates": [1.0, 2.0]}, "Point"),
+        ({"type": "LineString", "coordinates": [[0.0, 0.0], [1.0, 1.0]]}, "LineString"),
+        (
+            {
+                "type": "Polygon",
+                "coordinates": [
+                    [[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 0.0]]
+                ],
+            },
+            "Polygon",
+        ),
+        ({"type": "MultiPoint", "coordinates": [[0.0, 0.0], [1.0, 1.0]]}, "MultiPoint"),
+        (
+            {
+                "type": "MultiLineString",
+                "coordinates": [[[0.0, 0.0], [1.0, 1.0]]],
+            },
+            "MultiLineString",
+        ),
+        (
+            {
+                "type": "MultiPolygon",
+                "coordinates": [
+                    [[[0.0, 0.0], [2.0, 0.0], [2.0, 2.0], [0.0, 0.0]]]
+                ],
+            },
+            "MultiPolygon",
+        ),
+        (
+            {
+                "type": "GeometryCollection",
+                "geometries": [{"type": "Point", "coordinates": [1.0, 2.0]}],
+            },
+            "GeometryCollection",
+        ),
+        ({"type": "GeometryCollection", "geometries": []}, "Empty"),
+        ({"type": "UnknownThing", "coordinates": []}, "Unknown"),
+    ],
+)
+def test_geometry_type_supports_c1_geojson_subset(geometry: dict, expected: str):
+    assert gis.geometry_type(geometry) == expected
+
+
+def test_geometry_type_reports_mixed_and_empty_from_feature_collections(tmp_path: Path):
+    mixed = _write_geojson(tmp_path / "mixed.geojson", features=_sample_features())
+    empty = _write_geojson(tmp_path / "empty.geojson", features=[])
+
+    assert gis.geometry_type(mixed) == "Mixed"
+    assert gis.geometry_type(empty) == "Empty"
+
+
+def test_raw_feature_and_geometry_helper_paths():
+    raw_geometry = {"type": "Point", "coordinates": [3.0, 4.0]}
+    raw_feature = {
+        "type": "Feature",
+        "properties": {"name": "raw", "value": 7},
+        "geometry": raw_geometry,
+    }
+
+    assert gis.geometry_type(raw_feature) == "Point"
+    assert gis.geometry_type(raw_geometry) == "Point"
+    assert gis.feature_count(raw_feature) == 1
+    assert gis.feature_count(raw_geometry) == 1
+    assert gis.vector_schema(raw_feature) == [
+        {
+            "name": "name",
+            "type": "string",
+            "nullable": False,
+            "width": None,
+            "precision": None,
+        },
+        {
+            "name": "value",
+            "type": "integer",
+            "nullable": False,
+            "width": None,
+            "precision": None,
+        },
+    ]
+    assert gis.vector_bounds(raw_feature) == pytest.approx((3.0, 4.0, 3.0, 4.0))
+    assert gis.vector_bounds(raw_geometry) == pytest.approx((3.0, 4.0, 3.0, 4.0))
+    assert gis.vector_crs(raw_geometry)["missing"] is True
+
+
+def test_feature_count_zero_one_many_filtered_and_limited(tmp_path: Path):
+    empty = _write_geojson(tmp_path / "empty.geojson", features=[])
+    one = _write_geojson(
+        tmp_path / "one.geojson",
+        features=[{"type": "Feature", "properties": {}, "geometry": None}],
+    )
+    many = _write_geojson(tmp_path / "many.geojson", features=_sample_features())
+
+    assert gis.feature_count(empty) == 0
+    assert gis.feature_count(one) == 1
+    assert gis.feature_count(many) == 2
+
+    filtered = gis.read_vector(many, bbox=(100.0, 100.0, 101.0, 101.0))
+    assert gis.feature_count(filtered) == 0
+
+    limited = gis.read_vector(many, limit=1)
+    assert len(limited["features"]) == 1
+    assert gis.feature_count(limited) == 1
+
+    limit_zero = gis.read_vector(many, limit=0)
+    assert limit_zero["features"] == []
+    assert gis.feature_count(limit_zero) == 0
+    assert "empty_feature_set" in _codes(limit_zero["warnings"])
+
+
+def test_vector_bounds_cover_point_and_polygon_sources(tmp_path: Path):
+    point = _write_geojson(
+        tmp_path / "point.geojson",
+        features=[_feature("Point", [2.5, -1.25])],
+    )
+    polygon = _write_geojson(
+        tmp_path / "polygon.geojson",
+        features=[
+            _feature(
+                "Polygon",
+                [[[0.0, -2.0], [4.0, -2.0], [4.0, 5.0], [0.0, -2.0]]],
+            )
+        ],
+    )
+
+    assert gis.vector_bounds(point) == pytest.approx((2.5, -1.25, 2.5, -1.25))
+    assert gis.vector_bounds(polygon) == pytest.approx((0.0, -2.0, 4.0, 5.0))
+
+
+def test_read_vector_missing_path_missing_layer_and_unsupported_driver(tmp_path: Path):
+    with pytest.raises(FileNotFoundError, match="path not found"):
+        gis.read_vector(tmp_path / "missing.geojson")
+
+    path = _write_geojson(tmp_path / "sample.geojson", features=_sample_features())
+    with pytest.raises(ValueError, match="missing_layer"):
+        gis.read_vector(path, layer="absent")
+
+    unsupported = tmp_path / "sample.csv"
+    unsupported.write_text("x,y\n0,0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="unsupported_driver"):
+        gis.read_vector(unsupported)
+
+    backend_required = tmp_path / "sample.gpkg"
+    backend_required.write_bytes(b"not a real gpkg")
+    with pytest.raises(RuntimeError, match="backend_unavailable"):
+        gis.read_vector(backend_required)
+
+
+def test_empty_feature_collection_and_bbox_empty_result_warn(tmp_path: Path):
+    empty_path = _write_geojson(tmp_path / "empty.geojson", features=[])
+    empty = gis.read_vector(empty_path)
+
+    assert empty["features"] == []
+    assert empty["info"]["feature_count"] == 0
+    assert empty["info"]["geometry_type"] == "Empty"
+    assert empty["info"]["bounds"] is None
+    assert "empty_feature_set" in _codes(empty["warnings"])
+    with pytest.raises(ValueError, match="empty_feature_set"):
+        gis.vector_bounds(empty)
+
+    sample_path = _write_geojson(tmp_path / "sample.geojson", features=_sample_features())
+    filtered = gis.read_vector(sample_path, bbox=(100.0, 100.0, 101.0, 101.0))
+
+    assert filtered["features"] == []
+    assert filtered["info"]["feature_count"] == 0
+    assert "empty_feature_set" in _codes(filtered["warnings"])
+
+
+def test_column_filter_updates_features_and_schema(tmp_path: Path):
+    path = _write_geojson(tmp_path / "sample.geojson", features=_sample_features())
+
+    result = gis.read_vector(path, columns=["name"])
+
+    assert [feature["properties"] for feature in result["features"]] == [
+        {"name": "alpha"},
+        {"name": "beta"},
+    ]
+    assert result["info"]["schema"] == [
+        {
+            "name": "name",
+            "type": "string",
+            "nullable": False,
+            "width": None,
+            "precision": None,
+        }
+    ]
+
+
+def test_missing_crs_reports_warning_without_guessing(tmp_path: Path):
+    path = _write_geojson(tmp_path / "missing_crs.geojson", features=_sample_features(), crs=False)
+
+    result = gis.read_vector(path)
+    crs = gis.vector_crs(result)
+
+    assert result["info"]["crs_authority"] is None
+    assert result["info"]["crs_wkt"] is None
+    assert result["info"]["is_georeferenced"] is False
+    assert "missing_crs" in _codes(result["warnings"])
+    assert crs["missing"] is True
+    assert crs["authority"] is None
+    assert "missing_crs" in _codes(crs["warnings"])
+
+
+def test_invalid_crs_metadata_reports_stable_token(tmp_path: Path):
+    path = tmp_path / "invalid_crs.geojson"
+    payload = {
+        "type": "FeatureCollection",
+        "name": "bad_crs",
+        "crs": {"type": "name", "properties": {"name": "EPSG:999999"}},
+        "features": _sample_features(),
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="invalid_crs"):
+        gis.read_vector(path)
+
+
+def test_invalid_geojson_and_structurally_invalid_payload_report_invalid_geometry(tmp_path: Path):
+    bad_json = tmp_path / "bad.geojson"
+    bad_json.write_text("{not-json", encoding="utf-8")
+    with pytest.raises(ValueError, match="invalid_geometry"):
+        gis.read_vector(bad_json)
+
+    bad_payload = tmp_path / "bad_payload.geojson"
+    bad_payload.write_text(
+        json.dumps({"type": "FeatureCollection", "features": [42]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(ValueError, match="invalid_geometry"):
+        gis.read_vector(bad_payload)
+
+
+def test_vector_bounds_order_is_left_bottom_right_top(tmp_path: Path):
+    path = _write_geojson(tmp_path / "bounds.geojson", features=_sample_features())
+
+    left, bottom, right, top = gis.vector_bounds(path)
+
+    assert (left, bottom, right, top) == pytest.approx((0.0, 0.0, 4.0, 5.0))
+    assert left < right
+    assert bottom < top
+
+
+def test_optional_shapely_reference_bounds(tmp_path: Path):
+    shape = pytest.importorskip("shapely.geometry")
+    path = _write_geojson(tmp_path / "sample.geojson", features=_sample_features())
+
+    result = gis.read_vector(path)
+    bounds = [shape.shape(feature["geometry"]).bounds for feature in result["features"]]
+    expected = (
+        min(item[0] for item in bounds),
+        min(item[1] for item in bounds),
+        max(item[2] for item in bounds),
+        max(item[3] for item in bounds),
+    )
+
+    assert result["info"]["bounds"] == pytest.approx(expected)


### PR DESCRIPTION
## Scope summary

Adds the G-002c C1 vector metadata/read foundation with Rust-first GeoJSON support under `src/gis/` and thin Python wrappers over PyO3.

## Public APIs added

- `VectorInfo`
- `read_vector(path, *, layer=None, columns=None, bbox=None, limit=None)`
- `geometry_type(source, *, layer=None)`
- `vector_schema(source, *, layer=None)`
- `feature_count(source, *, layer=None)`
- `vector_crs(source, *, layer=None)`
- `vector_bounds(source, *, layer=None)`

## Files changed

- `python/forge3d/gis.py`
- `python/forge3d/gis.pyi`
- `src/gis/mod.rs`
- `src/gis/vector.rs`
- `src/py_module/classes.rs`
- `src/py_module/functions/gis.rs`
- `tests/test_api_contracts.py`
- `tests/test_gis_raster.py`
- `tests/test_gis_vector_io.py`

## C1 limitations

- Pure Rust GeoJSON/JSON baseline only.
- Unsupported non-GeoJSON drivers raise stable `unsupported_driver` or `backend_unavailable` diagnostics.
- Missing CRS is reported as `missing_crs` and never guessed.
- Bounds order is always `(left, bottom, right, top)`.
- Geometry inspection is structural only.

## Explicit non-goals

This PR does not include C2-C6 work: no `reproject_vector`, geometry validation/repair/measurement/mutation, overlay operations, rasterization, masks, thematic raster helpers, vector writes, examples, rendering behavior, visual goldens, remote/cache behavior, OSM, Terrarium, slippy tiles, domain helpers, or network travel-time analysis.

## Validation

All commands passed:

- `cargo fmt --check`
- `cargo check`
- `cargo check --features extension-module weighted-oit enable-tbn enable-gpu-instancing copc_laz`
- `python3 -m py_compile python/forge3d/gis.py`
- `python3 -m pytest tests/test_gis_vector_io.py -v` -> 23 passed
- `python3 -m pytest tests/test_api_contracts.py -v` -> 260 passed, 7 skipped
- `python3 -m pytest tests/test_gis_raster.py::test_public_gis_wrapper_surface tests/test_gis_raster.py::test_public_gis_all_matches_stub_exports tests/test_gis_crs_affine.py::test_python_gis_module_has_no_backend_gis_libraries tests/test_gis_crs_affine.py::test_gis_stub_exposes_runtime_api -v` -> 4 passed

Validation used `XDG_CACHE_HOME=/private/tmp/forge3d-g002c-c1-precommit-validation.ulrTty/xdg-cache` for Python commands to reduce local cache/fontconfig noise.

## Review bundle

`/private/tmp/forge3d-g002c-c1-pr-ready.h6EFbt`

## Next phase

C2 is not included. Next recommended implementation phase after C1 review and merge: C2 vector CRS / `reproject_vector` only.
