### PR TITLE
Implement G-002c C5 rasterization and masks

### DIFF
--- a/docs/carto-engine/g-002c-c5-implementation-plan.md
+++ b/docs/carto-engine/g-002c-c5-implementation-plan.md
@@ -1,0 +1,398 @@
+# G-002c C5 Rasterization and Masks Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add G-002c C5 rasterization and mask APIs on top of the committed C1-C4 vector and G-002a1/G-002b raster foundations.
+
+**Architecture:** GIS backend behavior stays in Rust under `src/gis/`. Python wrappers in `python/forge3d/gis.py` stay thin: `os.fspath` path normalization and direct PyO3 argument marshaling only. C5 uses an explicit target raster grid and never infers shape, transform, bounds, or CRS from vector bounds.
+
+**Tech Stack:** Rust, PyO3, NumPy at the Python boundary, existing `RasterInfo`/`RasterArray`/`RasterDType` raster helpers, existing affine and CRS helpers, existing GeoJSON-like vector/geometry parsing, and optional reference tests using rasterio only when installed.
+
+---
+
+## Global Constraints
+
+- Plan exactly these public APIs: `rasterize_vectors`, `geometry_mask`, and `mask_raster`.
+- Do not implement runtime code in this planning change-set.
+- Backend GIS behavior belongs in Rust under `src/gis/`.
+- Python wrappers stay thin: `os.fspath`/path normalization and argument marshaling only.
+- Do not implement rasterization or masking behavior in Python.
+- Do not use `rasterio`, `geopandas`, `shapely`, `rioxarray`, `xarray`, or `terra` as forge3d runtime backend behavior.
+- Reference libraries may appear only in optional tests or docs examples and must skip cleanly when unavailable.
+- Target grid must be explicit. Do not infer a grid from vector bounds.
+- CRS mismatch must fail. Missing CRS must be reported, not guessed.
+- Bounds order remains `(left, bottom, right, top)`.
+- Mask polarity must be explicit and stable.
+- `mask_raster` consumes an explicit mask. It must not secretly rasterize vectors.
+- Do not add vector writes, rendering, shaders, examples, visual goldens, gallery goldens, remote/cache/fetch, OSM, Terrarium, slippy tiles, domain helpers, MapScene work, or C6 thematic behavior.
+
+## Preflight Result
+
+- Current branch: `main`.
+- Current commit before this plan: `816661669a3ba00c28129add3df247e17240558b` (`Implement G-002c C4.7 load boundary`).
+- C4.7 is committed in local history; it is not an uncommitted review diff.
+- The older C4.7 review bundle at `C:\Users\milos\AppData\Local\Temp\forge3d-g002c-c47-review-bundle-20260702T062549Z` captured the pre-commit review diff for `src/gis/geometry/topology.rs`, `src/gis/vector.rs`, and `tests/test_gis_vector_overlay.py`.
+- The only pre-existing dirty path before this C5 plan was `logs/.9a9fb3a1aee4abd4cecd121a192f7ef77e352837-audit.json`; it is unrelated to C4.7 source files and is left untouched.
+- `python -m pytest tests/test_api_contracts.py -q` passed: `286 passed`.
+- Direct local import probe with `sys.path.insert(0, "python")` found no missing C1-C4 public functions and no leaked C5/C6 functions.
+
+## Current C1-C4 Evidence
+
+| Phase | Public surface | Evidence |
+|---|---|---|
+| G-002a1 raster read/write | `RasterInfo`, `read_raster_info`, `read_raster`, `write_raster` | `src/gis/types.rs:230`, `src/gis/raster_info.rs:38`, `src/gis/raster_info.rs:359`, `src/gis/raster_write.rs:287`, `python/forge3d/gis.py:43`, `python/forge3d/gis.py:48`, `python/forge3d/gis.py:242`, `tests/test_gis_raster.py:50` |
+| G-002b CRS/affine/nodata/window/resample/reproject | CRS helpers, affine helpers, `apply_nodata`, `read_raster_mask`, alignment, reprojection, windowing | `src/gis/affine.rs:49`, `src/gis/affine.rs:70`, `src/gis/affine.rs:129`, `src/gis/affine.rs:187`, `src/gis/warp.rs:49`, `src/gis/mod.rs:436`, `src/gis/mod.rs:465`, `tests/test_gis_crs_affine.py:1`, `tests/test_gis_alignment_windowing.py:1`, `tests/test_gis_resample_reproject.py:1` |
+| G-002c C1 vector metadata/read | `VectorInfo`, `read_vector`, `geometry_type`, `vector_schema`, `feature_count`, `vector_crs`, `vector_bounds` | `src/gis/vector.rs:35`, `src/gis/vector.rs:89`, `src/gis/vector.rs:2069`, `src/py_module/functions/gis.rs:8`, `python/forge3d/gis.py:68`, `python/forge3d/gis.pyi:133`, `tests/test_gis_vector_io.py:86` |
+| G-002c C2 vector reprojection | `reproject_vector` | `src/gis/vector.rs:186`, `src/gis/vector.rs:2174`, `src/py_module/functions/gis.rs:9`, `python/forge3d/gis.py:86`, `python/forge3d/gis.pyi:143`, `tests/test_gis_vector_crs.py:1` |
+| G-002c C3 geometry | `validate_geometry`, `repair_geometry`, `geometry_measure`, `geometry_centroid`, `representative_point`, `interpolate_line` | `src/gis/geometry.rs`, `src/gis/geometry/parse.rs:8`, `src/gis/geometry/model.rs:5`, `src/gis/geometry/py.rs`, `python/forge3d/gis.py:124`, `python/forge3d/gis.pyi:185`, `tests/test_gis_vector_geom.py:1` |
+| G-002c C4 overlay | `union_geometries`, `dissolve_vector`, `buffer_geometry`, `clip_vector`, `intersect_vectors`, `simplify_geometry`, `load_boundary` | `src/gis/geometry.rs:189`, `src/gis/vector.rs:255`, `src/gis/vector.rs:328`, `src/gis/vector.rs:375`, `src/gis/vector.rs:430`, `src/gis/geometry/topology.rs:5`, `src/py_module/functions/gis.rs:21`, `python/forge3d/gis.py:167`, `python/forge3d/gis.pyi:216`, `tests/test_gis_vector_overlay.py:25` |
+| Contract lock | C1-C4 expected, C5/C6 absent | `tests/test_api_contracts.py:61`, `tests/test_api_contracts.py:109`, `tests/test_api_contracts.py:184` |
+
+## Current C5/C6 Absence
+
+`rasterize_vectors`, `geometry_mask`, `mask_raster`, `normalize_raster`, and `classify_raster` are absent from:
+
+- `python/forge3d/gis.py` wrappers and `__all__`.
+- `python/forge3d/gis.pyi` stubs.
+- `src/py_module/functions/gis.rs` PyO3 function registration.
+- `src/gis/mod.rs` re-exports.
+
+They are intentionally listed only as later GIS functions in `tests/test_api_contracts.py:184`.
+
+## C5 APIs Planned
+
+```python
+def rasterize_vectors(
+    vectors,
+    target_info,
+    *,
+    value=1,
+    attribute=None,
+    dtype="uint8",
+    fill=0,
+    all_touched=False,
+) -> dict[str, Any]: ...
+
+def geometry_mask(
+    geometries,
+    target_info,
+    *,
+    invert=False,
+    all_touched=False,
+    mask_polarity="true_inside",
+) -> dict[str, Any]: ...
+
+def mask_raster(
+    source,
+    mask,
+    *,
+    mask_polarity,
+    crop=False,
+    fill=None,
+    nodata=None,
+) -> dict[str, Any]: ...
+```
+
+## Backend Decision
+
+- Do not add a new runtime dependency for C5.
+- Implement the default C5 path in Rust in `src/gis/rasterize.rs`.
+- Reuse existing `RasterInfo`, `RasterArray`, `RasterData`, `RasterDType`, affine helpers, CRS helpers, and GeoJSON-like geometry parsing.
+- Do not require `geos-topology`; current `Cargo.toml:57` gates C4 topology with `geo`, and current `pyproject.toml` maturin features do not include `geos-topology`.
+- Do not add GDAL for C5. If a later backend is added, it must be feature-gated, keep functions importable, and raise `BackendUnavailable` with `backend_unavailable` when absent.
+- Optional reference checks may use `rasterio.features.rasterize`, `rasterio.features.geometry_mask`, or `rasterio.mask.mask` only inside tests guarded by `pytest.importorskip("rasterio")`.
+
+## Behavior Contracts
+
+### Target Grid
+
+- `target_info` accepts a native `RasterInfo` or serialized `RasterInfo` dict.
+- Required fields: `width`, `height`, `transform`, and CRS metadata (`crs_authority` or `crs_wkt`).
+- Optional fields copied through output metadata: `path`, `driver`, `band_count`, `dtype_per_band`, `nodata_per_band`, `bounds`, `resolution`, `warnings`.
+- Missing width/height/transform is `invalid_argument` or `missing_transform`.
+- Missing target CRS is `missing_crs`.
+- Bounds order remains `(left, bottom, right, top)`.
+
+### Vector And Geometry Inputs
+
+- Accepted C5 inputs are the same GeoJSON-like dict shapes already used by C1-C4: Geometry, Feature, FeatureCollection, read-vector result dicts, and local vector paths where the API says `vectors`.
+- Source CRS is required for rasterization/mask geometry. Missing source CRS is `missing_crs`; incompatible source/target CRS is `crs_mismatch`.
+- First C5 semantic support is polygonal rasterization: `Polygon`, `MultiPolygon`, and FeatureCollections containing polygonal geometries.
+- `Point`, `LineString`, `MultiPoint`, `MultiLineString`, unsupported GeoJSON types, and malformed geometry raise `unsupported_geometry_type` or `invalid_geometry`.
+- Empty geometry raises `empty_geometry`; an empty vector source raises `empty_feature_set`.
+
+### Rasterization Semantics
+
+- `rasterize_vectors` returns:
+  - `array`: NumPy array shaped `(height, width)`.
+  - `info`: serialized `RasterInfo` dict for the target grid and output dtype.
+  - `target_shape`: `(height, width)`.
+  - `target_transform`: `(a, b, c, d, e, f)`.
+  - `target_bounds`: `(left, bottom, right, top)`.
+  - `dtype`, `fill`, `burned_pixels`, `all_touched`, and `warnings`.
+- Default `all_touched=False` burns a pixel when its center point is inside the polygon and not inside a hole.
+- `all_touched=True` burns a pixel when the pixel cell touches polygon area: center inside, any cell corner inside, any polygon vertex inside the cell, or any polygon edge intersects the cell.
+- Attribute burn reads `feature["properties"][attribute]`; missing or non-numeric values fail with `invalid_argument`.
+- Constant burn uses `value`.
+- `fill`, `value`, and attribute values must fit the output dtype or fail with `unsupported_dtype`/`invalid_argument`.
+
+### Geometry Mask Semantics
+
+- `geometry_mask` internally uses the same Rust rasterization kernel to create a boolean mask; it does not call Python GIS libraries.
+- Accepted `mask_polarity` values are `true_inside` and `true_outside`.
+- With `mask_polarity="true_inside"` and `invert=False`, mask values are true for pixels inside geometry.
+- With `invert=True`, values are flipped and the returned `mask_polarity` is flipped between `true_inside` and `true_outside`.
+- The result returns `mask`, `info`, `mask_polarity`, `true_count`, `false_count`, `crop_window=None`, and `warnings`.
+
+### Raster Mask Semantics
+
+- `mask_raster` accepts a local raster path, a `read_raster` result dict, or a NumPy array source.
+- `mask` must be an explicit boolean NumPy-compatible array.
+- Accepted mask shapes:
+  - `(height, width)`: applies to every band.
+  - `(1, height, width)`: applies to every band.
+  - `(bands, height, width)`: per-band mask.
+- Any other mask shape is `shape_mismatch`.
+- `mask_polarity` has no default. Missing, `None`, or unknown values raise `invalid_argument` with `mask_polarity_explicit`.
+- Accepted `mask_polarity` values are `true_valid`, `true_inside`, and `true_outside`. In all cases, true cells are the cells retained by `mask_raster`.
+- `fill=None` uses `nodata` when supplied, otherwise uses existing source nodata when available, otherwise leaves masked pixels unchanged but returns the output mask.
+- `fill` writes masked-out cells to the fill value after validating dtype compatibility.
+- `nodata` may be scalar, per-band list, or `None`; invalid values raise `invalid_nodata`.
+- `crop=True` crops to the minimal retained-pixel bounding window and updates `info.width`, `info.height`, `info.transform`, `info.bounds`, and `crop_window`.
+- If `crop=True` and the mask retains no pixels, return `empty_raster`.
+
+## Stable Diagnostics
+
+C5 implementations must include these lowercase tokens in exception messages or warning codes:
+
+- `missing_crs`
+- `crs_mismatch`
+- `mask_polarity_explicit`
+- `unsupported_dtype`
+- `unsupported_geometry_type`
+- `invalid_geometry`
+- `invalid_argument`
+- `empty_geometry`
+- `empty_feature_set`
+- `empty_raster`
+- `shape_mismatch`
+- `invalid_nodata`
+- `backend_unavailable`
+
+Prefer current `GisError` variants in `src/gis/error.rs:6`:
+
+- `MissingCrs` for `missing_crs`.
+- `CrsMismatch` for `crs_mismatch`.
+- `UnsupportedDType` for `unsupported_dtype`.
+- `InvalidGeometry` for `unsupported_geometry_type`, `invalid_geometry`, and `empty_geometry`.
+- `InvalidArgument` for `invalid_argument` and `mask_polarity_explicit`.
+- `ShapeMismatch` for `shape_mismatch`.
+- `InvalidNodata` for `invalid_nodata`.
+- `BackendUnavailable` for `backend_unavailable`.
+
+## File-Level Deltas
+
+| File | C5 delta |
+|---|---|
+| Create `src/gis/rasterize.rs` | Rust implementation for `rasterize_vectors`, `geometry_mask`, `mask_raster`, target-grid extraction, CRS compatibility, dtype parsing, mask polarity parsing, crop-window calculation, and result metadata. |
+| Modify `src/gis/mod.rs` | Add `pub mod rasterize;`, re-export the three Rust functions, and re-export the three PyO3 functions behind `extension-module`. |
+| Modify `src/py_module/functions/gis.rs` | Register `rasterize_vectors_py`, `geometry_mask_py`, and `mask_raster_py` after C4 GIS registrations and before raster CRS/affine registrations. |
+| Modify `python/forge3d/gis.py` | Add thin wrappers only. Use `_path_or_self(vectors)` and `_path_or_self(source)` where path-like inputs are accepted. Add the three names to `__all__`. |
+| Modify `python/forge3d/gis.pyi` | Add stubs for the three exact C5 signatures and `dict[str, Any]` return types. Do not advertise rasterio/Shapely/GeoPandas objects. |
+| Modify `tests/test_api_contracts.py` | Move only `rasterize_vectors`, `geometry_mask`, and `mask_raster` from `LATER_GIS_FUNCTIONS` to `EXPECTED_FUNCTIONS`. Leave `normalize_raster` and `classify_raster` absent for C6. |
+| Modify `tests/test_gis_raster.py` | Update wrapper `__all__` and callable assertions. Keep stub/export parity checks. |
+| Create `tests/test_gis_rasterize_mask.py` | Focused T-rasterize-mask behavior tests, backend-library absence checks, and optional rasterio references. |
+| Do not modify `Cargo.toml` or `pyproject.toml` | No new runtime backend dependency is needed for first C5. |
+
+## Planning Steps
+
+- [ ] Confirm `git status --short` does not contain uncommitted C4 source/test diffs before implementation starts.
+- [ ] Run `python -m pytest tests/test_api_contracts.py -q` and confirm C1-C4 are present and C5/C6 are absent before editing.
+- [ ] Keep this C5 work to the files listed in "File-Level Deltas" unless a compiler error proves a shared helper must move.
+- [ ] Do not implement C6 names in C5.
+
+## Implementation Steps
+
+### Task C5.0: Public Surface And Backend-Free Skeleton
+
+**Files:**
+- Create: `src/gis/rasterize.rs`
+- Modify: `src/gis/mod.rs`
+- Modify: `src/py_module/functions/gis.rs`
+- Modify: `python/forge3d/gis.py`
+- Modify: `python/forge3d/gis.pyi`
+- Modify: `tests/test_api_contracts.py`
+- Modify: `tests/test_gis_raster.py`
+- Create: `tests/test_gis_rasterize_mask.py`
+
+- [ ] Add failing contract tests for the three C5 functions.
+- [ ] Add thin Python wrappers and stubs with the exact C5 signatures.
+- [ ] Add PyO3 functions that marshal arguments and initially return `backend_unavailable: C5 skeleton incomplete` only inside this first local slice.
+- [ ] Run `python -m pytest tests/test_api_contracts.py tests/test_gis_raster.py -q`.
+- [ ] Replace the skeleton in later C5 tasks before completion; no final C5 implementation may leave the skeleton error path for supported inputs.
+
+### Task C5.1: Target Grid, CRS, DType, And Polarity Helpers
+
+**Files:**
+- Modify: `src/gis/rasterize.rs`
+- Test: `tests/test_gis_rasterize_mask.py`
+
+- [ ] Implement `TargetGrid` extraction from `RasterInfo` and serialized dict.
+- [ ] Validate positive shape, required transform, required CRS, and `(left, bottom, right, top)` bounds.
+- [ ] Parse `dtype` into existing `RasterDType`.
+- [ ] Validate scalar values against dtype using `RasterDType::nodata_fits`.
+- [ ] Parse mask polarity with exact accepted spellings.
+- [ ] Add tests for unsupported dtype, missing target CRS, missing source CRS, CRS mismatch, and missing/invalid mask polarity.
+
+### Task C5.2: `rasterize_vectors`
+
+**Files:**
+- Modify: `src/gis/rasterize.rs`
+- Test: `tests/test_gis_rasterize_mask.py`
+
+- [ ] Resolve `vectors` from local path, read-vector result, FeatureCollection, Feature, or geometry dict.
+- [ ] Require vector CRS and target CRS compatibility.
+- [ ] Reject empty vector sources with `empty_feature_set`.
+- [ ] Reject empty or malformed geometry with `empty_geometry` or `invalid_geometry`.
+- [ ] Implement polygonal point-in-polygon center burn.
+- [ ] Implement `all_touched=True` cell-touch burn.
+- [ ] Implement constant burn and attribute burn.
+- [ ] Return output metadata fields listed in "Rasterization Semantics".
+
+### Task C5.3: `geometry_mask`
+
+**Files:**
+- Modify: `src/gis/rasterize.rs`
+- Test: `tests/test_gis_rasterize_mask.py`
+
+- [ ] Reuse the rasterization kernel to build a bool array.
+- [ ] Support `true_inside`, `true_outside`, and `invert`.
+- [ ] Return true/false counts and `mask_polarity_explicit` warning metadata.
+- [ ] Test true-inside, true-outside, and inverted masks on the same small target grid.
+
+### Task C5.4: `mask_raster`
+
+**Files:**
+- Modify: `src/gis/rasterize.rs`
+- Test: `tests/test_gis_rasterize_mask.py`
+
+- [ ] Resolve source raster from path, `read_raster` result dict, or NumPy array.
+- [ ] Validate mask shape and broadcast 2D/one-band masks to every band.
+- [ ] Apply fill/nodata handling with dtype validation.
+- [ ] Preserve or synthesize output `info` without CRS guessing.
+- [ ] Implement crop window and transform/bounds updates with existing affine helpers.
+- [ ] Ensure this function never accepts vectors or calls rasterization internally.
+
+## Test Plan
+
+Add `tests/test_gis_rasterize_mask.py` with these required groups:
+
+- [ ] Polygon constant burn into an explicit small `RasterInfo` grid.
+- [ ] Attribute burn from feature properties.
+- [ ] Fill value and dtype handling.
+- [ ] `all_touched=True` and `all_touched=False` behavior.
+- [ ] `geometry_mask` `true_inside` behavior.
+- [ ] `geometry_mask` `invert=True` behavior.
+- [ ] Explicit `mask_polarity` requirements and bad-polarity errors.
+- [ ] `mask_raster` with `true_valid` mask.
+- [ ] `mask_raster` crop behavior and `crop_window`.
+- [ ] `fill` and `nodata` handling, including invalid nodata.
+- [ ] Shape mismatch.
+- [ ] CRS mismatch.
+- [ ] Missing CRS.
+- [ ] Empty geometry and empty source.
+- [ ] Unsupported geometry type.
+- [ ] Unsupported dtype.
+- [ ] Optional rasterio reference checks, skipped when rasterio is unavailable.
+
+Contract/API tests:
+
+- [ ] `tests/test_api_contracts.py`: add only C5 APIs to `EXPECTED_FUNCTIONS`.
+- [ ] `tests/test_api_contracts.py`: keep `normalize_raster` and `classify_raster` in later/absent assertions.
+- [ ] `python/forge3d/gis.py`: update `__all__`.
+- [ ] `python/forge3d/gis.pyi`: add stubs.
+- [ ] `tests/test_gis_raster.py`: update wrapper-surface and stub parity tests.
+- [ ] Add a no-backend-Python-GIS-library test that scans `python/forge3d/gis.py` and `src/gis/rasterize.rs` for forbidden runtime imports/usages of `rasterio`, `geopandas`, `shapely`, `rioxarray`, `xarray`, and `terra`.
+
+Optional reference-library policy:
+
+- Optional rasterio tests must use `pytest.importorskip("rasterio")`.
+- Optional reference checks compare small arrays only.
+- Optional checks must not be the only coverage for any required behavior.
+- No mandatory test may require rasterio, geopandas, shapely, rioxarray, xarray, or terra.
+
+## Validation Plan For C5 Implementation
+
+Run at minimum after implementation:
+
+```text
+cargo fmt --check
+cargo check
+python -m py_compile python/forge3d/gis.py
+python -m pytest tests/test_api_contracts.py tests/test_gis_raster.py tests/test_gis_rasterize_mask.py -q
+python -m pytest tests/test_gis_raster.py tests/test_gis_crs_affine.py tests/test_gis_alignment_windowing.py tests/test_gis_resample_reproject.py -q
+python -m pytest tests/test_gis_vector_io.py tests/test_gis_vector_crs.py tests/test_gis_vector_geom.py tests/test_gis_vector_overlay.py -q
+git status --short
+git diff --name-status
+git diff --stat
+git diff
+git ls-files --others --exclude-standard
+```
+
+If C5 implementation touches only Rust/Python GIS API files and focused tests, do not run GPU/rendering suites unless a change crosses into rendering code.
+
+## Validation Plan For This Planning Change-Set
+
+Because this change-set is documentation/planning only, run:
+
+```text
+git status --short
+git diff --name-status
+git diff --stat
+git diff
+git ls-files --others --exclude-standard
+python -c "import sphinx"
+python -m sphinx -b html docs docs/_build/html
+```
+
+If Sphinx is unavailable, record the docs build as skipped because the dependency is missing. No Rust/Python runtime tests are required for this planning-only diff beyond the preflight contract test already run.
+
+## Review Bundle Requirement
+
+After this planning change-set, create a fresh temporary review bundle outside the repo. Do not stage or commit it.
+
+The bundle must include:
+
+- `git status --short`
+- `git diff --name-status`
+- `git diff --stat`
+- full `git diff`
+- `git ls-files --others --exclude-standard`
+- validation logs
+- command metadata and exit codes
+- branch
+- merge base
+- current commit
+- timestamp
+- cwd
+
+Suggested path pattern:
+
+```text
+%TEMP%/forge3d-g002c-c5-plan-review-bundle-<timestamp>/
+```
+
+## Explicit Non-Goals
+
+- No C6 `normalize_raster` or `classify_raster`.
+- No vector writes.
+- No rasterization or masking behavior in Python.
+- No runtime rasterio, geopandas, shapely, rioxarray, xarray, terra, or GDAL backend.
+- No rendering, shaders, visual goldens, gallery goldens, or examples.
+- No remote/cache/fetch, OSM, Terrarium, slippy tiles, domain helpers, or MapScene work.
+- No implicit target grid inference from vector bounds.
+- No hidden vector rasterization inside `mask_raster`.
+
+## Open Questions
+
+None block implementation. Conservative decisions are locked above: pure-Rust default C5 backend, polygonal rasterization first, explicit target grid, strict CRS checks, explicit mask polarity, and C6 remains absent.

--- a/python/forge3d/gis.py
+++ b/python/forge3d/gis.py
@@ -31,6 +31,7 @@ else:  # pragma: no cover - exercised only without the compiled extension
     CrsTransform = None
 
 RasterReadResult = dict
+_MISSING = object()
 
 
 def _require_native():
@@ -232,6 +233,67 @@ def load_boundary(
         os.fspath(path),
         layer=layer,
         where=where,
+    )
+
+
+def rasterize_vectors(
+    vectors: os.PathLike[str] | str | dict[str, Any],
+    target_info: Any,
+    *,
+    value: float = 1,
+    attribute: str | None = None,
+    dtype: str = "uint8",
+    fill: float = 0,
+    all_touched: bool = False,
+):
+    """Rasterize polygonal vector features onto an explicit target grid."""
+    return _require_native().rasterize_vectors(
+        _path_or_self(vectors),
+        target_info,
+        value=value,
+        attribute=attribute,
+        dtype=dtype,
+        fill=fill,
+        all_touched=all_touched,
+    )
+
+
+def geometry_mask(
+    geometries: dict[str, Any],
+    target_info: Any,
+    *,
+    invert: bool = False,
+    all_touched: bool = False,
+    mask_polarity: str = "true_inside",
+):
+    """Create a boolean geometry mask on an explicit target grid."""
+    return _require_native().geometry_mask(
+        _path_or_self(geometries),
+        target_info,
+        invert=invert,
+        all_touched=all_touched,
+        mask_polarity=mask_polarity,
+    )
+
+
+def mask_raster(
+    source: os.PathLike[str] | str | Any,
+    mask: Any,
+    *,
+    mask_polarity=_MISSING,
+    crop: bool = False,
+    fill: float | None = None,
+    nodata: float | list[float | None] | tuple[float | None, ...] | None = None,
+):
+    """Apply an explicit true-retain boolean mask to raster data."""
+    polarity = None if mask_polarity is _MISSING else mask_polarity
+    return _require_native().mask_raster(
+        _path_or_self(source),
+        mask,
+        mask_polarity=polarity,
+        crop=crop,
+        fill=fill,
+        nodata=nodata,
     )
 
 
@@ -554,6 +616,9 @@ __all__ = [
     "intersect_vectors",
     "simplify_geometry",
     "load_boundary",
+    "rasterize_vectors",
+    "geometry_mask",
+    "mask_raster",
     "write_raster",
     "parse_crs",
     "inspect_crs",

--- a/python/forge3d/gis.pyi
+++ b/python/forge3d/gis.pyi
@@ -263,6 +263,39 @@ def load_boundary(
 ) -> dict[str, Any]: ...
 
 
+def rasterize_vectors(
+    vectors: os.PathLike[str] | str | dict[str, Any],
+    target_info: RasterInfo | dict[str, Any],
+    *,
+    value: float = ...,
+    attribute: str | None = ...,
+    dtype: str = ...,
+    fill: float = ...,
+    all_touched: bool = ...,
+) -> dict[str, Any]: ...
+
+
+def geometry_mask(
+    geometries: os.PathLike[str] | str | dict[str, Any],
+    target_info: RasterInfo | dict[str, Any],
+    *,
+    invert: bool = ...,
+    all_touched: bool = ...,
+    mask_polarity: str = ...,
+) -> dict[str, Any]: ...
+
+
+def mask_raster(
+    source: os.PathLike[str] | str | np.ndarray | dict[str, Any],
+    mask: np.ndarray,
+    *,
+    mask_polarity: str,
+    crop: bool = ...,
+    fill: float | None = ...,
+    nodata: float | list[float | None] | tuple[float | None, ...] | None = ...,
+) -> dict[str, Any]: ...
+
+
 def write_raster(
     path: os.PathLike[str] | str,
     array: np.ndarray,

--- a/src/gis/mod.rs
+++ b/src/gis/mod.rs
@@ -6,6 +6,7 @@ pub mod geometry;
 pub(crate) mod py_json;
 pub mod raster_info;
 pub mod raster_write;
+pub mod rasterize;
 pub mod types;
 pub mod vector;
 pub mod warp;
@@ -27,6 +28,13 @@ pub use raster_info::{read_raster, read_raster_info};
 pub use raster_write::{
     write_raster, CreationOptions, CrsSpec, RasterArray, RasterData, WriteRasterOptions,
 };
+pub use rasterize::{
+    geometry_mask, mask_raster, rasterize_vectors, GeometryMaskOptions, GeometryMaskResult,
+    MaskPolarity, MaskRasterOptions, MaskRasterResult, RasterMaskPolarity, RasterizeOptions,
+    RasterizeResult,
+};
+#[cfg(feature = "extension-module")]
+pub use rasterize::{geometry_mask_py, mask_raster_py, rasterize_vectors_py};
 pub use types::{AffineTransform, RasterBounds, RasterDType, RasterInfo, RasterWarning};
 pub use vector::{
     clip_vector, dissolve_vector, intersect_vectors, load_boundary, read_vector, read_vector_info,

--- a/src/gis/rasterize.rs
+++ b/src/gis/rasterize.rs
@@ -1,0 +1,1488 @@
+use serde_json::Value;
+
+use crate::gis::affine::{self, PixelWindow};
+use crate::gis::crs;
+use crate::gis::error::{GisError, GisResult};
+use crate::gis::raster_info;
+use crate::gis::raster_write::{CrsSpec, RasterArray};
+use crate::gis::types::{AffineTransform, RasterDType, RasterInfo, RasterWarning};
+use crate::gis::vector;
+
+const MISSING_CRS: &str = "missing_crs";
+const CRS_MISMATCH: &str = "crs_mismatch";
+const MASK_POLARITY_EXPLICIT: &str = "mask_polarity_explicit";
+const UNSUPPORTED_DTYPE: &str = "unsupported_dtype";
+const UNSUPPORTED_GEOMETRY_TYPE: &str = "unsupported_geometry_type";
+const INVALID_GEOMETRY: &str = "invalid_geometry";
+const INVALID_ARGUMENT: &str = "invalid_argument";
+const EMPTY_GEOMETRY: &str = "empty_geometry";
+const EMPTY_FEATURE_SET: &str = "empty_feature_set";
+const EMPTY_RASTER: &str = "empty_raster";
+const SHAPE_MISMATCH: &str = "shape_mismatch";
+const INVALID_NODATA: &str = "invalid_nodata";
+
+#[derive(Debug, Clone)]
+pub struct RasterizeOptions {
+    pub value: f64,
+    pub attribute: Option<String>,
+    pub dtype: RasterDType,
+    pub fill: f64,
+    pub all_touched: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct RasterizeResult {
+    pub values: Vec<f64>,
+    pub info: RasterInfo,
+    pub target_shape: (usize, usize),
+    pub target_transform: AffineTransform,
+    pub target_bounds: (f64, f64, f64, f64),
+    pub dtype: RasterDType,
+    pub fill: f64,
+    pub burned_pixels: usize,
+    pub all_touched: bool,
+    pub warnings: Vec<RasterWarning>,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryMaskOptions {
+    pub invert: bool,
+    pub all_touched: bool,
+    pub mask_polarity: MaskPolarity,
+}
+
+#[derive(Debug, Clone)]
+pub struct GeometryMaskResult {
+    pub mask: Vec<bool>,
+    pub info: RasterInfo,
+    pub mask_polarity: MaskPolarity,
+    pub true_count: usize,
+    pub false_count: usize,
+    pub warnings: Vec<RasterWarning>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MaskRasterOptions {
+    pub mask_polarity: RasterMaskPolarity,
+    pub crop: bool,
+    pub fill: Option<f64>,
+    pub nodata: Option<Vec<Option<f64>>>,
+}
+
+#[derive(Debug, Clone)]
+pub struct MaskRasterResult {
+    pub array: RasterArray,
+    pub mask: Vec<bool>,
+    pub info: RasterInfo,
+    pub mask_polarity: RasterMaskPolarity,
+    pub fill: Option<f64>,
+    pub valid_count: usize,
+    pub crop_window: Option<PixelWindow>,
+    pub nodata_per_band: Vec<Option<f64>>,
+    pub warnings: Vec<RasterWarning>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaskPolarity {
+    TrueInside,
+    TrueOutside,
+}
+
+impl MaskPolarity {
+    pub fn parse(value: &str) -> GisResult<Self> {
+        match value {
+            "true_inside" => Ok(Self::TrueInside),
+            "true_outside" => Ok(Self::TrueOutside),
+            _ => Err(GisError::InvalidArgument(format!(
+                "{MASK_POLARITY_EXPLICIT}: mask_polarity must be 'true_inside' or 'true_outside'"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TrueInside => "true_inside",
+            Self::TrueOutside => "true_outside",
+        }
+    }
+
+    fn flipped(self) -> Self {
+        match self {
+            Self::TrueInside => Self::TrueOutside,
+            Self::TrueOutside => Self::TrueInside,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RasterMaskPolarity {
+    TrueValid,
+    TrueInside,
+    TrueOutside,
+}
+
+impl RasterMaskPolarity {
+    pub fn parse(value: Option<&str>) -> GisResult<Self> {
+        match value {
+            Some("true_valid") => Ok(Self::TrueValid),
+            Some("true_inside") => Ok(Self::TrueInside),
+            Some("true_outside") => Ok(Self::TrueOutside),
+            _ => Err(GisError::InvalidArgument(format!(
+                "{MASK_POLARITY_EXPLICIT}: mask_polarity must be explicit: 'true_valid', 'true_inside', or 'true_outside'"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TrueValid => "true_valid",
+            Self::TrueInside => "true_inside",
+            Self::TrueOutside => "true_outside",
+        }
+    }
+}
+
+#[derive(Clone)]
+struct TargetGrid {
+    info: RasterInfo,
+    transform: AffineTransform,
+    bounds: (f64, f64, f64, f64),
+    crs: CrsSpec,
+}
+
+#[derive(Clone)]
+struct VectorSource {
+    features: Vec<Value>,
+    crs: CrsSpec,
+}
+
+#[derive(Clone, Copy)]
+struct Point {
+    x: f64,
+    y: f64,
+}
+
+type Ring = Vec<Point>;
+type Polygon = Vec<Ring>;
+
+pub fn parse_raster_dtype(value: &str) -> GisResult<RasterDType> {
+    match value.to_ascii_lowercase().as_str() {
+        "uint8" => Ok(RasterDType::UInt8),
+        "int16" => Ok(RasterDType::Int16),
+        "uint16" => Ok(RasterDType::UInt16),
+        "int32" => Ok(RasterDType::Int32),
+        "uint32" => Ok(RasterDType::UInt32),
+        "float32" => Ok(RasterDType::Float32),
+        "float64" => Ok(RasterDType::Float64),
+        _ => Err(GisError::UnsupportedDType(format!(
+            "{UNSUPPORTED_DTYPE}: unsupported raster dtype {value:?}"
+        ))),
+    }
+}
+
+pub fn rasterize_vectors(
+    source: &Value,
+    target_info: &RasterInfo,
+    options: RasterizeOptions,
+) -> GisResult<RasterizeResult> {
+    validate_value_for_dtype(options.dtype, options.fill, "fill")?;
+    validate_value_for_dtype(options.dtype, options.value, "value")?;
+    let grid = target_grid(target_info)?;
+    let source = resolve_vector_source(source)?;
+    require_same_crs(&source.crs, &grid.crs)?;
+    let (values, burned_pixels) = rasterize_source(&source, &grid, &options)?;
+    let info = output_info(&grid.info, options.dtype, grid.info.nodata_per_band.clone())?;
+    Ok(RasterizeResult {
+        values,
+        info,
+        target_shape: (grid.info.height as usize, grid.info.width as usize),
+        target_transform: grid.transform,
+        target_bounds: grid.bounds,
+        dtype: options.dtype,
+        fill: options.fill,
+        burned_pixels,
+        all_touched: options.all_touched,
+        warnings: Vec::new(),
+    })
+}
+
+pub fn geometry_mask(
+    source: &Value,
+    target_info: &RasterInfo,
+    options: GeometryMaskOptions,
+) -> GisResult<GeometryMaskResult> {
+    let grid = target_grid(target_info)?;
+    let source = resolve_vector_source(source)?;
+    require_same_crs(&source.crs, &grid.crs)?;
+    let inside = rasterize_bool(&source, &grid, options.all_touched)?;
+    let mut polarity = options.mask_polarity;
+    let mut mask = match options.mask_polarity {
+        MaskPolarity::TrueInside => inside,
+        MaskPolarity::TrueOutside => inside.into_iter().map(|value| !value).collect(),
+    };
+    if options.invert {
+        mask.iter_mut().for_each(|value| *value = !*value);
+        polarity = polarity.flipped();
+    }
+    let true_count = mask.iter().filter(|&&value| value).count();
+    let false_count = mask.len() - true_count;
+    Ok(GeometryMaskResult {
+        mask,
+        info: output_info(&grid.info, RasterDType::UInt8, vec![None])?,
+        mask_polarity: polarity,
+        true_count,
+        false_count,
+        warnings: vec![RasterWarning::new(
+            MASK_POLARITY_EXPLICIT,
+            "mask polarity is explicit",
+            Some("mask_polarity"),
+        )],
+    })
+}
+
+pub fn mask_raster(
+    source_array: RasterArray,
+    source_info: RasterInfo,
+    mask: Vec<bool>,
+    mask_shape: &[usize],
+    options: MaskRasterOptions,
+) -> GisResult<MaskRasterResult> {
+    let dtype = source_array.dtype();
+    let mut nodata = match options.nodata {
+        Some(values) => values,
+        None => normalize_nodata_len(source_info.nodata_per_band.clone(), source_array.bands)?,
+    };
+    for value in nodata.iter().flatten() {
+        validate_nodata_for_dtype(dtype, *value)?;
+    }
+    if let Some(fill) = options.fill {
+        validate_value_for_dtype(dtype, fill, "fill")?;
+    }
+
+    let valid_mask = expand_mask(mask, mask_shape, &source_array)?;
+    let valid_count = valid_mask.iter().filter(|&&value| value).count();
+    let mut values = raster_info::raster_to_f64(&source_array);
+    apply_mask_values(
+        &mut values,
+        &valid_mask,
+        &source_array,
+        options.fill,
+        &nodata,
+    );
+
+    let mut info = source_info_for_output(&source_info, &source_array, nodata.clone());
+    let mut crop_window = None;
+    let mut warnings = Vec::new();
+
+    let (values, valid_mask, height, width) = if options.crop {
+        match retained_window(&valid_mask, &source_array) {
+            Some(window) => {
+                crop_window = Some(window);
+                update_info_for_window(&mut info, window)?;
+                (
+                    crop_values(&values, &source_array, window),
+                    crop_values_bool(&valid_mask, &source_array, window),
+                    window.height as usize,
+                    window.width as usize,
+                )
+            }
+            None => {
+                crop_window = Some(PixelWindow {
+                    col_off: 0,
+                    row_off: 0,
+                    width: 0,
+                    height: 0,
+                });
+                info.width = 0;
+                info.height = 0;
+                info.bounds = None;
+                warnings.push(RasterWarning::new(
+                    EMPTY_RASTER,
+                    "empty_raster: mask retains no pixels",
+                    Some("mask"),
+                ));
+                (Vec::new(), Vec::new(), 0, 0)
+            }
+        }
+    } else {
+        (values, valid_mask, source_array.height, source_array.width)
+    };
+
+    let array = if height == 0 || width == 0 {
+        source_array.clone()
+    } else {
+        raster_info::f64_to_raster_data(dtype, values, source_array.bands, height, width)?
+    };
+    if nodata.len() != source_array.bands {
+        nodata = normalize_nodata_len(nodata, source_array.bands)?;
+    }
+    Ok(MaskRasterResult {
+        array,
+        mask: valid_mask,
+        info,
+        mask_polarity: options.mask_polarity,
+        fill: options.fill,
+        valid_count,
+        crop_window,
+        nodata_per_band: nodata,
+        warnings,
+    })
+}
+
+fn target_grid(info: &RasterInfo) -> GisResult<TargetGrid> {
+    if info.width == 0 || info.height == 0 {
+        return Err(GisError::InvalidArgument(format!(
+            "{INVALID_ARGUMENT}: target width and height must be positive"
+        )));
+    }
+    let transform = affine::require_transform(info)?;
+    let crs = crs::require_crs(info).map_err(|_| {
+        GisError::MissingCrs(format!("{MISSING_CRS}: target raster has no CRS metadata"))
+    })?;
+    let bounds = affine::raster_bounds(info)?.tuple();
+    Ok(TargetGrid {
+        info: info.clone(),
+        transform,
+        bounds,
+        crs,
+    })
+}
+
+fn resolve_vector_source(source: &Value) -> GisResult<VectorSource> {
+    let features = vector::normalize_features(source).map_err(invalid_arg_to_geometry)?;
+    if features.is_empty() {
+        return Err(GisError::InvalidGeometry(format!(
+            "{EMPTY_FEATURE_SET}: vector source has zero features"
+        )));
+    }
+    let info_crs = source
+        .get("info")
+        .map(vector::crs_spec_from_info_json)
+        .transpose()?
+        .flatten();
+    let crs = vector::compatible_metadata_crs(info_crs, vector::geojson_crs(source)?, "source")?
+        .ok_or_else(|| {
+            GisError::MissingCrs(format!("{MISSING_CRS}: vector source has no CRS metadata"))
+        })?;
+    Ok(VectorSource { features, crs })
+}
+
+fn invalid_arg_to_geometry(error: GisError) -> GisError {
+    match error {
+        GisError::InvalidArgument(message) => GisError::InvalidGeometry(message),
+        other => other,
+    }
+}
+
+fn require_same_crs(left: &CrsSpec, right: &CrsSpec) -> GisResult<()> {
+    if crs::crs_equal(left, right) {
+        Ok(())
+    } else {
+        Err(GisError::CrsMismatch(format!(
+            "{CRS_MISMATCH}: source CRS {} does not match target CRS {}",
+            crs::canonical_label(left)?,
+            crs::canonical_label(right)?
+        )))
+    }
+}
+
+fn rasterize_source(
+    source: &VectorSource,
+    grid: &TargetGrid,
+    options: &RasterizeOptions,
+) -> GisResult<(Vec<f64>, usize)> {
+    let width = grid.info.width as usize;
+    let height = grid.info.height as usize;
+    let mut values = vec![options.fill; width * height];
+    let mut burned = vec![false; width * height];
+    for feature in &source.features {
+        let geometry = vector::feature_geometry(feature)?;
+        let burn = burn_value(feature, options)?;
+        let polygons = parse_polygonal_geometry(geometry)?;
+        if polygons.is_empty() {
+            return Err(GisError::InvalidGeometry(format!(
+                "{EMPTY_GEOMETRY}: geometry is empty"
+            )));
+        }
+        for row in 0..height {
+            for col in 0..width {
+                if polygons.iter().any(|polygon| {
+                    pixel_hits_polygon(polygon, grid.transform, row, col, options.all_touched)
+                }) {
+                    let index = row * width + col;
+                    values[index] = burn;
+                    burned[index] = true;
+                }
+            }
+        }
+    }
+    Ok((values, burned.iter().filter(|&&value| value).count()))
+}
+
+fn rasterize_bool(
+    source: &VectorSource,
+    grid: &TargetGrid,
+    all_touched: bool,
+) -> GisResult<Vec<bool>> {
+    let options = RasterizeOptions {
+        value: 1.0,
+        attribute: None,
+        dtype: RasterDType::UInt8,
+        fill: 0.0,
+        all_touched,
+    };
+    rasterize_source(source, grid, &options).map(|(values, _)| {
+        values
+            .into_iter()
+            .map(|value| (value - 1.0).abs() <= f64::EPSILON)
+            .collect()
+    })
+}
+
+fn burn_value(feature: &Value, options: &RasterizeOptions) -> GisResult<f64> {
+    let Some(attribute) = options.attribute.as_deref() else {
+        return Ok(options.value);
+    };
+    let value = feature
+        .get("properties")
+        .and_then(Value::as_object)
+        .and_then(|properties| properties.get(attribute))
+        .and_then(Value::as_f64)
+        .ok_or_else(|| {
+            GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: attribute {attribute:?} must exist and be numeric"
+            ))
+        })?;
+    validate_value_for_dtype(options.dtype, value, attribute)?;
+    Ok(value)
+}
+
+fn parse_polygonal_geometry(value: &Value) -> GisResult<Vec<Polygon>> {
+    let object = value.as_object().ok_or_else(|| {
+        GisError::InvalidGeometry(format!("{INVALID_GEOMETRY}: geometry must be an object"))
+    })?;
+    match object.get("type").and_then(Value::as_str) {
+        Some("Polygon") => Ok(vec![parse_polygon_coordinates(
+            object.get("coordinates").ok_or_else(|| {
+                GisError::InvalidGeometry(format!(
+                    "{INVALID_GEOMETRY}: Polygon requires coordinates"
+                ))
+            })?,
+        )?]),
+        Some("MultiPolygon") => {
+            let polygons = object
+                .get("coordinates")
+                .and_then(Value::as_array)
+                .ok_or_else(|| {
+                    GisError::InvalidGeometry(format!(
+                        "{INVALID_GEOMETRY}: MultiPolygon coordinates must be an array"
+                    ))
+                })?;
+            if polygons.is_empty() {
+                return Err(GisError::InvalidGeometry(format!(
+                    "{EMPTY_GEOMETRY}: geometry is empty"
+                )));
+            }
+            polygons
+                .iter()
+                .map(parse_polygon_coordinates)
+                .collect::<GisResult<Vec<_>>>()
+        }
+        Some(other) => Err(GisError::InvalidGeometry(format!(
+            "{UNSUPPORTED_GEOMETRY_TYPE}: rasterize_vectors supports Polygon and MultiPolygon, got {other}"
+        ))),
+        None => Err(GisError::InvalidGeometry(format!(
+            "{INVALID_GEOMETRY}: geometry requires a type string"
+        ))),
+    }
+}
+
+fn parse_polygon_coordinates(value: &Value) -> GisResult<Polygon> {
+    let rings = value.as_array().ok_or_else(|| {
+        GisError::InvalidGeometry(format!(
+            "{INVALID_GEOMETRY}: Polygon coordinates must be an array"
+        ))
+    })?;
+    if rings.is_empty() {
+        return Err(GisError::InvalidGeometry(format!(
+            "{EMPTY_GEOMETRY}: geometry is empty"
+        )));
+    }
+    rings.iter().map(parse_ring).collect::<GisResult<Vec<_>>>()
+}
+
+fn parse_ring(value: &Value) -> GisResult<Ring> {
+    let points = value.as_array().ok_or_else(|| {
+        GisError::InvalidGeometry(format!("{INVALID_GEOMETRY}: polygon ring must be an array"))
+    })?;
+    if points.len() < 4 {
+        return Err(GisError::InvalidGeometry(format!(
+            "{INVALID_GEOMETRY}: polygon ring must contain at least four positions"
+        )));
+    }
+    points.iter().map(parse_point).collect()
+}
+
+fn parse_point(value: &Value) -> GisResult<Point> {
+    let items = value.as_array().ok_or_else(|| {
+        GisError::InvalidGeometry(format!("{INVALID_GEOMETRY}: position must be an array"))
+    })?;
+    if items.len() < 2 {
+        return Err(GisError::InvalidGeometry(format!(
+            "{INVALID_GEOMETRY}: position requires x and y"
+        )));
+    }
+    let x = items[0].as_f64().ok_or_else(|| {
+        GisError::InvalidGeometry(format!("{INVALID_GEOMETRY}: x coordinate must be numeric"))
+    })?;
+    let y = items[1].as_f64().ok_or_else(|| {
+        GisError::InvalidGeometry(format!("{INVALID_GEOMETRY}: y coordinate must be numeric"))
+    })?;
+    if !x.is_finite() || !y.is_finite() {
+        return Err(GisError::InvalidGeometry(format!(
+            "{INVALID_GEOMETRY}: coordinates must be finite"
+        )));
+    }
+    Ok(Point { x, y })
+}
+
+fn pixel_hits_polygon(
+    polygon: &Polygon,
+    transform: AffineTransform,
+    row: usize,
+    col: usize,
+    all_touched: bool,
+) -> bool {
+    let center = affine::xy(transform, row as i64, col as i64)
+        .map(|(x, y)| Point { x, y })
+        .ok();
+    if center.is_some_and(|point| point_in_polygon(point, polygon)) {
+        return true;
+    }
+    if !all_touched {
+        return false;
+    }
+    let corners = cell_corners(transform, row, col);
+    if corners
+        .iter()
+        .any(|&corner| point_in_polygon(corner, polygon))
+    {
+        return true;
+    }
+    if polygon
+        .iter()
+        .flat_map(|ring| ring.iter())
+        .any(|&point| point_in_cell(transform, point, row, col))
+    {
+        return true;
+    }
+    for ring in polygon {
+        for segment in ring.windows(2) {
+            if cell_edges(corners)
+                .iter()
+                .any(|edge| segments_intersect(segment[0], segment[1], edge.0, edge.1))
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+fn cell_corners(transform: AffineTransform, row: usize, col: usize) -> [Point; 4] {
+    let row = row as f64;
+    let col = col as f64;
+    [
+        point_from_tuple(transform.apply(col, row)),
+        point_from_tuple(transform.apply(col + 1.0, row)),
+        point_from_tuple(transform.apply(col + 1.0, row + 1.0)),
+        point_from_tuple(transform.apply(col, row + 1.0)),
+    ]
+}
+
+fn point_from_tuple(value: (f64, f64)) -> Point {
+    Point {
+        x: value.0,
+        y: value.1,
+    }
+}
+
+fn cell_edges(corners: [Point; 4]) -> [(Point, Point); 4] {
+    [
+        (corners[0], corners[1]),
+        (corners[1], corners[2]),
+        (corners[2], corners[3]),
+        (corners[3], corners[0]),
+    ]
+}
+
+fn point_in_cell(transform: AffineTransform, point: Point, row: usize, col: usize) -> bool {
+    affine::inverse_apply(transform, point.x, point.y).is_ok_and(|(pixel_col, pixel_row)| {
+        let col = col as f64;
+        let row = row as f64;
+        pixel_col >= col && pixel_col <= col + 1.0 && pixel_row >= row && pixel_row <= row + 1.0
+    })
+}
+
+fn point_in_polygon(point: Point, polygon: &Polygon) -> bool {
+    let Some(shell) = polygon.first() else {
+        return false;
+    };
+    point_in_ring(point, shell)
+        && !polygon
+            .iter()
+            .skip(1)
+            .any(|ring| point_in_ring(point, ring))
+}
+
+fn point_in_ring(point: Point, ring: &Ring) -> bool {
+    if ring
+        .windows(2)
+        .any(|segment| point_on_segment(point, segment[0], segment[1]))
+    {
+        return true;
+    }
+    let mut inside = false;
+    for segment in ring.windows(2) {
+        let a = segment[0];
+        let b = segment[1];
+        if (a.y > point.y) != (b.y > point.y) {
+            let x = (b.x - a.x) * (point.y - a.y) / (b.y - a.y) + a.x;
+            if point.x < x {
+                inside = !inside;
+            }
+        }
+    }
+    inside
+}
+
+fn point_on_segment(point: Point, a: Point, b: Point) -> bool {
+    let cross = (point.y - a.y) * (b.x - a.x) - (point.x - a.x) * (b.y - a.y);
+    if cross.abs() > 1.0e-10 {
+        return false;
+    }
+    let dot = (point.x - a.x) * (b.x - a.x) + (point.y - a.y) * (b.y - a.y);
+    if dot < 0.0 {
+        return false;
+    }
+    let len_sq = (b.x - a.x).powi(2) + (b.y - a.y).powi(2);
+    dot <= len_sq
+}
+
+fn segments_intersect(a: Point, b: Point, c: Point, d: Point) -> bool {
+    let o1 = orientation(a, b, c);
+    let o2 = orientation(a, b, d);
+    let o3 = orientation(c, d, a);
+    let o4 = orientation(c, d, b);
+    if o1.abs() <= 1.0e-10 && point_on_segment(c, a, b) {
+        return true;
+    }
+    if o2.abs() <= 1.0e-10 && point_on_segment(d, a, b) {
+        return true;
+    }
+    if o3.abs() <= 1.0e-10 && point_on_segment(a, c, d) {
+        return true;
+    }
+    if o4.abs() <= 1.0e-10 && point_on_segment(b, c, d) {
+        return true;
+    }
+    (o1 > 0.0) != (o2 > 0.0) && (o3 > 0.0) != (o4 > 0.0)
+}
+
+fn orientation(a: Point, b: Point, c: Point) -> f64 {
+    (b.x - a.x) * (c.y - a.y) - (b.y - a.y) * (c.x - a.x)
+}
+
+fn validate_value_for_dtype(dtype: RasterDType, value: f64, field: &str) -> GisResult<()> {
+    if dtype.nodata_fits(value) {
+        Ok(())
+    } else {
+        Err(GisError::InvalidArgument(format!(
+            "{INVALID_ARGUMENT}: {field} value {value} does not fit {}",
+            dtype.name()
+        )))
+    }
+}
+
+fn validate_nodata_for_dtype(dtype: RasterDType, value: f64) -> GisResult<()> {
+    if dtype.nodata_fits(value) {
+        Ok(())
+    } else {
+        Err(GisError::InvalidNodata(format!(
+            "{INVALID_NODATA}: nodata value {value} does not fit {}",
+            dtype.name()
+        )))
+    }
+}
+
+fn normalize_nodata_len(
+    mut values: Vec<Option<f64>>,
+    band_count: usize,
+) -> GisResult<Vec<Option<f64>>> {
+    if values.is_empty() {
+        values = vec![None; band_count];
+    }
+    if values.len() == 1 && band_count > 1 {
+        return Ok(vec![values[0]; band_count]);
+    }
+    if values.len() != band_count {
+        return Err(GisError::InvalidNodata(format!(
+            "{INVALID_NODATA}: nodata length {} does not match band count {band_count}",
+            values.len()
+        )));
+    }
+    Ok(values)
+}
+
+fn expand_mask(mask: Vec<bool>, shape: &[usize], array: &RasterArray) -> GisResult<Vec<bool>> {
+    let pixels = array.height * array.width;
+    match shape {
+        [height, width] if *height == array.height && *width == array.width => {
+            let mut out = Vec::with_capacity(array.bands * pixels);
+            for _ in 0..array.bands {
+                out.extend(mask.iter().copied());
+            }
+            Ok(out)
+        }
+        [bands, height, width]
+            if *bands == 1 && *height == array.height && *width == array.width =>
+        {
+            let mut out = Vec::with_capacity(array.bands * pixels);
+            for _ in 0..array.bands {
+                out.extend(mask.iter().copied());
+            }
+            Ok(out)
+        }
+        [bands, height, width]
+            if *bands == array.bands && *height == array.height && *width == array.width =>
+        {
+            Ok(mask)
+        }
+        _ => Err(GisError::ShapeMismatch(format!(
+            "{SHAPE_MISMATCH}: mask shape {:?} is not compatible with raster shape ({}, {}, {})",
+            shape, array.bands, array.height, array.width
+        ))),
+    }
+}
+
+fn apply_mask_values(
+    values: &mut [f64],
+    valid_mask: &[bool],
+    array: &RasterArray,
+    fill: Option<f64>,
+    nodata: &[Option<f64>],
+) {
+    let pixels = array.height * array.width;
+    for band in 0..array.bands {
+        let fallback = fill.or_else(|| nodata.get(band).copied().flatten());
+        let Some(fill_value) = fallback else {
+            continue;
+        };
+        for pixel in 0..pixels {
+            let index = band * pixels + pixel;
+            if !valid_mask[index] {
+                values[index] = fill_value;
+            }
+        }
+    }
+}
+
+fn retained_window(mask: &[bool], array: &RasterArray) -> Option<PixelWindow> {
+    let pixels = array.height * array.width;
+    let mut min_row = array.height;
+    let mut min_col = array.width;
+    let mut max_row = 0usize;
+    let mut max_col = 0usize;
+    let mut found = false;
+    for band in 0..array.bands {
+        for row in 0..array.height {
+            for col in 0..array.width {
+                if mask[band * pixels + row * array.width + col] {
+                    found = true;
+                    min_row = min_row.min(row);
+                    min_col = min_col.min(col);
+                    max_row = max_row.max(row);
+                    max_col = max_col.max(col);
+                }
+            }
+        }
+    }
+    found.then(|| PixelWindow {
+        col_off: min_col as i64,
+        row_off: min_row as i64,
+        width: (max_col - min_col + 1) as u32,
+        height: (max_row - min_row + 1) as u32,
+    })
+}
+
+fn crop_values(values: &[f64], array: &RasterArray, window: PixelWindow) -> Vec<f64> {
+    let mut out = Vec::with_capacity(array.bands * window.height as usize * window.width as usize);
+    let pixels = array.height * array.width;
+    for band in 0..array.bands {
+        for row in window.row_off as usize..(window.row_off as usize + window.height as usize) {
+            let start = band * pixels + row * array.width + window.col_off as usize;
+            out.extend_from_slice(&values[start..start + window.width as usize]);
+        }
+    }
+    out
+}
+
+fn crop_values_bool(values: &[bool], array: &RasterArray, window: PixelWindow) -> Vec<bool> {
+    let mut out = Vec::with_capacity(array.bands * window.height as usize * window.width as usize);
+    let pixels = array.height * array.width;
+    for band in 0..array.bands {
+        for row in window.row_off as usize..(window.row_off as usize + window.height as usize) {
+            let start = band * pixels + row * array.width + window.col_off as usize;
+            out.extend_from_slice(&values[start..start + window.width as usize]);
+        }
+    }
+    out
+}
+
+fn source_info_for_output(
+    source_info: &RasterInfo,
+    array: &RasterArray,
+    nodata: Vec<Option<f64>>,
+) -> RasterInfo {
+    let mut info = source_info.clone();
+    info.width = array.width as u32;
+    info.height = array.height as u32;
+    info.band_count = array.bands as u16;
+    info.dtype_per_band = vec![array.dtype().name().to_string(); array.bands];
+    info.nodata_per_band = nodata;
+    info
+}
+
+fn output_info(
+    source: &RasterInfo,
+    dtype: RasterDType,
+    nodata: Vec<Option<f64>>,
+) -> GisResult<RasterInfo> {
+    let mut info = source.clone();
+    info.band_count = 1;
+    info.dtype_per_band = vec![dtype.name().to_string()];
+    info.nodata_per_band = normalize_nodata_len(nodata, 1)?;
+    info.bounds = Some(affine::raster_bounds(&info)?.tuple());
+    info.resolution = Some(affine::raster_resolution(&info)?);
+    info.is_georeferenced =
+        info.transform.is_some() && (info.crs_wkt.is_some() || info.crs_authority.is_some());
+    Ok(info)
+}
+
+fn update_info_for_window(info: &mut RasterInfo, window: PixelWindow) -> GisResult<()> {
+    info.width = window.width;
+    info.height = window.height;
+    if info.transform.is_some() {
+        let transform = affine::window_transform(info, window)?;
+        info.transform = Some(transform.tuple());
+        info.bounds = Some(transform.bounds(window.width, window.height).tuple());
+        info.resolution = Some(transform.resolution());
+    }
+    Ok(())
+}
+
+#[cfg(feature = "extension-module")]
+mod py {
+    use super::*;
+
+    use std::collections::HashMap;
+
+    use numpy::{PyArray1, PyArrayMethods};
+    use pyo3::prelude::*;
+    use pyo3::types::{PyAny, PyDict, PyDictMethods, PyList, PyTuple};
+    use pyo3::IntoPy;
+
+    use crate::gis::py_json::{py_to_json_strict, warnings_to_py};
+
+    #[pyfunction(
+        name = "rasterize_vectors",
+        signature = (vectors, target_info, *, value = 1.0, attribute = None, dtype = "uint8", fill = 0.0, all_touched = false)
+    )]
+    pub fn rasterize_vectors_py(
+        py: Python<'_>,
+        vectors: &Bound<'_, PyAny>,
+        target_info: &Bound<'_, PyAny>,
+        value: f64,
+        attribute: Option<String>,
+        dtype: &str,
+        fill: f64,
+        all_touched: bool,
+    ) -> PyResult<PyObject> {
+        let source = vector_source_to_json(vectors)?;
+        let target_info = raster_info_from_py(target_info)?;
+        let result = super::rasterize_vectors(
+            &source,
+            &target_info,
+            RasterizeOptions {
+                value,
+                attribute,
+                dtype: parse_raster_dtype(dtype)?,
+                fill,
+                all_touched,
+            },
+        )?;
+        rasterize_result_to_py(py, &result)
+    }
+
+    #[pyfunction(
+        name = "geometry_mask",
+        signature = (geometries, target_info, *, invert = false, all_touched = false, mask_polarity = "true_inside")
+    )]
+    pub fn geometry_mask_py(
+        py: Python<'_>,
+        geometries: &Bound<'_, PyAny>,
+        target_info: &Bound<'_, PyAny>,
+        invert: bool,
+        all_touched: bool,
+        mask_polarity: &str,
+    ) -> PyResult<PyObject> {
+        let source = vector_source_to_json(geometries)?;
+        let target_info = raster_info_from_py(target_info)?;
+        let result = super::geometry_mask(
+            &source,
+            &target_info,
+            GeometryMaskOptions {
+                invert,
+                all_touched,
+                mask_polarity: MaskPolarity::parse(mask_polarity)?,
+            },
+        )?;
+        geometry_mask_result_to_py(py, &result)
+    }
+
+    #[pyfunction(
+        name = "mask_raster",
+        signature = (source, mask, *, mask_polarity = None, crop = false, fill = None, nodata = None)
+    )]
+    pub fn mask_raster_py(
+        py: Python<'_>,
+        source: &Bound<'_, PyAny>,
+        mask: &Bound<'_, PyAny>,
+        mask_polarity: Option<String>,
+        crop: bool,
+        fill: Option<&Bound<'_, PyAny>>,
+        nodata: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<PyObject> {
+        let (array, info) = raster_source_from_py(source)?;
+        let (mask, mask_shape) = super::super::extract_typed_array::<bool>(mask)?;
+        let fill = optional_f64(fill, "fill")?;
+        let nodata = optional_nodata(nodata, array.bands, array.dtype())?;
+        let result = super::mask_raster(
+            array,
+            info,
+            mask,
+            &mask_shape,
+            MaskRasterOptions {
+                mask_polarity: RasterMaskPolarity::parse(mask_polarity.as_deref())?,
+                crop,
+                fill,
+                nodata,
+            },
+        )?;
+        mask_raster_result_to_py(py, &result)
+    }
+
+    fn vector_source_to_json(value: &Bound<'_, PyAny>) -> PyResult<Value> {
+        if let Ok(path) = value.extract::<String>() {
+            let result = vector::read_vector(
+                path,
+                vector::VectorReadOptions {
+                    layer: None,
+                    columns: None,
+                    bbox: None,
+                    limit: None,
+                },
+            )?;
+            return vector_result_to_json(result);
+        }
+        py_to_json_strict(value)
+    }
+
+    fn vector_result_to_json(result: vector::VectorReadResult) -> PyResult<Value> {
+        let info = serde_json::to_value(vector_info_map(&result.info)).map_err(|err| {
+            GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: failed to serialize info: {err}"
+            ))
+        })?;
+        Ok(serde_json::json!({
+            "type": "FeatureCollection",
+            "features": result.features,
+            "info": info,
+            "warnings": warnings_json(&result.warnings),
+        }))
+    }
+
+    fn vector_info_map(info: &vector::VectorInfo) -> HashMap<&'static str, Value> {
+        let mut out = HashMap::new();
+        out.insert("path", Value::String(info.path.clone()));
+        out.insert("driver", Value::String(info.driver.clone()));
+        out.insert(
+            "layer_name",
+            info.layer_name
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        out.insert("layer_count", Value::from(info.layer_count));
+        out.insert("geometry_type", Value::String(info.geometry_type.clone()));
+        out.insert("feature_count", Value::from(info.feature_count));
+        out.insert(
+            "crs_wkt",
+            info.crs_wkt
+                .clone()
+                .map(Value::String)
+                .unwrap_or(Value::Null),
+        );
+        out.insert(
+            "crs_authority",
+            serde_json::to_value(&info.crs_authority).unwrap_or(Value::Null),
+        );
+        out.insert(
+            "bounds",
+            serde_json::to_value(info.bounds).unwrap_or(Value::Null),
+        );
+        out.insert("is_georeferenced", Value::Bool(info.is_georeferenced));
+        out
+    }
+
+    fn warnings_json(warnings: &[RasterWarning]) -> Value {
+        Value::Array(
+            warnings
+                .iter()
+                .map(|warning| {
+                    serde_json::json!({
+                        "code": warning.code,
+                        "message": warning.message,
+                        "field": warning.field,
+                    })
+                })
+                .collect(),
+        )
+    }
+
+    fn raster_info_from_py(value: &Bound<'_, PyAny>) -> PyResult<RasterInfo> {
+        if let Ok(info) = value.extract::<PyRef<'_, RasterInfo>>() {
+            return Ok(info.clone());
+        }
+        let dict = value.downcast::<PyDict>().map_err(|_| {
+            GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: raster info must be RasterInfo or dict"
+            ))
+        })?;
+        let width = required_u32(dict, "width")?;
+        let height = required_u32(dict, "height")?;
+        let band_count = dict
+            .get_item("band_count")?
+            .map(|value| value.extract::<u16>())
+            .transpose()?
+            .unwrap_or(1);
+        let transform = optional_tuple6(dict.get_item("transform")?)?;
+        let dtype_per_band = dict
+            .get_item("dtype_per_band")?
+            .map(|value| value.extract::<Vec<String>>())
+            .transpose()?
+            .unwrap_or_else(|| vec!["uint8".to_string(); band_count as usize]);
+        let nodata_per_band = dict
+            .get_item("nodata_per_band")?
+            .map(|value| value.extract::<Vec<Option<f64>>>())
+            .transpose()?
+            .unwrap_or_else(|| vec![None; band_count as usize]);
+        let mut info = RasterInfo::new(
+            dict.get_item("path")?
+                .and_then(|value| value.extract::<String>().ok())
+                .unwrap_or_default()
+                .into(),
+            width,
+            height,
+            band_count,
+        );
+        info.driver = dict
+            .get_item("driver")?
+            .and_then(|value| value.extract::<String>().ok())
+            .unwrap_or_else(|| "memory".to_string());
+        info.dtype_per_band = dtype_per_band;
+        info.crs_wkt = optional_string(dict.get_item("crs_wkt")?)?;
+        info.crs_authority = dict
+            .get_item("crs_authority")?
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract::<HashMap<String, String>>().map(Some)
+                }
+            })
+            .transpose()?
+            .flatten();
+        info.transform = transform;
+        info.bounds = optional_tuple4(dict.get_item("bounds")?)?;
+        if info.bounds.is_none() && info.transform.is_some() && width > 0 && height > 0 {
+            info.bounds = Some(affine::raster_bounds(&info)?.tuple());
+        }
+        info.resolution = optional_tuple2(dict.get_item("resolution")?)?;
+        if info.resolution.is_none() && info.transform.is_some() {
+            info.resolution = Some(affine::raster_resolution(&info)?);
+        }
+        info.nodata_per_band = nodata_per_band;
+        info.is_georeferenced =
+            info.transform.is_some() && (info.crs_wkt.is_some() || info.crs_authority.is_some());
+        Ok(info)
+    }
+
+    fn raster_source_from_py(value: &Bound<'_, PyAny>) -> PyResult<(RasterArray, RasterInfo)> {
+        if let Ok(path) = value.extract::<String>() {
+            let result = raster_info::read_raster(path, None, None, false)?;
+            return Ok((result.array, result.info));
+        }
+        if let Ok(dict) = value.downcast::<PyDict>() {
+            if let Some(array_value) = dict.get_item("array")? {
+                let array = super::super::extract_raster_array(&array_value)?;
+                let info = if let Some(info_value) = dict.get_item("info")? {
+                    raster_info_from_py(&info_value)?
+                } else {
+                    synthetic_info(&array)
+                };
+                validate_info_shape(&info, &array)?;
+                return Ok((array, info));
+            }
+        }
+        let array = super::super::extract_raster_array(value)?;
+        let info = synthetic_info(&array);
+        Ok((array, info))
+    }
+
+    fn synthetic_info(array: &RasterArray) -> RasterInfo {
+        let mut info = RasterInfo::new(
+            "".into(),
+            array.width as u32,
+            array.height as u32,
+            array.bands as u16,
+        );
+        info.driver = "memory".to_string();
+        info.dtype_per_band = vec![array.dtype().name().to_string(); array.bands];
+        info.nodata_per_band = vec![None; array.bands];
+        info
+    }
+
+    fn validate_info_shape(info: &RasterInfo, array: &RasterArray) -> PyResult<()> {
+        if info.width as usize != array.width || info.height as usize != array.height {
+            return Err(GisError::ShapeMismatch(format!(
+                "{SHAPE_MISMATCH}: source info shape {}x{} does not match array shape {}x{}",
+                info.width, info.height, array.width, array.height
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    fn required_u32(dict: &Bound<'_, PyDict>, key: &'static str) -> PyResult<u32> {
+        dict.get_item(key)?
+            .ok_or_else(|| {
+                GisError::InvalidArgument(format!("{INVALID_ARGUMENT}: raster info missing {key}"))
+            })?
+            .extract::<u32>()
+            .map_err(Into::into)
+    }
+
+    fn optional_string(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<String>> {
+        value
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract::<String>().map(Some)
+                }
+            })
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn optional_tuple6(
+        value: Option<Bound<'_, PyAny>>,
+    ) -> PyResult<Option<(f64, f64, f64, f64, f64, f64)>> {
+        value
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract::<(f64, f64, f64, f64, f64, f64)>().map(Some)
+                }
+            })
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn optional_tuple4(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<(f64, f64, f64, f64)>> {
+        value
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract::<(f64, f64, f64, f64)>().map(Some)
+                }
+            })
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn optional_tuple2(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<(f64, f64)>> {
+        value
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract::<(f64, f64)>().map(Some)
+                }
+            })
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn optional_f64(value: Option<&Bound<'_, PyAny>>, field: &str) -> PyResult<Option<f64>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        if value.is_none() {
+            return Ok(None);
+        }
+        value.extract::<f64>().map(Some).map_err(|_| {
+            GisError::InvalidArgument(format!("{INVALID_ARGUMENT}: {field} must be numeric")).into()
+        })
+    }
+
+    fn optional_nodata(
+        value: Option<&Bound<'_, PyAny>>,
+        bands: usize,
+        dtype: RasterDType,
+    ) -> PyResult<Option<Vec<Option<f64>>>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        if value.is_none() {
+            return Ok(None);
+        }
+        let values = if let Ok(number) = value.extract::<f64>() {
+            vec![Some(number); bands]
+        } else if let Ok(list) = value.downcast::<PyList>() {
+            nodata_from_iter(list.iter(), bands)?
+        } else if let Ok(tuple) = value.downcast::<PyTuple>() {
+            nodata_from_iter(tuple.iter(), bands)?
+        } else {
+            return Err(GisError::InvalidNodata(format!(
+                "{INVALID_NODATA}: nodata must be a scalar or per-band list"
+            ))
+            .into());
+        };
+        for item in values.iter().flatten() {
+            validate_nodata_for_dtype(dtype, *item)?;
+        }
+        Ok(Some(values))
+    }
+
+    fn nodata_from_iter<'py>(
+        items: impl Iterator<Item = Bound<'py, PyAny>>,
+        bands: usize,
+    ) -> PyResult<Vec<Option<f64>>> {
+        let values = items
+            .map(|item| {
+                if item.is_none() {
+                    Ok(None)
+                } else {
+                    item.extract::<f64>().map(Some).map_err(|_| {
+                        GisError::InvalidNodata(format!(
+                            "{INVALID_NODATA}: nodata list values must be numeric or None"
+                        ))
+                        .into()
+                    })
+                }
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        if values.len() != bands {
+            return Err(GisError::InvalidNodata(format!(
+                "{INVALID_NODATA}: nodata length {} does not match band count {bands}",
+                values.len()
+            ))
+            .into());
+        }
+        Ok(values)
+    }
+
+    fn rasterize_result_to_py(py: Python<'_>, result: &RasterizeResult) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item(
+            "array",
+            values_to_py_2d(
+                py,
+                result.dtype,
+                result.values.clone(),
+                result.target_shape.0,
+                result.target_shape.1,
+            )?,
+        )?;
+        dict.set_item(
+            "info",
+            super::super::raster_info_to_py_dict(py, &result.info)?,
+        )?;
+        dict.set_item("target_shape", result.target_shape)?;
+        dict.set_item("target_transform", result.target_transform.tuple())?;
+        dict.set_item("target_bounds", result.target_bounds)?;
+        dict.set_item("dtype", result.dtype.name())?;
+        dict.set_item("fill", result.fill)?;
+        dict.set_item("burned_pixels", result.burned_pixels)?;
+        dict.set_item("all_touched", result.all_touched)?;
+        dict.set_item("warnings", warnings_to_py(py, &result.warnings)?)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn geometry_mask_result_to_py(
+        py: Python<'_>,
+        result: &GeometryMaskResult,
+    ) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        let height = result.info.height as usize;
+        let width = result.info.width as usize;
+        dict.set_item(
+            "mask",
+            PyArray1::from_vec_bound(py, result.mask.clone())
+                .reshape([height, width])?
+                .into_py(py),
+        )?;
+        dict.set_item(
+            "info",
+            super::super::raster_info_to_py_dict(py, &result.info)?,
+        )?;
+        dict.set_item("mask_polarity", result.mask_polarity.as_str())?;
+        dict.set_item("true_count", result.true_count)?;
+        dict.set_item("false_count", result.false_count)?;
+        dict.set_item("crop_window", py.None())?;
+        dict.set_item("warnings", warnings_to_py(py, &result.warnings)?)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn mask_raster_result_to_py(py: Python<'_>, result: &MaskRasterResult) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        let empty_crop = result
+            .crop_window
+            .is_some_and(|window| window.width == 0 || window.height == 0);
+        if empty_crop {
+            dict.set_item(
+                "array",
+                empty_array_to_py(py, result.array.dtype(), result.array.bands)?,
+            )?;
+            dict.set_item(
+                "mask",
+                PyArray1::from_vec_bound(py, Vec::<bool>::new())
+                    .reshape([result.array.bands, 0, 0])?
+                    .into_py(py),
+            )?;
+        } else {
+            dict.set_item(
+                "array",
+                super::super::raster_array_to_py(py, &result.array)?,
+            )?;
+            dict.set_item(
+                "mask",
+                super::super::bool_array_to_py_shape(
+                    py,
+                    result.mask.clone(),
+                    (result.array.bands, result.array.height, result.array.width),
+                )?,
+            )?;
+        }
+        dict.set_item(
+            "info",
+            super::super::raster_info_to_py_dict(py, &result.info)?,
+        )?;
+        dict.set_item("mask_polarity", result.mask_polarity.as_str())?;
+        dict.set_item("fill", result.fill)?;
+        dict.set_item("nodata", result.nodata_per_band.clone())?;
+        dict.set_item("valid_count", result.valid_count)?;
+        let true_count = result.mask.iter().filter(|&&value| value).count();
+        dict.set_item("true_count", true_count)?;
+        dict.set_item("false_count", result.mask.len() - true_count)?;
+        dict.set_item(
+            "crop_window",
+            result
+                .crop_window
+                .map(|window| (window.col_off, window.row_off, window.width, window.height)),
+        )?;
+        dict.set_item("nodata_per_band", result.nodata_per_band.clone())?;
+        dict.set_item("warnings", warnings_to_py(py, &result.warnings)?)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn empty_array_to_py(py: Python<'_>, dtype: RasterDType, bands: usize) -> PyResult<PyObject> {
+        match dtype {
+            RasterDType::UInt8 => Ok(PyArray1::from_vec_bound(py, Vec::<u8>::new())
+                .reshape([bands, 0, 0])?
+                .into_py(py)),
+            RasterDType::Int16 => Ok(PyArray1::from_vec_bound(py, Vec::<i16>::new())
+                .reshape([bands, 0, 0])?
+                .into_py(py)),
+            RasterDType::UInt16 => Ok(PyArray1::from_vec_bound(py, Vec::<u16>::new())
+                .reshape([bands, 0, 0])?
+                .into_py(py)),
+            RasterDType::Int32 => Ok(PyArray1::from_vec_bound(py, Vec::<i32>::new())
+                .reshape([bands, 0, 0])?
+                .into_py(py)),
+            RasterDType::UInt32 => Ok(PyArray1::from_vec_bound(py, Vec::<u32>::new())
+                .reshape([bands, 0, 0])?
+                .into_py(py)),
+            RasterDType::Float32 => Ok(PyArray1::from_vec_bound(py, Vec::<f32>::new())
+                .reshape([bands, 0, 0])?
+                .into_py(py)),
+            RasterDType::Float64 => Ok(PyArray1::from_vec_bound(py, Vec::<f64>::new())
+                .reshape([bands, 0, 0])?
+                .into_py(py)),
+        }
+    }
+
+    fn values_to_py_2d(
+        py: Python<'_>,
+        dtype: RasterDType,
+        values: Vec<f64>,
+        height: usize,
+        width: usize,
+    ) -> PyResult<PyObject> {
+        let array = raster_info::f64_to_raster_data(dtype, values, 1, height, width)?;
+        match array.data {
+            crate::gis::raster_write::RasterData::U8(data) => {
+                Ok(PyArray1::from_vec_bound(py, data)
+                    .reshape([height, width])?
+                    .into_py(py))
+            }
+            crate::gis::raster_write::RasterData::I16(data) => {
+                Ok(PyArray1::from_vec_bound(py, data)
+                    .reshape([height, width])?
+                    .into_py(py))
+            }
+            crate::gis::raster_write::RasterData::U16(data) => {
+                Ok(PyArray1::from_vec_bound(py, data)
+                    .reshape([height, width])?
+                    .into_py(py))
+            }
+            crate::gis::raster_write::RasterData::I32(data) => {
+                Ok(PyArray1::from_vec_bound(py, data)
+                    .reshape([height, width])?
+                    .into_py(py))
+            }
+            crate::gis::raster_write::RasterData::U32(data) => {
+                Ok(PyArray1::from_vec_bound(py, data)
+                    .reshape([height, width])?
+                    .into_py(py))
+            }
+            crate::gis::raster_write::RasterData::F32(data) => {
+                Ok(PyArray1::from_vec_bound(py, data)
+                    .reshape([height, width])?
+                    .into_py(py))
+            }
+            crate::gis::raster_write::RasterData::F64(data) => {
+                Ok(PyArray1::from_vec_bound(py, data)
+                    .reshape([height, width])?
+                    .into_py(py))
+            }
+        }
+    }
+}
+
+#[cfg(feature = "extension-module")]
+pub use py::{geometry_mask_py, mask_raster_py, rasterize_vectors_py};

--- a/src/gis/vector.rs
+++ b/src/gis/vector.rs
@@ -675,7 +675,7 @@ fn resolve_clip_crs(clip_geometry: &Value, explicit: Option<Value>) -> GisResult
     })
 }
 
-fn compatible_metadata_crs(
+pub(crate) fn compatible_metadata_crs(
     left: Option<CrsSpec>,
     right: Option<CrsSpec>,
     label: &str,
@@ -731,7 +731,7 @@ fn crs_spec_from_json_value(value: &Value) -> GisResult<Option<CrsSpec>> {
     CrsSpec::from_parts(Some(name), Some(code), None).map(Some)
 }
 
-fn crs_spec_from_info_json(info: &Value) -> GisResult<Option<CrsSpec>> {
+pub(crate) fn crs_spec_from_info_json(info: &Value) -> GisResult<Option<CrsSpec>> {
     if let Some(authority) = info.get("crs_authority").and_then(Value::as_object) {
         if let (Some(name), Some(code)) = (
             authority.get("name").and_then(json_value_string),
@@ -748,7 +748,7 @@ fn crs_spec_from_info_json(info: &Value) -> GisResult<Option<CrsSpec>> {
     Ok(None)
 }
 
-fn feature_geometry(feature: &Value) -> GisResult<&Value> {
+pub(crate) fn feature_geometry(feature: &Value) -> GisResult<&Value> {
     feature.get("geometry").ok_or_else(|| {
         GisError::InvalidGeometry("invalid_geometry: Feature requires geometry".to_string())
     })
@@ -1255,7 +1255,7 @@ fn resolve_vector_source_crs(
     }
 }
 
-fn crs_spec_from_vector_info(info: &VectorInfo) -> GisResult<Option<CrsSpec>> {
+pub(crate) fn crs_spec_from_vector_info(info: &VectorInfo) -> GisResult<Option<CrsSpec>> {
     if let Some(authority) = info.crs_authority.as_ref() {
         let name = authority.get("name").cloned().ok_or_else(|| {
             GisError::InvalidCrs("invalid_crs: vector CRS authority is missing name".to_string())
@@ -1553,7 +1553,7 @@ fn geojson_layer_name(path: &Path, root: &Value) -> Option<String> {
         .or_else(|| path.file_stem()?.to_str().map(str::to_string))
 }
 
-fn geojson_crs(root: &Value) -> GisResult<Option<CrsSpec>> {
+pub(crate) fn geojson_crs(root: &Value) -> GisResult<Option<CrsSpec>> {
     let Some(crs_value) = root.get("crs") else {
         return Ok(None);
     };
@@ -1595,7 +1595,7 @@ fn parse_vector_crs_spec(value: &str) -> GisResult<Option<CrsSpec>> {
         .map_err(|err| GisError::InvalidCrs(format!("invalid_crs: {}", err.message())))
 }
 
-fn normalize_features(root: &Value) -> GisResult<Vec<Value>> {
+pub(crate) fn normalize_features(root: &Value) -> GisResult<Vec<Value>> {
     match root.get("type").and_then(Value::as_str) {
         Some("FeatureCollection") => {
             let features = root

--- a/src/py_module/functions/gis.rs
+++ b/src/py_module/functions/gis.rs
@@ -25,6 +25,9 @@ pub(crate) fn register_gis_py_functions(m: &Bound<'_, PyModule>) -> PyResult<()>
     m.add_function(wrap_pyfunction!(crate::gis::intersect_vectors_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::simplify_geometry_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::load_boundary_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::rasterize_vectors_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::geometry_mask_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::mask_raster_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::parse_crs_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::inspect_crs_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::raster_crs_py, m)?)?;

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -147,6 +147,9 @@ class TestNativeModuleSymbols:
         "intersect_vectors",
         "simplify_geometry",
         "load_boundary",
+        "rasterize_vectors",
+        "geometry_mask",
+        "mask_raster",
         # G-002b: Rust-backed GIS CRS/affine/warp operations
         "parse_crs",
         "inspect_crs",
@@ -181,9 +184,6 @@ class TestNativeModuleSymbols:
     ]
 
     LATER_GIS_FUNCTIONS = [
-        "rasterize_vectors",
-        "geometry_mask",
-        "mask_raster",
         "normalize_raster",
         "classify_raster",
     ]

--- a/tests/test_gis_raster.py
+++ b/tests/test_gis_raster.py
@@ -141,6 +141,9 @@ def test_public_gis_wrapper_surface():
         "intersect_vectors",
         "simplify_geometry",
         "load_boundary",
+        "rasterize_vectors",
+        "geometry_mask",
+        "mask_raster",
         "write_raster",
         "parse_crs",
         "inspect_crs",
@@ -195,6 +198,9 @@ def test_public_gis_wrapper_surface():
     assert callable(gis.intersect_vectors)
     assert callable(gis.simplify_geometry)
     assert callable(gis.load_boundary)
+    assert callable(gis.rasterize_vectors)
+    assert callable(gis.geometry_mask)
+    assert callable(gis.mask_raster)
     assert callable(gis.write_raster)
     assert callable(gis.parse_crs)
     assert callable(gis.inspect_crs)

--- a/tests/test_gis_rasterize_mask.py
+++ b/tests/test_gis_rasterize_mask.py
@@ -1,0 +1,309 @@
+"""G-002c C5 rasterization and explicit mask contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import forge3d.gis as gis
+from forge3d._native import NATIVE_AVAILABLE
+
+
+pytestmark = pytest.mark.skipif(
+    not NATIVE_AVAILABLE,
+    reason="GIS rasterize/mask tests require the compiled _forge3d extension",
+)
+
+
+def _target_info(
+    *,
+    width: int = 4,
+    height: int = 4,
+    transform: tuple[float, float, float, float, float, float] = (
+        1.0,
+        0.0,
+        0.0,
+        0.0,
+        -1.0,
+        4.0,
+    ),
+    dtype: str = "uint8",
+    crs: str | None = "4326",
+) -> dict:
+    info = {
+        "path": "",
+        "driver": "memory",
+        "width": width,
+        "height": height,
+        "band_count": 1,
+        "dtype_per_band": [dtype],
+        "crs_wkt": None,
+        "crs_authority": None if crs is None else {"name": "EPSG", "code": crs},
+        "transform": transform,
+        "bounds": gis.array_bounds(height, width, transform),
+        "resolution": (abs(transform[0]), abs(transform[4])),
+        "nodata_per_band": [None],
+        "warnings": [],
+    }
+    return info
+
+
+def _square() -> dict:
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [[1.0, 1.0], [3.0, 1.0], [3.0, 3.0], [1.0, 3.0], [1.0, 1.0]]
+        ],
+    }
+
+
+def _tiny_boundary_square() -> dict:
+    return {
+        "type": "Polygon",
+        "coordinates": [
+            [[0.9, 0.9], [1.1, 0.9], [1.1, 1.1], [0.9, 1.1], [0.9, 0.9]]
+        ],
+    }
+
+
+def _fc(features: list[dict], *, crs: str | None = "4326") -> dict:
+    out = {"type": "FeatureCollection", "features": features}
+    if crs is not None:
+        out["crs"] = {"type": "name", "properties": {"name": f"EPSG:{crs}"}}
+    return out
+
+
+def _feature(geometry: dict, properties: dict | None = None) -> dict:
+    return {
+        "type": "Feature",
+        "properties": properties or {},
+        "geometry": geometry,
+    }
+
+
+def _write_geojson(path: Path, payload: dict) -> Path:
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _codes(warnings) -> set[str]:
+    return {warning["code"] for warning in warnings}
+
+
+def test_rasterize_vectors_constant_burn_on_explicit_grid(tmp_path: Path):
+    path = _write_geojson(tmp_path / "poly.geojson", _fc([_feature(_square())]))
+
+    result = gis.rasterize_vectors(path, _target_info(), value=7)
+
+    expected = np.zeros((4, 4), dtype=np.uint8)
+    expected[1:3, 1:3] = 7
+    np.testing.assert_array_equal(result["array"], expected)
+    assert result["target_shape"] == (4, 4)
+    assert result["target_transform"] == pytest.approx((1.0, 0.0, 0.0, 0.0, -1.0, 4.0))
+    assert result["target_bounds"] == pytest.approx((0.0, 0.0, 4.0, 4.0))
+    assert result["dtype"] == "uint8"
+    assert result["fill"] == 0
+    assert result["burned_pixels"] == 4
+    assert result["all_touched"] is False
+    assert result["warnings"] == []
+    assert result["info"]["width"] == 4
+    assert result["info"]["height"] == 4
+
+
+def test_rasterize_vectors_attribute_burn_fill_and_dtype():
+    source = _fc([_feature(_square(), {"burn": -2})])
+
+    result = gis.rasterize_vectors(
+        source,
+        _target_info(dtype="int16"),
+        attribute="burn",
+        dtype="int16",
+        fill=-9,
+    )
+
+    expected = np.full((4, 4), -9, dtype=np.int16)
+    expected[1:3, 1:3] = -2
+    np.testing.assert_array_equal(result["array"], expected)
+    assert result["dtype"] == "int16"
+    assert result["fill"] == -9
+    assert result["burned_pixels"] == 4
+
+
+def test_rasterize_vectors_all_touched_cell_touch_semantics():
+    source = _fc([_feature(_tiny_boundary_square())])
+    target = _target_info(width=3, height=3, transform=(1.0, 0.0, 0.0, 0.0, -1.0, 3.0))
+
+    center = gis.rasterize_vectors(source, target, value=1, all_touched=False)
+    touched = gis.rasterize_vectors(source, target, value=1, all_touched=True)
+
+    np.testing.assert_array_equal(center["array"], np.zeros((3, 3), dtype=np.uint8))
+    expected = np.zeros((3, 3), dtype=np.uint8)
+    expected[1:3, 0:2] = 1
+    np.testing.assert_array_equal(touched["array"], expected)
+    assert touched["burned_pixels"] == 4
+
+
+def test_geometry_mask_true_inside_and_invert():
+    source = _fc([_feature(_square())])
+
+    inside = gis.geometry_mask(source, _target_info(), mask_polarity="true_inside")
+    inverted = gis.geometry_mask(
+        source,
+        _target_info(),
+        invert=True,
+        mask_polarity="true_inside",
+    )
+
+    expected = np.zeros((4, 4), dtype=bool)
+    expected[1:3, 1:3] = True
+    np.testing.assert_array_equal(inside["mask"], expected)
+    assert inside["mask_polarity"] == "true_inside"
+    assert inside["true_count"] == 4
+    assert inside["false_count"] == 12
+    assert inside["crop_window"] is None
+    np.testing.assert_array_equal(inverted["mask"], ~expected)
+    assert inverted["mask_polarity"] == "true_outside"
+    assert inverted["true_count"] == 12
+    assert inverted["false_count"] == 4
+
+
+def test_mask_raster_requires_explicit_valid_polarity_and_applies_fill():
+    source = np.arange(1, 10, dtype=np.uint8).reshape(3, 3)
+    mask = np.array(
+        [[True, False, True], [False, True, False], [True, False, True]],
+        dtype=bool,
+    )
+
+    with pytest.raises(ValueError, match="mask_polarity_explicit"):
+        gis.mask_raster(source, mask)
+    with pytest.raises(ValueError, match="mask_polarity_explicit"):
+        gis.mask_raster(source, mask, mask_polarity="inside")
+
+    result = gis.mask_raster(source, mask, mask_polarity="true_valid", fill=0)
+
+    expected = np.array(
+        [[[1, 0, 3], [0, 5, 0], [7, 0, 9]]],
+        dtype=np.uint8,
+    )
+    np.testing.assert_array_equal(result["array"], expected)
+    assert result["mask_polarity"] == "true_valid"
+    assert result["fill"] == 0.0
+    assert result["nodata"] == [None]
+    assert result["true_count"] == 5
+    assert result["false_count"] == 4
+    assert result["valid_count"] == 5
+    assert result["crop_window"] is None
+
+
+def test_mask_raster_crop_updates_window_transform_and_bounds():
+    source = {
+        "array": np.arange(16, dtype=np.uint8).reshape(1, 4, 4),
+        "info": _target_info(),
+    }
+    mask = np.zeros((4, 4), dtype=bool)
+    mask[1:3, 1:3] = True
+
+    result = gis.mask_raster(source, mask, mask_polarity="true_valid", crop=True)
+
+    np.testing.assert_array_equal(
+        result["array"],
+        np.array([[[5, 6], [9, 10]]], dtype=np.uint8),
+    )
+    assert result["crop_window"] == (1, 1, 2, 2)
+    assert result["info"]["width"] == 2
+    assert result["info"]["height"] == 2
+    assert result["info"]["transform"] == pytest.approx((1.0, 0.0, 1.0, 0.0, -1.0, 3.0))
+    assert result["info"]["bounds"] == pytest.approx((1.0, 1.0, 3.0, 3.0))
+
+
+def test_mask_raster_nodata_fill_invalid_nodata_and_empty_crop():
+    source = np.arange(1, 10, dtype=np.uint8).reshape(3, 3)
+    mask = np.zeros((3, 3), dtype=bool)
+    mask[1, 1] = True
+
+    result = gis.mask_raster(source, mask, mask_polarity="true_valid", nodata=255)
+    expected = np.full((1, 3, 3), 255, dtype=np.uint8)
+    expected[0, 1, 1] = 5
+    np.testing.assert_array_equal(result["array"], expected)
+    assert result["fill"] is None
+    assert result["nodata"] == [255.0]
+    assert result["nodata_per_band"] == [255.0]
+    assert result["true_count"] == 1
+    assert result["false_count"] == 8
+
+    with pytest.raises(ValueError, match="invalid_nodata"):
+        gis.mask_raster(source, mask, mask_polarity="true_valid", nodata=-1)
+    empty = gis.mask_raster(source, np.zeros((3, 3), dtype=bool), mask_polarity="true_valid", crop=True)
+    assert empty["array"].shape == (1, 0, 0)
+    assert empty["crop_window"] == (0, 0, 0, 0)
+    assert "empty_raster" in _codes(empty["warnings"])
+
+
+def test_mask_raster_shape_mismatch():
+    source = np.zeros((2, 3, 3), dtype=np.uint8)
+
+    with pytest.raises(ValueError, match="shape_mismatch"):
+        gis.mask_raster(source, np.zeros((2, 2), dtype=bool), mask_polarity="true_valid")
+    with pytest.raises(ValueError, match="shape_mismatch"):
+        gis.mask_raster(source, np.zeros((3, 3, 3), dtype=bool), mask_polarity="true_valid")
+
+
+def test_rasterize_vectors_crs_mismatch_and_missing_crs_errors():
+    with pytest.raises(ValueError, match="crs_mismatch"):
+        gis.rasterize_vectors(_fc([_feature(_square())], crs="3857"), _target_info())
+
+    with pytest.raises(ValueError, match="missing_crs"):
+        gis.rasterize_vectors(_fc([_feature(_square())], crs=None), _target_info())
+
+    with pytest.raises(ValueError, match="missing_crs"):
+        gis.rasterize_vectors(_fc([_feature(_square())]), _target_info(crs=None))
+
+
+def test_rasterize_vectors_empty_unsupported_and_dtype_errors():
+    with pytest.raises(ValueError, match="empty_feature_set"):
+        gis.rasterize_vectors(_fc([]), _target_info())
+
+    with pytest.raises(ValueError, match="empty_geometry"):
+        gis.rasterize_vectors(_fc([_feature({"type": "Polygon", "coordinates": []})]), _target_info())
+
+    with pytest.raises(ValueError, match="unsupported_geometry_type"):
+        gis.rasterize_vectors(
+            _fc([_feature({"type": "Point", "coordinates": [1.0, 1.0]})]),
+            _target_info(),
+        )
+
+    with pytest.raises(TypeError, match="unsupported_dtype"):
+        gis.rasterize_vectors(_fc([_feature(_square())]), _target_info(), dtype="bool")
+
+
+def test_no_runtime_python_gis_backend_imports_or_rust_backend_mentions():
+    repo = Path(__file__).resolve().parents[1]
+    files = [repo / "python/forge3d/gis.py", repo / "src/gis/rasterize.rs"]
+    banned = ("rasterio", "geopandas", "shapely", "rioxarray", "xarray", "terra")
+
+    for path in files:
+        if not path.exists():
+            continue
+        source = path.read_text(encoding="utf-8")
+        for name in banned:
+            assert name not in source
+
+
+def test_optional_rasterio_reference_rasterize_matches_small_polygon():
+    rio_features = pytest.importorskip("rasterio.features")
+    rio_transform = pytest.importorskip("rasterio.transform")
+    source = _fc([_feature(_square())])
+
+    result = gis.rasterize_vectors(source, _target_info(), value=1)
+    expected = rio_features.rasterize(
+        [(_square(), 1)],
+        out_shape=(4, 4),
+        transform=rio_transform.Affine(1.0, 0.0, 0.0, 0.0, -1.0, 4.0),
+        fill=0,
+        dtype="uint8",
+    )
+
+    np.testing.assert_array_equal(result["array"], expected)

--- a/tests/test_gis_vector_geom.py
+++ b/tests/test_gis_vector_geom.py
@@ -366,23 +366,14 @@ def test_no_python_gis_backend_imports_in_forge3d_gis():
         assert banned not in source
 
 
-def test_no_c5_c6_api_names_in_gis_public_surfaces():
+def test_no_c6_api_names_in_gis_public_surfaces():
     repo = Path(__file__).resolve().parents[1]
     files = [
         repo / "python/forge3d/gis.py",
         repo / "python/forge3d/gis.pyi",
         repo / "src/py_module/functions/gis.rs",
     ]
-    banned = [
-        "_".join(parts)
-        for parts in (
-            ("rasterize", "vectors"),
-            ("geometry", "mask"),
-            ("mask", "raster"),
-            ("normalize", "raster"),
-            ("classify", "raster"),
-        )
-    ]
+    banned = ["normalize_raster", "classify_raster"]
 
     for path in files:
         source = path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
- Implements the G-002c C5 public APIs: `rasterize_vectors`, `geometry_mask`, and `mask_raster`.
- Adds the Rust rasterization/mask backend, thin Python wrappers/stubs, API contract updates, and focused rasterize/mask tests.
- Keeps the target grid explicit and mask polarity explicit for C5 behavior.

## Explicit Non-Goals
- No `normalize_raster`.
- No `classify_raster`.
- No Python GIS backend libraries for runtime behavior: no rasterio, geopandas, shapely, rioxarray, xarray, or terra.
- No rendering, gallery, remote/cache, or domain helper work.

## Validation
Post-commit evidence bundle: `C:\Users\milos\AppData\Local\Temp\forge3d-g002c-c5-post-commit-bundle-20260702T082709Z`

- `cargo fmt --check`: passed
- `cargo check`: passed
- `python -m py_compile python/forge3d/gis.py`: passed
- `python -m pytest tests/test_api_contracts.py tests/test_gis_raster.py tests/test_gis_rasterize_mask.py -q`: 351 passed
- `python -m pytest tests/test_gis_raster.py tests/test_gis_crs_affine.py tests/test_gis_alignment_windowing.py tests/test_gis_resample_reproject.py -q`: 105 passed
- `python -m pytest tests/test_gis_vector_io.py tests/test_gis_vector_crs.py tests/test_gis_vector_geom.py tests/test_gis_vector_overlay.py -q`: 93 passed, 63 skipped
- Runtime API probe confirmed C5 APIs present and C6 APIs absent.
- Runtime backend scan found no forbidden Python GIS backend libraries in C5 runtime files.

Review bundle: `C:\Users\milos\AppData\Local\Temp\forge3d-g002c-c5-review-bundle-20260702T074335Z`

## Notes
- The unrelated audit log was not included.