### PR TITLE
G-002c C2 vector reprojection

### DIFF
--- a/python/forge3d/gis.py
+++ b/python/forge3d/gis.py
@@ -83,6 +83,15 @@ def read_vector(
     )
 
 
+def reproject_vector(
+    input: os.PathLike[str] | str | dict[str, Any],
+    dst_crs: str | int | dict[str, Any],
+    src_crs: str | int | dict[str, Any] | None = None,
+):
+    """Reproject a vector FeatureCollection through the native built-in CRS path."""
+    return _require_native().reproject_vector(_path_or_self(input), dst_crs, src_crs)
+
+
 def geometry_type(source: os.PathLike[str] | str | Any, *, layer: str | None = None) -> str:
     """Return a stable geometry type string for a vector source or GeoJSON-like object."""
     return _require_native().geometry_type(_path_or_self(source), layer=layer)
@@ -412,6 +421,7 @@ __all__ = [
     "read_raster_info",
     "read_raster",
     "read_vector",
+    "reproject_vector",
     "geometry_type",
     "vector_schema",
     "feature_count",

--- a/python/forge3d/gis.pyi
+++ b/python/forge3d/gis.pyi
@@ -140,6 +140,13 @@ def read_vector(
 ) -> dict[str, Any]: ...
 
 
+def reproject_vector(
+    input: os.PathLike[str] | str | dict[str, Any],
+    dst_crs: str | int | dict[str, Any],
+    src_crs: str | int | dict[str, Any] | None = ...,
+) -> dict[str, Any]: ...
+
+
 def geometry_type(
     source: os.PathLike[str] | str | VectorInfo | dict[str, Any],
     *,

--- a/src/gis/error.rs
+++ b/src/gis/error.rs
@@ -16,6 +16,7 @@ pub enum GisError {
     MissingTransform(String),
     InvalidNodata(String),
     InvalidArgument(String),
+    InvalidGeometry(String),
     InvalidBounds(String),
     MissingCrs(String),
     CrsAlreadyExists(String),
@@ -45,6 +46,7 @@ impl GisError {
             GisError::MissingTransform(_) => "MissingTransform",
             GisError::InvalidNodata(_) => "InvalidNodata",
             GisError::InvalidArgument(_) => "InvalidArgument",
+            GisError::InvalidGeometry(_) => "InvalidGeometry",
             GisError::InvalidBounds(_) => "InvalidBounds",
             GisError::MissingCrs(_) => "MissingCrs",
             GisError::CrsAlreadyExists(_) => "CrsAlreadyExists",
@@ -73,6 +75,7 @@ impl GisError {
             | GisError::MissingTransform(message)
             | GisError::InvalidNodata(message)
             | GisError::InvalidArgument(message)
+            | GisError::InvalidGeometry(message)
             | GisError::InvalidBounds(message)
             | GisError::MissingCrs(message)
             | GisError::CrsAlreadyExists(message)
@@ -138,6 +141,7 @@ impl From<GisError> for pyo3::PyErr {
             | GisError::MissingTransform(_)
             | GisError::InvalidNodata(_)
             | GisError::InvalidArgument(_)
+            | GisError::InvalidGeometry(_)
             | GisError::InvalidBounds(_)
             | GisError::MissingCrs(_)
             | GisError::CrsAlreadyExists(_)

--- a/src/gis/mod.rs
+++ b/src/gis/mod.rs
@@ -17,10 +17,13 @@ pub use raster_write::{
 pub use types::{AffineTransform, RasterBounds, RasterDType, RasterInfo, RasterWarning};
 #[cfg(feature = "extension-module")]
 pub use vector::{
-    feature_count_py, geometry_type_py, read_vector_py, vector_bounds_py, vector_crs_py,
-    vector_schema_py,
+    feature_count_py, geometry_type_py, read_vector_py, reproject_vector_py, vector_bounds_py,
+    vector_crs_py, vector_schema_py,
 };
-pub use vector::{read_vector, read_vector_info, VectorInfo, VectorReadOptions, VectorReadResult};
+pub use vector::{
+    read_vector, read_vector_info, reproject_vector, VectorInfo, VectorReadOptions,
+    VectorReadResult, VectorReprojectInput, VectorReprojectResult,
+};
 pub use warp::{align_raster_to, assign_crs, reproject_raster, resample_array, resample_raster};
 
 #[cfg(feature = "extension-module")]
@@ -754,7 +757,7 @@ fn looks_like_dataset_path(value: &str) -> bool {
 }
 
 #[cfg(feature = "extension-module")]
-fn extract_crs(crs: Option<&Bound<'_, PyAny>>) -> PyResult<Option<CrsSpec>> {
+pub(crate) fn extract_crs(crs: Option<&Bound<'_, PyAny>>) -> PyResult<Option<CrsSpec>> {
     let Some(crs) = crs else {
         return Ok(None);
     };
@@ -797,7 +800,7 @@ fn extract_crs(crs: Option<&Bound<'_, PyAny>>) -> PyResult<Option<CrsSpec>> {
 }
 
 #[cfg(feature = "extension-module")]
-fn extract_required_crs(crs: Option<&Bound<'_, PyAny>>) -> PyResult<CrsSpec> {
+pub(crate) fn extract_required_crs(crs: Option<&Bound<'_, PyAny>>) -> PyResult<CrsSpec> {
     extract_crs(crs)?.ok_or_else(|| {
         GisError::MissingCrs("missing_crs: CRS argument is required".to_string()).into()
     })

--- a/src/gis/vector.rs
+++ b/src/gis/vector.rs
@@ -1,8 +1,8 @@
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
-use serde_json::{Map, Value};
+use serde_json::{Map, Number, Value};
 
 use crate::gis::affine::validate_bounds_tuple;
 use crate::gis::crs;
@@ -11,6 +11,7 @@ use crate::gis::raster_write::CrsSpec;
 use crate::gis::types::{RasterBounds, RasterWarning, WARNING_MISSING_CRS};
 
 pub const WARNING_EMPTY_FEATURE_SET: &str = "empty_feature_set";
+pub const WARNING_EMPTY_GEOMETRY: &str = "empty_geometry";
 pub const WARNING_INVALID_GEOMETRY: &str = "invalid_geometry";
 
 #[derive(Debug, Clone, PartialEq)]
@@ -54,6 +55,27 @@ pub struct VectorReadOptions {
 pub struct VectorReadResult {
     pub features: Vec<Value>,
     pub info: VectorInfo,
+    pub warnings: Vec<RasterWarning>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum VectorReprojectInput {
+    Path(PathBuf),
+    Features {
+        features: Vec<Value>,
+        info: Option<VectorInfo>,
+        geojson_crs: Option<CrsSpec>,
+    },
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VectorReprojectResult {
+    pub features: Vec<Value>,
+    pub info: VectorInfo,
+    pub src_crs: CrsSpec,
+    pub dst_crs: CrsSpec,
+    pub bounds: Option<(f64, f64, f64, f64)>,
+    pub feature_count: u64,
     pub warnings: Vec<RasterWarning>,
 }
 
@@ -152,6 +174,430 @@ pub fn read_vector_info(path: impl AsRef<Path>, layer: Option<String>) -> GisRes
         },
     )?
     .info)
+}
+
+pub fn reproject_vector(
+    input: VectorReprojectInput,
+    dst_crs: CrsSpec,
+    src_crs: Option<CrsSpec>,
+) -> GisResult<VectorReprojectResult> {
+    let (features, info, geojson_crs) = match input {
+        VectorReprojectInput::Path(path) => {
+            let result = read_vector(
+                &path,
+                VectorReadOptions {
+                    layer: None,
+                    columns: None,
+                    bbox: None,
+                    limit: None,
+                },
+            )?;
+            let geojson_crs = crs_spec_from_vector_info(&result.info)?;
+            (result.features, Some(result.info), geojson_crs)
+        }
+        VectorReprojectInput::Features {
+            features,
+            info,
+            geojson_crs,
+        } => {
+            let features = features
+                .iter()
+                .map(normalize_reproject_feature)
+                .collect::<GisResult<Vec<_>>>()?;
+            (features, info, geojson_crs)
+        }
+    };
+    let metadata_crs = vector_metadata_crs(info.as_ref(), geojson_crs)?;
+    let src_crs = resolve_vector_source_crs(src_crs, metadata_crs)?;
+
+    let mut warnings = Vec::new();
+    if features.is_empty() {
+        warnings.push(RasterWarning::new(
+            WARNING_EMPTY_FEATURE_SET,
+            "vector source has zero features",
+            Some("features"),
+        ));
+    }
+
+    let mut out_features = Vec::with_capacity(features.len());
+    for feature in &features {
+        out_features.push(reproject_feature(
+            feature,
+            &src_crs,
+            &dst_crs,
+            &mut warnings,
+        )?);
+    }
+
+    let bounds = bounds_for_features(&out_features).map(RasterBounds::tuple);
+    let feature_count = out_features.len() as u64;
+    let out_info =
+        build_reprojected_vector_info(info.as_ref(), &out_features, &dst_crs, warnings.clone());
+
+    Ok(VectorReprojectResult {
+        features: out_features,
+        info: out_info,
+        src_crs,
+        dst_crs,
+        bounds,
+        feature_count,
+        warnings,
+    })
+}
+
+#[cfg(feature = "extension-module")]
+fn normalize_reproject_features(root: &Value) -> GisResult<Vec<Value>> {
+    match root.get("type").and_then(Value::as_str) {
+        Some("FeatureCollection") => normalize_feature_array(root),
+        None if root.get("features").is_some() => normalize_feature_array(root),
+        _ => normalize_features(root),
+    }
+}
+
+#[cfg(feature = "extension-module")]
+fn normalize_feature_array(root: &Value) -> GisResult<Vec<Value>> {
+    let features = root
+        .get("features")
+        .and_then(Value::as_array)
+        .ok_or_else(|| {
+            GisError::InvalidGeometry(
+                "invalid_geometry: FeatureCollection requires a features array".to_string(),
+            )
+        })?;
+    features.iter().map(normalize_reproject_feature).collect()
+}
+
+fn normalize_reproject_feature(value: &Value) -> GisResult<Value> {
+    normalize_feature(value).map_err(invalid_argument_to_invalid_geometry)
+}
+
+fn invalid_argument_to_invalid_geometry(err: GisError) -> GisError {
+    match err {
+        GisError::InvalidArgument(message) if message.contains(WARNING_INVALID_GEOMETRY) => {
+            GisError::InvalidGeometry(message)
+        }
+        other => other,
+    }
+}
+
+fn vector_metadata_crs(
+    info: Option<&VectorInfo>,
+    geojson_crs: Option<CrsSpec>,
+) -> GisResult<Option<CrsSpec>> {
+    let info_crs = info.map(crs_spec_from_vector_info).transpose()?.flatten();
+    match (info_crs, geojson_crs) {
+        (Some(info_crs), Some(geojson_crs)) => {
+            if crs::crs_equal(&info_crs, &geojson_crs) {
+                Ok(Some(info_crs))
+            } else {
+                Err(GisError::CrsMismatch(format!(
+                    "CrsMismatch: input info CRS {} conflicts with GeoJSON CRS {}",
+                    crs::canonical_label(&info_crs)?,
+                    crs::canonical_label(&geojson_crs)?
+                )))
+            }
+        }
+        (Some(info_crs), None) => Ok(Some(info_crs)),
+        (None, Some(geojson_crs)) => Ok(Some(geojson_crs)),
+        (None, None) => Ok(None),
+    }
+}
+
+fn resolve_vector_source_crs(
+    explicit: Option<CrsSpec>,
+    metadata: Option<CrsSpec>,
+) -> GisResult<CrsSpec> {
+    match (explicit, metadata) {
+        (Some(explicit), Some(metadata)) => {
+            if crs::crs_equal(&explicit, &metadata) {
+                Ok(explicit)
+            } else {
+                Err(GisError::CrsMismatch(format!(
+                    "CrsMismatch: explicit src_crs {} conflicts with input CRS metadata {}",
+                    crs::canonical_label(&explicit)?,
+                    crs::canonical_label(&metadata)?
+                )))
+            }
+        }
+        (Some(explicit), None) => Ok(explicit),
+        (None, Some(metadata)) => Ok(metadata),
+        (None, None) => Err(GisError::MissingCrs(
+            "missing_crs: vector source has no CRS metadata; provide src_crs".to_string(),
+        )),
+    }
+}
+
+fn crs_spec_from_vector_info(info: &VectorInfo) -> GisResult<Option<CrsSpec>> {
+    if let Some(authority) = info.crs_authority.as_ref() {
+        let name = authority.get("name").cloned().ok_or_else(|| {
+            GisError::InvalidCrs("invalid_crs: vector CRS authority is missing name".to_string())
+        })?;
+        let code = authority.get("code").cloned().ok_or_else(|| {
+            GisError::InvalidCrs("invalid_crs: vector CRS authority is missing code".to_string())
+        })?;
+        return CrsSpec::from_parts(Some(name), Some(code), None).map(Some);
+    }
+    info.crs_wkt
+        .clone()
+        .map(|wkt| CrsSpec::from_parts(None, None, Some(wkt)))
+        .transpose()
+}
+
+fn reproject_feature(
+    feature: &Value,
+    src: &CrsSpec,
+    dst: &CrsSpec,
+    warnings: &mut Vec<RasterWarning>,
+) -> GisResult<Value> {
+    let object = feature.as_object().ok_or_else(|| {
+        GisError::InvalidGeometry("invalid_geometry: feature must be an object".to_string())
+    })?;
+    if object.get("type").and_then(Value::as_str) != Some("Feature") {
+        return Err(GisError::InvalidGeometry(
+            "invalid_geometry: features must be Feature objects".to_string(),
+        ));
+    }
+
+    let mut out = object.clone();
+    let geometry = object.get("geometry").unwrap_or(&Value::Null);
+    out.insert(
+        "geometry".to_string(),
+        reproject_geometry(geometry, src, dst, warnings)?,
+    );
+    let transformed = Value::Object(out.clone());
+    update_bbox_member(&mut out, feature_bounds(&transformed))?;
+    Ok(Value::Object(out))
+}
+
+fn reproject_geometry(
+    geometry: &Value,
+    src: &CrsSpec,
+    dst: &CrsSpec,
+    warnings: &mut Vec<RasterWarning>,
+) -> GisResult<Value> {
+    if geometry.is_null() {
+        warning_once(
+            warnings,
+            WARNING_EMPTY_GEOMETRY,
+            "vector feature has null or empty geometry",
+            Some("geometry"),
+        );
+        return Ok(Value::Null);
+    }
+    let object = geometry.as_object().ok_or_else(|| {
+        GisError::InvalidGeometry("invalid_geometry: geometry must be an object".to_string())
+    })?;
+    let kind = object.get("type").and_then(Value::as_str).ok_or_else(|| {
+        GisError::InvalidGeometry("invalid_geometry: geometry requires a type string".to_string())
+    })?;
+
+    if kind == "GeometryCollection" {
+        let geometries = object
+            .get("geometries")
+            .and_then(Value::as_array)
+            .ok_or_else(|| {
+                GisError::InvalidGeometry(
+                    "invalid_geometry: GeometryCollection requires a geometries array".to_string(),
+                )
+            })?;
+        if geometries.is_empty() {
+            warning_once(
+                warnings,
+                WARNING_EMPTY_GEOMETRY,
+                "vector feature has null or empty geometry",
+                Some("geometry"),
+            );
+        }
+        let mut out = object.clone();
+        let transformed = geometries
+            .iter()
+            .map(|geometry| reproject_geometry(geometry, src, dst, warnings))
+            .collect::<GisResult<Vec<_>>>()?;
+        out.insert("geometries".to_string(), Value::Array(transformed));
+        let transformed_geometry = Value::Object(out.clone());
+        update_bbox_member(&mut out, geometry_bounds(&transformed_geometry))?;
+        return Ok(Value::Object(out));
+    }
+
+    if !matches!(
+        kind,
+        "Point" | "LineString" | "Polygon" | "MultiPoint" | "MultiLineString" | "MultiPolygon"
+    ) {
+        return Err(GisError::InvalidGeometry(format!(
+            "invalid_geometry: unsupported geometry type {kind:?}"
+        )));
+    }
+
+    let coordinates = object.get("coordinates").ok_or_else(|| {
+        GisError::InvalidGeometry("invalid_geometry: geometry requires coordinates".to_string())
+    })?;
+    let mut out = object.clone();
+    if coordinates_are_empty(coordinates) {
+        warning_once(
+            warnings,
+            WARNING_EMPTY_GEOMETRY,
+            "vector feature has null or empty geometry",
+            Some("geometry"),
+        );
+        out.insert("coordinates".to_string(), coordinates.clone());
+    } else {
+        out.insert(
+            "coordinates".to_string(),
+            reproject_coordinates_for_geometry_type(kind, coordinates, src, dst)?,
+        );
+    }
+    let transformed_geometry = Value::Object(out.clone());
+    update_bbox_member(&mut out, geometry_bounds(&transformed_geometry))?;
+    Ok(Value::Object(out))
+}
+
+fn reproject_coordinates_for_geometry_type(
+    kind: &str,
+    coordinates: &Value,
+    src: &CrsSpec,
+    dst: &CrsSpec,
+) -> GisResult<Value> {
+    match kind {
+        "Point" => reproject_position(coordinates, src, dst),
+        "LineString" | "MultiPoint" => reproject_position_nested(coordinates, 1, src, dst),
+        "Polygon" | "MultiLineString" => reproject_position_nested(coordinates, 2, src, dst),
+        "MultiPolygon" => reproject_position_nested(coordinates, 3, src, dst),
+        _ => Err(GisError::InvalidGeometry(format!(
+            "invalid_geometry: unsupported geometry type {kind:?}"
+        ))),
+    }
+}
+
+fn reproject_position_nested(
+    value: &Value,
+    depth: usize,
+    src: &CrsSpec,
+    dst: &CrsSpec,
+) -> GisResult<Value> {
+    if depth == 0 {
+        return reproject_position(value, src, dst);
+    }
+    let items = value.as_array().ok_or_else(|| {
+        GisError::InvalidGeometry(
+            "invalid_geometry: coordinate nesting does not match geometry type".to_string(),
+        )
+    })?;
+    if items.is_empty() {
+        return Err(GisError::InvalidGeometry(
+            "invalid_geometry: nested coordinate arrays must not be empty".to_string(),
+        ));
+    }
+    items
+        .iter()
+        .map(|item| reproject_position_nested(item, depth - 1, src, dst))
+        .collect::<GisResult<Vec<_>>>()
+        .map(Value::Array)
+}
+
+fn reproject_position(position: &Value, src: &CrsSpec, dst: &CrsSpec) -> GisResult<Value> {
+    let items = position.as_array().ok_or_else(|| {
+        GisError::InvalidGeometry("invalid_geometry: position must be an array".to_string())
+    })?;
+    if items.len() < 2 {
+        return Err(GisError::InvalidGeometry(
+            "invalid_geometry: position requires at least x and y".to_string(),
+        ));
+    }
+    let x = finite_coordinate(&items[0], "x")?;
+    let y = finite_coordinate(&items[1], "y")?;
+    let (x, y) = crs::transform_point(x, y, src, dst)?;
+    let mut out = items.clone();
+    out[0] = finite_json_number(x)?;
+    out[1] = finite_json_number(y)?;
+    Ok(Value::Array(out))
+}
+
+fn finite_coordinate(value: &Value, axis: &str) -> GisResult<f64> {
+    let number = value.as_f64().ok_or_else(|| {
+        GisError::InvalidGeometry(format!(
+            "invalid_geometry: coordinate {axis} must be numeric"
+        ))
+    })?;
+    if !number.is_finite() {
+        return Err(GisError::InvalidGeometry(format!(
+            "invalid_geometry: coordinate {axis} must be finite"
+        )));
+    }
+    Ok(number)
+}
+
+fn finite_json_number(value: f64) -> GisResult<Value> {
+    Number::from_f64(value).map(Value::Number).ok_or_else(|| {
+        GisError::InvalidGeometry(
+            "invalid_geometry: transformed coordinate is not finite".to_string(),
+        )
+    })
+}
+
+fn update_bbox_member(
+    object: &mut Map<String, Value>,
+    bounds: Option<RasterBounds>,
+) -> GisResult<()> {
+    if !object.contains_key("bbox") {
+        return Ok(());
+    }
+    match bounds {
+        Some(bounds) => {
+            object.insert("bbox".to_string(), bbox_value(bounds)?);
+        }
+        None => {
+            object.remove("bbox");
+        }
+    }
+    Ok(())
+}
+
+fn bbox_value(bounds: RasterBounds) -> GisResult<Value> {
+    Ok(Value::Array(vec![
+        finite_json_number(bounds.left)?,
+        finite_json_number(bounds.bottom)?,
+        finite_json_number(bounds.right)?,
+        finite_json_number(bounds.top)?,
+    ]))
+}
+
+fn build_reprojected_vector_info(
+    base: Option<&VectorInfo>,
+    features: &[Value],
+    dst: &CrsSpec,
+    warnings: Vec<RasterWarning>,
+) -> VectorInfo {
+    let bounds = bounds_for_features(features).map(RasterBounds::tuple);
+    let crs_wkt = dst.wkt.clone();
+    let crs_authority = crs::authority_map(dst);
+    VectorInfo {
+        path: base.map(|info| info.path.clone()).unwrap_or_default(),
+        driver: base
+            .map(|info| info.driver.clone())
+            .unwrap_or_else(|| "GeoJSON".to_string()),
+        layer_name: base.and_then(|info| info.layer_name.clone()),
+        layer_count: base.map(|info| info.layer_count).unwrap_or(1),
+        geometry_type: geometry_type_for_features(features),
+        feature_count: features.len() as u64,
+        schema: infer_schema(features),
+        crs_wkt,
+        crs_authority,
+        bounds,
+        is_georeferenced: bounds.is_some(),
+        warnings,
+    }
+}
+
+fn warning_once(
+    warnings: &mut Vec<RasterWarning>,
+    code: &'static str,
+    message: &str,
+    field: Option<&'static str>,
+) {
+    if warnings.iter().any(|warning| warning.code == code) {
+        return;
+    }
+    warnings.push(RasterWarning::new(code, message, field));
 }
 
 fn validate_vector_path(path: &Path) -> GisResult<()> {
@@ -503,6 +949,112 @@ fn bounds_intersects(left: RasterBounds, right: RasterBounds) -> bool {
         && left.top >= right.bottom
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn epsg(code: &str) -> CrsSpec {
+        CrsSpec::from_string(format!("EPSG:{code}")).expect("valid test CRS")
+    }
+
+    fn coordinate(value: &Value, index: usize) -> f64 {
+        value
+            .as_array()
+            .and_then(|items| items.get(index))
+            .and_then(Value::as_f64)
+            .expect("numeric coordinate")
+    }
+
+    #[test]
+    fn reproject_position_preserves_extra_ordinates() {
+        let src = epsg("4326");
+        let dst = epsg("3857");
+
+        let out = reproject_position(&json!([1.0, 1.0, 42.0, "kept"]), &src, &dst)
+            .expect("position reprojects");
+
+        assert!((coordinate(&out, 0) - 111_319.490_793_273_57).abs() < 1e-6);
+        assert!((coordinate(&out, 1) - 111_325.142_866_385_1).abs() < 1e-6);
+        assert_eq!(out[2], json!(42.0));
+        assert_eq!(out[3], json!("kept"));
+    }
+
+    #[test]
+    fn resolve_vector_source_crs_errors_when_missing() {
+        let err = resolve_vector_source_crs(None, None).expect_err("missing CRS must fail");
+
+        assert!(matches!(err, GisError::MissingCrs(_)));
+        assert!(err.to_string().contains("missing_crs"));
+    }
+
+    #[test]
+    fn resolve_vector_source_crs_rejects_conflict() {
+        let err = resolve_vector_source_crs(Some(epsg("3857")), Some(epsg("4326")))
+            .expect_err("conflicting source CRS must fail");
+
+        assert!(matches!(err, GisError::CrsMismatch(_)));
+    }
+
+    #[test]
+    fn reproject_geometry_collection_recurses() {
+        let src = epsg("4326");
+        let dst = epsg("3857");
+        let geometry = json!({
+            "type": "GeometryCollection",
+            "geometries": [
+                {"type": "Point", "coordinates": [1.0, 1.0]},
+                {"type": "LineString", "coordinates": [[0.0, 0.0], [1.0, 1.0]]}
+            ]
+        });
+        let mut warnings = Vec::new();
+
+        let out = reproject_geometry(&geometry, &src, &dst, &mut warnings)
+            .expect("collection reprojects");
+
+        assert!(
+            (out["geometries"][0]["coordinates"][0].as_f64().unwrap() - 111_319.490_793_273_57)
+                .abs()
+                < 1e-6
+        );
+        assert!(
+            (out["geometries"][1]["coordinates"][1][1].as_f64().unwrap() - 111_325.142_866_385_1)
+                .abs()
+                < 1e-6
+        );
+        assert!(warnings.is_empty());
+    }
+
+    #[test]
+    fn same_crs_reprojection_is_copy_with_destination_metadata() {
+        let crs = epsg("4326");
+        let feature = json!({
+            "type": "Feature",
+            "id": "point-a",
+            "properties": {"name": "alpha"},
+            "geometry": {"type": "Point", "coordinates": [1.0, 2.0]}
+        });
+
+        let result = reproject_vector(
+            VectorReprojectInput::Features {
+                features: vec![feature],
+                info: None,
+                geojson_crs: Some(crs.clone()),
+            },
+            crs,
+            None,
+        )
+        .expect("same-CRS reprojection succeeds");
+
+        assert_eq!(
+            result.features[0]["geometry"]["coordinates"],
+            json!([1.0, 2.0])
+        );
+        assert_eq!(result.info.crs_authority, crs::authority_map(&epsg("4326")));
+        assert_eq!(result.feature_count, 1);
+    }
+}
+
 #[cfg(feature = "extension-module")]
 mod py {
     use super::*;
@@ -690,6 +1242,20 @@ mod py {
             })
     }
 
+    #[pyfunction(name = "reproject_vector", signature = (input, dst_crs, src_crs = None))]
+    pub fn reproject_vector_py(
+        py: Python<'_>,
+        input: &Bound<'_, PyAny>,
+        dst_crs: &Bound<'_, PyAny>,
+        src_crs: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<PyObject> {
+        let dst_crs = crate::gis::extract_required_crs(Some(dst_crs))?;
+        let src_crs = crate::gis::extract_crs(src_crs)?;
+        let input = reproject_input_from_py(input)?;
+        let result = reproject_vector(input, dst_crs, src_crs)?;
+        vector_reproject_result_to_py(py, &result)
+    }
+
     fn vector_read_result_to_py(py: Python<'_>, result: &VectorReadResult) -> PyResult<PyObject> {
         let dict = PyDict::new_bound(py);
         dict.set_item("type", "FeatureCollection")?;
@@ -700,6 +1266,39 @@ mod py {
         dict.set_item("info", vector_info_to_py_dict(py, &result.info)?)?;
         dict.set_item("vector_info", Py::new(py, result.info.clone())?)?;
         dict.set_item("warnings", warnings_to_py(py, &result.warnings)?)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn vector_reproject_result_to_py(
+        py: Python<'_>,
+        result: &VectorReprojectResult,
+    ) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item("type", "FeatureCollection")?;
+        dict.set_item(
+            "features",
+            json_to_py(py, &Value::Array(result.features.clone()))?,
+        )?;
+        dict.set_item("info", vector_info_to_py_dict(py, &result.info)?)?;
+        dict.set_item("vector_info", Py::new(py, result.info.clone())?)?;
+        dict.set_item("src_crs", crs_spec_to_py(py, &result.src_crs, "crs")?)?;
+        dict.set_item("dst_crs", crs_spec_to_py(py, &result.dst_crs, "crs")?)?;
+        dict.set_item("bounds", result.bounds)?;
+        dict.set_item("feature_count", result.feature_count)?;
+        dict.set_item("warnings", warnings_to_py(py, &result.warnings)?)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn crs_spec_to_py(py: Python<'_>, spec: &CrsSpec, source_kind: &str) -> PyResult<PyObject> {
+        let inspection = crs::inspect_crs_spec(spec, source_kind);
+        let dict = PyDict::new_bound(py);
+        dict.set_item("source_kind", inspection.source_kind)?;
+        dict.set_item("missing", inspection.missing)?;
+        dict.set_item("wkt", inspection.wkt)?;
+        dict.set_item("authority", inspection.authority)?;
+        dict.set_item("axis_order", inspection.axis_order)?;
+        dict.set_item("axis_order_policy", inspection.axis_order_policy)?;
+        dict.set_item("warnings", warnings_to_py(py, &inspection.warnings)?)?;
         Ok(dict.into_py(py))
     }
 
@@ -718,6 +1317,85 @@ mod py {
         dict.set_item("is_georeferenced", info.is_georeferenced)?;
         dict.set_item("warnings", warnings_to_py(py, &info.warnings)?)?;
         Ok(dict.into_py(py))
+    }
+
+    fn reproject_input_from_py(source: &Bound<'_, PyAny>) -> PyResult<VectorReprojectInput> {
+        if source.extract::<PyRef<'_, VectorInfo>>().is_ok() {
+            return Err(GisError::InvalidArgument(
+                "feature payload is required; VectorInfo alone cannot be reprojected".to_string(),
+            )
+            .into());
+        }
+        if let Ok(path) = source.extract::<String>() {
+            return Ok(VectorReprojectInput::Path(PathBuf::from(path)));
+        }
+        let dict = source.downcast::<PyDict>().map_err(|_| {
+            GisError::InvalidArgument(
+                "input must be a vector path, read_vector result, or GeoJSON-like dict".to_string(),
+            )
+        })?;
+        if is_info_dict(dict)? && !dict.contains("features")? {
+            return Err(GisError::InvalidArgument(
+                "feature payload is required; VectorInfo metadata alone cannot be reprojected"
+                    .to_string(),
+            )
+            .into());
+        }
+        let info = reproject_info_from_dict(dict)?;
+        let root = reproject_source_json(source)?;
+        let geojson_crs = geojson_crs(&root)?;
+        let features = normalize_reproject_features(&root)?;
+        Ok(VectorReprojectInput::Features {
+            features,
+            info,
+            geojson_crs,
+        })
+    }
+
+    fn reproject_info_from_dict(dict: &Bound<'_, PyDict>) -> PyResult<Option<VectorInfo>> {
+        if let Some(vector_info) = dict.get_item("vector_info")? {
+            if vector_info.is_none() {
+                return Ok(None);
+            }
+            return vector_info_from_info_value(&vector_info).map(Some);
+        }
+        if let Some(info) = dict.get_item("info")? {
+            if info.is_none() {
+                return Ok(None);
+            }
+            return vector_info_from_info_value(&info).map(Some);
+        }
+        Ok(None)
+    }
+
+    fn reproject_source_json(source: &Bound<'_, PyAny>) -> PyResult<Value> {
+        if let Ok(dict) = source.downcast::<PyDict>() {
+            let type_name = dict
+                .get_item("type")?
+                .map(|value| value.extract::<String>())
+                .transpose()
+                .ok()
+                .flatten();
+            if type_name.as_deref() == Some("FeatureCollection")
+                || (type_name.is_none() && dict.contains("features")?)
+            {
+                let mut out = Map::new();
+                if let Some(type_value) = dict.get_item("type")? {
+                    out.insert("type".to_string(), py_to_json_strict(&type_value)?);
+                }
+                if let Some(features) = dict.get_item("features")? {
+                    out.insert("features".to_string(), py_to_json_strict(&features)?);
+                }
+                if let Some(crs) = dict.get_item("crs")? {
+                    out.insert("crs".to_string(), py_to_json_strict(&crs)?);
+                }
+                if let Some(bbox) = dict.get_item("bbox")? {
+                    out.insert("bbox".to_string(), py_to_json_strict(&bbox)?);
+                }
+                return Ok(Value::Object(out));
+            }
+        }
+        py_to_json_strict(source)
     }
 
     fn vector_crs_to_py(py: Python<'_>, info: &VectorInfo) -> PyResult<PyObject> {
@@ -1060,6 +1738,62 @@ mod py {
         .into())
     }
 
+    fn py_to_json_strict(value: &Bound<'_, PyAny>) -> PyResult<Value> {
+        if value.is_none() {
+            return Ok(Value::Null);
+        }
+        if let Ok(value) = value.extract::<bool>() {
+            return Ok(Value::Bool(value));
+        }
+        if let Ok(value) = value.extract::<i64>() {
+            return Ok(Value::Number(value.into()));
+        }
+        if let Ok(value) = value.extract::<u64>() {
+            return Ok(Value::Number(value.into()));
+        }
+        if let Ok(value) = value.extract::<f64>() {
+            return Number::from_f64(value).map(Value::Number).ok_or_else(|| {
+                GisError::InvalidGeometry(
+                    "invalid_geometry: JSON numbers must be finite".to_string(),
+                )
+                .into()
+            });
+        }
+        if let Ok(value) = value.extract::<String>() {
+            return Ok(Value::String(value));
+        }
+        if let Ok(dict) = value.downcast::<PyDict>() {
+            let mut out = Map::new();
+            for (key, item) in dict.iter() {
+                let key = key.extract::<String>().map_err(|_| {
+                    GisError::InvalidGeometry(
+                        "invalid_geometry: JSON object keys must be strings".to_string(),
+                    )
+                })?;
+                out.insert(key, py_to_json_strict(&item)?);
+            }
+            return Ok(Value::Object(out));
+        }
+        if let Ok(list) = value.downcast::<PyList>() {
+            return list
+                .iter()
+                .map(|item| py_to_json_strict(&item))
+                .collect::<PyResult<Vec<_>>>()
+                .map(Value::Array);
+        }
+        if let Ok(tuple) = value.downcast::<PyTuple>() {
+            return tuple
+                .iter()
+                .map(|item| py_to_json_strict(&item))
+                .collect::<PyResult<Vec<_>>>()
+                .map(Value::Array);
+        }
+        Err(GisError::InvalidGeometry(
+            "invalid_geometry: GeoJSON values must be JSON-compatible".to_string(),
+        )
+        .into())
+    }
+
     fn json_to_py(py: Python<'_>, value: &Value) -> PyResult<PyObject> {
         match value {
             Value::Null => Ok(py.None()),
@@ -1096,6 +1830,6 @@ mod py {
 
 #[cfg(feature = "extension-module")]
 pub use py::{
-    feature_count_py, geometry_type_py, read_vector_py, vector_bounds_py, vector_crs_py,
-    vector_schema_py,
+    feature_count_py, geometry_type_py, read_vector_py, reproject_vector_py, vector_bounds_py,
+    vector_crs_py, vector_schema_py,
 };

--- a/src/py_module/functions/gis.rs
+++ b/src/py_module/functions/gis.rs
@@ -6,6 +6,7 @@ pub(crate) fn register_gis_py_functions(m: &Bound<'_, PyModule>) -> PyResult<()>
     m.add_function(wrap_pyfunction!(crate::gis::read_raster_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::write_raster_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::read_vector_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::reproject_vector_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::geometry_type_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::vector_schema_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::feature_count_py, m)?)?;

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -128,6 +128,7 @@ class TestNativeModuleSymbols:
         "read_raster",
         "write_raster",
         "read_vector",
+        "reproject_vector",
         "geometry_type",
         "vector_schema",
         "feature_count",

--- a/tests/test_gis_crs_affine.py
+++ b/tests/test_gis_crs_affine.py
@@ -84,6 +84,7 @@ def test_gis_stub_exposes_runtime_api():
         "assert_grid_compatible",
         "align_raster_grid",
         "align_raster_to",
+        "reproject_vector",
         "reproject_raster",
         "calculate_default_transform",
         "read_raster_window",

--- a/tests/test_gis_raster.py
+++ b/tests/test_gis_raster.py
@@ -122,6 +122,7 @@ def test_public_gis_wrapper_surface():
         "read_raster_info",
         "read_raster",
         "read_vector",
+        "reproject_vector",
         "geometry_type",
         "vector_schema",
         "feature_count",
@@ -162,6 +163,7 @@ def test_public_gis_wrapper_surface():
     assert callable(gis.read_raster_info)
     assert callable(gis.read_raster)
     assert callable(gis.read_vector)
+    assert callable(gis.reproject_vector)
     assert callable(gis.geometry_type)
     assert callable(gis.vector_schema)
     assert callable(gis.feature_count)

--- a/tests/test_gis_vector_crs.py
+++ b/tests/test_gis_vector_crs.py
@@ -1,0 +1,351 @@
+"""G-002c C2 vector CRS reprojection contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import forge3d.gis as gis
+from forge3d._native import NATIVE_AVAILABLE
+
+
+pytestmark = pytest.mark.skipif(
+    not NATIVE_AVAILABLE,
+    reason="GIS vector CRS tests require the compiled _forge3d extension",
+)
+
+
+WEB_MERCATOR_X_1 = 111_319.49079327357
+WEB_MERCATOR_Y_1 = 111_325.1428663851
+
+
+def _codes(items) -> set[str]:
+    return {item["code"] for item in items}
+
+
+def _feature(kind: str, coordinates, **extra):
+    feature = {
+        "type": "Feature",
+        "id": extra.pop("feature_id", f"{kind.lower()}-1"),
+        "properties": {"kind": kind, "name": extra.pop("name", kind.lower())},
+        "geometry": {"type": kind, "coordinates": coordinates},
+    }
+    feature.update(extra)
+    return feature
+
+
+def _collection(features: list[dict], *, crs: bool = True, **extra) -> dict:
+    payload = {"type": "FeatureCollection", "features": features}
+    if crs:
+        payload["crs"] = {"type": "name", "properties": {"name": "EPSG:4326"}}
+    payload.update(extra)
+    return payload
+
+
+def _write_geojson(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _point_coordinates(result: dict, index: int = 0):
+    return result["features"][index]["geometry"]["coordinates"]
+
+
+def test_reproject_vector_geojson_path_epsg4326_to_3857(tmp_path: Path):
+    payload = _collection(
+        [
+            _feature(
+                "Point",
+                [1.0, 1.0],
+                feature_id="point-a",
+                source_member="kept",
+                bbox=[0.0, 0.0, 0.0, 0.0],
+            ),
+            _feature("LineString", [[0.0, 0.0], [1.0, 1.0]]),
+            _feature(
+                "Polygon",
+                [[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 0.0]]],
+            ),
+        ],
+        bbox=[-999.0, -999.0, 999.0, 999.0],
+    )
+    path = _write_geojson(tmp_path / "sample.geojson", payload)
+
+    result = gis.reproject_vector(path, "EPSG:3857")
+
+    assert result["type"] == "FeatureCollection"
+    assert result["feature_count"] == 3
+    assert result["info"]["feature_count"] == 3
+    assert result["vector_info"].feature_count == 3
+    assert result["src_crs"]["authority"] == {"name": "EPSG", "code": "4326"}
+    assert result["dst_crs"]["authority"] == {"name": "EPSG", "code": "3857"}
+    assert _point_coordinates(result) == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1]
+    )
+    assert result["bounds"] == pytest.approx(
+        (0.0, 0.0, WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1), abs=1e-6
+    )
+    assert result["info"]["bounds"] == pytest.approx(result["bounds"])
+    assert result["features"][0]["id"] == "point-a"
+    assert result["features"][0]["properties"] == {"kind": "Point", "name": "point"}
+    assert result["features"][0]["source_member"] == "kept"
+    assert result["features"][0]["bbox"] == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1, WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1]
+    )
+
+
+def test_reproject_vector_dict_feature_collection_with_explicit_src_crs():
+    payload = _collection([_feature("Point", [1.0, 1.0])], crs=False)
+
+    result = gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:4326")
+
+    assert _point_coordinates(result) == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1]
+    )
+    assert result["src_crs"]["authority"] == {"name": "EPSG", "code": "4326"}
+
+
+def test_reproject_vector_empty_feature_collection_with_crs_warns_consistently():
+    payload = _collection([], crs=True, bbox=[-10.0, -5.0, 10.0, 5.0])
+
+    result = gis.reproject_vector(payload, "EPSG:3857")
+
+    assert result["features"] == []
+    assert result["feature_count"] == 0
+    assert result["info"]["feature_count"] == 0
+    assert result["bounds"] is None
+    assert result["info"]["bounds"] is None
+    assert result["info"]["is_georeferenced"] is False
+    assert result["src_crs"]["authority"] == {"name": "EPSG", "code": "4326"}
+    assert result["dst_crs"]["authority"] == {"name": "EPSG", "code": "3857"}
+    assert "empty_feature_set" in _codes(result["warnings"])
+    assert "bbox" not in result
+
+
+def test_reproject_vector_accepts_read_vector_result_dict(tmp_path: Path):
+    path = _write_geojson(
+        tmp_path / "sample.geojson",
+        _collection([_feature("Point", [1.0, 1.0])]),
+    )
+    read_result = gis.read_vector(path)
+
+    result = gis.reproject_vector(read_result, "EPSG:3857")
+
+    assert _point_coordinates(result) == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1]
+    )
+    assert result["src_crs"]["authority"] == {"name": "EPSG", "code": "4326"}
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {
+            "type": "Feature",
+            "properties": {"kind": "raw"},
+            "geometry": {"type": "Point", "coordinates": [1.0, 1.0]},
+        },
+        {"type": "Point", "coordinates": [1.0, 1.0]},
+    ],
+)
+def test_reproject_vector_accepts_raw_feature_and_geometry_with_explicit_src_crs(payload: dict):
+    result = gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:4326")
+
+    assert _point_coordinates(result) == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1]
+    )
+
+
+def test_reproject_vector_missing_source_crs_errors():
+    payload = _collection([_feature("Point", [1.0, 1.0])], crs=False)
+
+    with pytest.raises(ValueError, match="MissingCrs|missing_crs"):
+        gis.reproject_vector(payload, "EPSG:3857")
+
+
+def test_reproject_vector_invalid_destination_crs_errors():
+    payload = _collection([_feature("Point", [1.0, 1.0])])
+
+    with pytest.raises(ValueError, match="InvalidCrs|invalid_crs"):
+        gis.reproject_vector(payload, "not-a-crs")
+
+
+def test_reproject_vector_src_crs_conflict_with_metadata_errors():
+    payload = _collection([_feature("Point", [1.0, 1.0])])
+
+    with pytest.raises(ValueError, match="CrsMismatch"):
+        gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:3857")
+
+
+def test_reproject_vector_same_crs_copies_features_and_updates_metadata():
+    payload = _collection(
+        [_feature("Point", [1.0, 1.0], bbox=[0.0, 0.0, 0.0, 0.0])]
+    )
+
+    result = gis.reproject_vector(payload, "EPSG:4326")
+
+    assert _point_coordinates(result) == pytest.approx([1.0, 1.0])
+    assert result["features"][0]["bbox"] == pytest.approx([1.0, 1.0, 1.0, 1.0])
+    assert result["dst_crs"]["authority"] == {"name": "EPSG", "code": "4326"}
+    assert result["bounds"] == pytest.approx((1.0, 1.0, 1.0, 1.0))
+
+
+def test_reproject_vector_recomputes_or_removes_geojson_bbox_members():
+    payload = _collection(
+        [
+            _feature(
+                "Point",
+                [1.0, 1.0],
+                bbox=[-999.0, -999.0, 999.0, 999.0],
+            ),
+            {
+                "type": "Feature",
+                "properties": {"name": "geometry-bbox"},
+                "geometry": {
+                    "type": "Point",
+                    "coordinates": [1.0, 1.0],
+                    "bbox": [-999.0, -999.0, 999.0, 999.0],
+                },
+            },
+            {
+                "type": "Feature",
+                "properties": {"name": "empty-with-bbox"},
+                "bbox": [-999.0, -999.0, 999.0, 999.0],
+                "geometry": {"type": "LineString", "coordinates": []},
+            },
+        ],
+        crs=False,
+        bbox=[-999.0, -999.0, 999.0, 999.0],
+    )
+
+    result = gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:4326")
+
+    expected_point_bbox = [
+        WEB_MERCATOR_X_1,
+        WEB_MERCATOR_Y_1,
+        WEB_MERCATOR_X_1,
+        WEB_MERCATOR_Y_1,
+    ]
+    assert result["features"][0]["bbox"] == pytest.approx(expected_point_bbox)
+    assert result["features"][1]["geometry"]["bbox"] == pytest.approx(expected_point_bbox)
+    assert "bbox" not in result["features"][2]
+    assert "bbox" not in result
+    assert result["bounds"] == pytest.approx(
+        (WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1, WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1)
+    )
+
+
+def test_reproject_vector_preserves_z_and_additional_ordinates():
+    payload = _collection([_feature("Point", [1.0, 1.0, 42.0, 7.0])], crs=False)
+
+    result = gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:4326")
+
+    assert _point_coordinates(result) == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1, 42.0, 7.0]
+    )
+
+
+def test_reproject_vector_geometry_collection_recurses():
+    payload = _collection(
+        [
+            {
+                "type": "Feature",
+                "properties": {"name": "collection"},
+                "geometry": {
+                    "type": "GeometryCollection",
+                    "geometries": [
+                        {"type": "Point", "coordinates": [1.0, 1.0]},
+                        {
+                            "type": "LineString",
+                            "coordinates": [[0.0, 0.0], [1.0, 1.0]],
+                        },
+                    ],
+                },
+            }
+        ],
+        crs=False,
+    )
+
+    result = gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:4326")
+
+    geometries = result["features"][0]["geometry"]["geometries"]
+    assert geometries[0]["coordinates"] == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1]
+    )
+    assert geometries[1]["coordinates"][1] == pytest.approx(
+        [WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1]
+    )
+
+
+@pytest.mark.parametrize(
+    "geometry",
+    [
+        {"type": "Point", "coordinates": ["x", 1.0]},
+        {"type": "Point", "coordinates": [1.0]},
+        {"type": "LineString", "coordinates": [1.0, 2.0]},
+        {"type": "GeometryCollection"},
+    ],
+)
+def test_reproject_vector_rejects_malformed_coordinates(geometry: dict):
+    payload = {"type": "Feature", "properties": {}, "geometry": geometry}
+
+    with pytest.raises(ValueError, match="InvalidGeometry|invalid_geometry"):
+        gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:4326")
+
+
+def test_reproject_vector_preserves_null_and_empty_geometries_with_warning():
+    payload = _collection(
+        [
+            {"type": "Feature", "properties": {"name": "null"}, "geometry": None},
+            _feature("LineString", []),
+        ],
+        crs=False,
+    )
+
+    result = gis.reproject_vector(payload, "EPSG:3857", src_crs="EPSG:4326")
+
+    assert result["feature_count"] == 2
+    assert result["features"][0]["geometry"] is None
+    assert result["features"][1]["geometry"]["coordinates"] == []
+    assert result["bounds"] is None
+    assert "empty_geometry" in _codes(result["warnings"])
+
+
+def test_reproject_vector_bounds_order_is_left_bottom_right_top():
+    payload = _collection(
+        [
+            _feature("Point", [-1.0, -1.0]),
+            _feature("Point", [1.0, 1.0]),
+        ],
+        crs=False,
+    )
+
+    left, bottom, right, top = gis.reproject_vector(
+        payload, "EPSG:3857", src_crs="EPSG:4326"
+    )["bounds"]
+
+    assert left < right
+    assert bottom < top
+    assert (left, bottom, right, top) == pytest.approx(
+        (-WEB_MERCATOR_X_1, -WEB_MERCATOR_Y_1, WEB_MERCATOR_X_1, WEB_MERCATOR_Y_1)
+    )
+
+
+def test_reproject_vector_rejects_vector_info_without_feature_payload(tmp_path: Path):
+    path = _write_geojson(
+        tmp_path / "sample.geojson",
+        _collection([_feature("Point", [1.0, 1.0])]),
+    )
+    result = gis.read_vector(path)
+
+    with pytest.raises(ValueError, match="feature payload is required"):
+        gis.reproject_vector(result["vector_info"], "EPSG:3857")
+
+
+def test_reproject_vector_valid_but_unsupported_crs_pair_fails_backend_unavailable():
+    payload = _collection([_feature("Point", [1.0, 1.0])])
+
+    with pytest.raises(RuntimeError, match="BackendUnavailable"):
+        gis.reproject_vector(payload, "EPSG:32631")


### PR DESCRIPTION
## Scope summary

Implements the G-002c C2 vector CRS reprojection slice as a focused Rust-first GIS API addition. The change wires `reproject_vector` through the native module, Python wrapper, and type stub, with contract coverage for GeoJSON path and dict inputs, CRS metadata resolution, bbox updates, geometry recursion, warnings, and backend-unavailable behavior.

## Public API added

- `forge3d.gis.reproject_vector(data, dst_crs, src_crs=None) -> dict`
- Native `_forge3d.reproject_vector(data, dst_crs, src_crs=None) -> dict`
- Export locked in `tests/test_api_contracts.py`

## Backend limits

This is the C2 vector reprojection slice only. It stays within the current Rust GIS backend and GeoJSON-style feature payloads. The supported CRS reprojection backend is intentionally narrow; valid but unsupported CRS pairs raise `BackendUnavailable`. It does not add a general PROJ/GDAL vector reprojection backend, write APIs, raster/vector fusion, golden-map rendering, or C3-C6 behavior.

## Input/output contract

- Accepts GeoJSON path strings, FeatureCollection dicts, Feature dicts, Geometry dicts, and `read_vector` result dicts that contain feature payloads.
- Resolves source CRS from explicit `src_crs` or GeoJSON/read-vector metadata, and rejects missing or conflicting CRS metadata.
- Returns a GeoJSON-style dict with destination CRS metadata.
- Recurses through Points, LineStrings, Polygons, Multi-geometries, and GeometryCollections.
- Preserves feature members, properties, IDs, null geometry, and additional coordinate ordinates.
- Recomputes valid bboxes and removes stale bbox members when geometry is empty/null.

## Files changed

- `python/forge3d/gis.py`
- `python/forge3d/gis.pyi`
- `src/gis/error.rs`
- `src/gis/mod.rs`
- `src/gis/vector.rs`
- `src/py_module/functions/gis.rs`
- `tests/test_api_contracts.py`
- `tests/test_gis_crs_affine.py`
- `tests/test_gis_raster.py`
- `tests/test_gis_vector_crs.py`

## Validation

| Command | Exit | Result |
| --- | ---: | --- |
| `cargo fmt --check` | 0 | Pass |
| `cargo test` | 0 | Pass: 586 Rust tests passed; doc tests passed with 2 passed and 7 ignored |
| `.venv/bin/python -m pytest tests/test_gis_vector_crs.py -v` | 0 | Pass: 21 passed |
| `.venv/bin/python -m pytest tests/test_api_contracts.py -v` | 0 | Pass: 261 passed, 7 skipped |
| `.venv/bin/python -m pytest tests/test_gis_raster.py tests/test_gis_crs_affine.py -v` | 0 | Pass: 75 passed |
| `.venv/bin/python -m pytest tests/ -q --tb=short -m "not viewer and not interactive_viewer and not offscreen"` | 2 | Expected broader-suite collection stop only; see next section |

## Known broader-suite collection failure

The broader selector stops during collection because two local example modules are missing from the environment:

- `tests/test_colorado_rem_example.py`: `ModuleNotFoundError: No module named 'colorado_rem_forge3d'`
- `tests/test_platte_rem_example.py`: `ModuleNotFoundError: No module named 'platte_rem_forge3d'`

This matches the expected broader-suite blocker and is unrelated to the C2 vector reprojection slice.

## Explicit non-goals

- No C3, C4, C5, or C6 implementation.
- No new public APIs beyond `reproject_vector`.
- No docs committed from `docs/carto-engine/`.
- No broad CRS backend expansion beyond the existing supported transform behavior.
- No rendering, golden-map, or UI work.
