### PR TITLE
Implement G-002c C6 thematic raster

### DIFF
--- a/docs/carto-engine/g-002c-c6-implementation-plan.md
+++ b/docs/carto-engine/g-002c-c6-implementation-plan.md
@@ -1,0 +1,263 @@
+# G-002c C6 Thematic Raster Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement only `normalize_raster` and `classify_raster` for G-002c C6 thematic raster operations.
+
+**Architecture:** Keep GIS backend behavior in Rust under `src/gis/`, with a new focused `src/gis/thematic.rs`. Python wrappers stay thin: path normalization, keyword forwarding, and `__all__` exposure only.
+
+**Tech Stack:** Rust, PyO3, NumPy at the Python boundary, existing `RasterArray`/`RasterData`/`RasterDType`/`RasterInfo` helpers, and NumPy-only reference tests.
+
+---
+
+## Current State
+
+Synced `main` is at merge commit `1189ad1b06227012db3a1f794a8d30e301945e19`, merged from PR #96. C5 is present on current `main`; do not write a blocker note.
+
+| Surface | Evidence |
+|---|---|
+| G-002a1 raster read/write: `RasterInfo`, `read_raster_info`, `read_raster`, `write_raster` | `src/gis/mod.rs:27`, `src/gis/mod.rs:28`, `src/gis/raster_info.rs:38`, `src/gis/raster_info.rs:359`, `src/gis/raster_write.rs:287`, `python/forge3d/gis.py:44`, `python/forge3d/gis.py:49`, `python/forge3d/gis.py:304`, `tests/test_gis_raster.py:50` |
+| G-002b CRS, affine, nodata/mask, resampling, alignment, reprojection, windows | `docs/carto-engine/g-002b-support-matrix.md:14`, `docs/carto-engine/g-002b-support-matrix.md:17`, `docs/carto-engine/g-002b-support-matrix.md:18`, `docs/carto-engine/g-002b-support-matrix.md:19`, `docs/carto-engine/g-002b-support-matrix.md:20`, `docs/carto-engine/g-002b-support-matrix.md:21`, `src/gis/mod.rs:31`, `src/gis/mod.rs:435`, `src/gis/mod.rs:473`, `src/gis/warp.rs:88` |
+| G-002c C1 vector metadata/read: `VectorInfo`, `read_vector`, `geometry_type`, `vector_schema`, `feature_count`, `vector_crs`, `vector_bounds` | `src/gis/mod.rs:39`, `src/py_module/functions/gis.rs:8`, `src/py_module/functions/gis.rs:10`, `src/py_module/functions/gis.rs:11`, `src/py_module/functions/gis.rs:12`, `src/py_module/functions/gis.rs:13`, `src/py_module/functions/gis.rs:14`, `python/forge3d/gis.py:69`, `python/forge3d/gis.py:96`, `python/forge3d/gis.py:101`, `python/forge3d/gis.py:106`, `python/forge3d/gis.py:111`, `python/forge3d/gis.py:116`, `python/forge3d/gis.pyi:47`, `python/forge3d/gis.pyi:133` |
+| G-002c C2: `reproject_vector` | `src/py_module/functions/gis.rs:9`, `python/forge3d/gis.py:87`, `python/forge3d/gis.pyi:143`, `tests/test_gis_vector_crs.py:1` |
+| G-002c C3 geometry: `validate_geometry`, `repair_geometry`, `geometry_measure`, `geometry_centroid`, `representative_point`, `interpolate_line` | `src/gis/mod.rs:17`, `src/py_module/functions/gis.rs:15`, `src/py_module/functions/gis.rs:16`, `src/py_module/functions/gis.rs:17`, `src/py_module/functions/gis.rs:18`, `src/py_module/functions/gis.rs:19`, `src/py_module/functions/gis.rs:20`, `python/forge3d/gis.py:125`, `python/forge3d/gis.py:130`, `python/forge3d/gis.py:135`, `python/forge3d/gis.py:144`, `python/forge3d/gis.py:149`, `python/forge3d/gis.py:154`, `tests/test_gis_vector_geom.py:1` |
+| G-002c C4 overlay/topology: `union_geometries`, `dissolve_vector`, `buffer_geometry`, `clip_vector`, `intersect_vectors`, `simplify_geometry`, `load_boundary` | `src/gis/mod.rs:22`, `src/py_module/functions/gis.rs:21`, `src/py_module/functions/gis.rs:22`, `src/py_module/functions/gis.rs:23`, `src/py_module/functions/gis.rs:24`, `src/py_module/functions/gis.rs:25`, `src/py_module/functions/gis.rs:26`, `src/py_module/functions/gis.rs:27`, `python/forge3d/gis.py:168`, `python/forge3d/gis.py:173`, `python/forge3d/gis.py:178`, `python/forge3d/gis.py:183`, `python/forge3d/gis.py:197`, `python/forge3d/gis.py:211`, `python/forge3d/gis.py:225`, `tests/test_gis_vector_overlay.py:25` |
+| G-002c C5 rasterization/masks: `rasterize_vectors`, `geometry_mask`, `mask_raster` | `src/gis/mod.rs:9`, `src/gis/mod.rs:31`, `src/gis/mod.rs:37`, `src/gis/rasterize.rs:183`, `src/gis/rasterize.rs:209`, `src/gis/rasterize.rs:243`, `src/py_module/functions/gis.rs:28`, `src/py_module/functions/gis.rs:29`, `src/py_module/functions/gis.rs:30`, `python/forge3d/gis.py:239`, `python/forge3d/gis.py:261`, `python/forge3d/gis.py:279`, `python/forge3d/gis.pyi:266`, `python/forge3d/gis.pyi:278`, `python/forge3d/gis.pyi:288`, `tests/test_gis_rasterize_mask.py:96` |
+| C6 is still absent from runtime/export surfaces | `rg normalize_raster classify_raster python/forge3d/gis.py python/forge3d/gis.pyi src/py_module/functions/gis.rs src/gis/mod.rs src/gis/rasterize.rs` returns no runtime hits; `tests/test_api_contracts.py:186` keeps both names in `LATER_GIS_FUNCTIONS`; `tests/test_gis_vector_geom.py:376` bans both names |
+
+## C6 Public APIs
+
+Plan exactly these functions:
+
+```python
+def normalize_raster(
+    source,
+    *,
+    method="minmax",
+    valid_mask=None,
+    nodata=None,
+    clip=None,
+) -> dict[str, Any]: ...
+
+def classify_raster(
+    source,
+    *,
+    bins=None,
+    labels=None,
+    right=False,
+    valid_mask=None,
+    nodata=None,
+    dtype="uint16",
+) -> dict[str, Any]: ...
+```
+
+Both return a ThematicResult-like dict with these keys:
+
+- `array`
+- `info`
+- `method`
+- `valid_count`
+- `nodata_count`
+- `min`
+- `max`
+- `mean`
+- `std`
+- `class_table`
+- `warnings`
+
+## Behavior Decisions
+
+- `normalize_raster` supports only `method="minmax"` in C6.
+- Unsupported `method` values fail with `GisError::InvalidArgument` containing `unsupported_option`.
+- Stats use only cells where source value is finite, not nodata, and `valid_mask` is not false.
+- `valid_mask` is true-valid: false cells are excluded from stats and assigned to the invalid/nodata output class.
+- `nodata_count` means all cells excluded from stats: explicit nodata, NaN, or `valid_mask=False`.
+- Float `NaN` values are invalid even without explicit `nodata`; `nodata=np.nan` also matches NaN deliberately.
+- `clip=(min, max)` is supported as a finite ordered pre-normalization clamp. Invalid clip values fail with `invalid_argument`.
+- All invalid or all nodata input fails with `empty_raster`.
+- Normalized output dtype is `float32`; invalid/nodata cells are `NaN`.
+- `normalize_raster` returns `method="minmax"` and `class_table=None`.
+- `classify_raster` supports explicit `bins` only.
+- `classify_raster` returns `method="explicit_bins"`.
+- `bins=None` fails with `invalid_argument`; C6 has no inferred classification.
+- `bins` is a finite, strictly increasing sequence. Empty, non-finite, unsorted, or duplicate bins fail with `invalid_argument`.
+- `right` follows `numpy.digitize(values, bins, right=right)`.
+- Class ID `0` is reserved for nodata/invalid pixels. Valid classes start at `1`.
+- Number of valid classes is `len(bins) + 1`.
+- `labels`, when supplied, must have exactly `len(bins) + 1` entries.
+- `class_table` contains one nodata row plus one row per valid class. Each row includes `class_id`, `label`, `left`, `right`, `right_inclusive`, `count`, and `nodata`.
+- Output `dtype` supports integer class arrays only: `uint8`, `uint16`, `int16`, `uint32`, `int32`. Reject floats and unsupported names with `unsupported_dtype`.
+- Output dtype must represent class IDs `0..len(bins)+1`; otherwise fail with `unsupported_dtype`.
+
+## Backend Dependency Decision
+
+- Use existing Rust raster, NumPy/PyO3, and ndarray-adjacent helpers already in the repository.
+- Do not add `rasterio`, `geopandas`, `shapely`, `rioxarray`, `xarray`, `terra`, GDAL, or a new runtime dependency.
+- Do not introduce `BackendUnavailable`; C6 is pure Rust/NumPy-compatible behavior. Use `BackendUnavailable` only if a real optional backend is introduced, which this plan forbids.
+- Accept sources as local raster path, `RasterInfo`, NumPy array, or `read_raster`-style dict containing `array` and optional `info`. Do not add remote/cache/fetch behavior.
+
+## File-Level Deltas
+
+| File | C6 delta |
+|---|---|
+| Create `src/gis/thematic.rs` | Rust implementation for `normalize_raster`, `classify_raster`, shared source extraction, valid-mask/nodata filtering, stats, minmax normalization, explicit-bin classification, class table creation, result metadata, and PyO3 wrappers. |
+| Modify `src/gis/mod.rs` | Add `pub mod thematic;` and re-export `normalize_raster_py` and `classify_raster_py` behind `extension-module`. Reuse existing private helpers from descendant module code where possible. |
+| Modify `src/py_module/functions/gis.rs` | Register `normalize_raster_py` and `classify_raster_py` immediately after C5 rasterization/mask registrations. |
+| Modify `python/forge3d/gis.py` | Add thin wrappers and add both names to `__all__`. Wrapper work is limited to `os.fspath`/`_path_or_self` normalization and keyword forwarding. |
+| Modify `python/forge3d/gis.pyi` | Add exact stubs for both C6 signatures returning `dict[str, Any]`. |
+| Modify `tests/test_api_contracts.py` | Move only `normalize_raster` and `classify_raster` from `LATER_GIS_FUNCTIONS` to `EXPECTED_FUNCTIONS`. |
+| Modify `tests/test_gis_raster.py` | Update wrapper `__all__` and callable assertions if that test still hard-codes GIS public functions. |
+| Create `tests/test_gis_thematic.py` | Focused T-thematic behavior tests, NumPy reference comparisons, wrapper-surface checks, and no-runtime-Python-GIS-backend assertions. |
+| Do not modify `Cargo.toml` or `pyproject.toml` | No new runtime dependency or feature gate is planned for C6. |
+
+## Diagnostics
+
+Use existing `GisError` variants from `src/gis/error.rs`.
+
+| Token | Variant | Use |
+|---|---|---|
+| `empty_raster` | `InvalidArgument` | No valid cells remain after nodata, NaN, and mask filtering. |
+| `unsupported_dtype` | `UnsupportedDType` | Unsupported source/output dtype, float classification dtype, or dtype too small for class IDs. |
+| `invalid_argument` | `InvalidArgument` | Bad bins, label mismatch, bad clip, invalid method argument shape, or malformed source dict. |
+| `shape_mismatch` | `ShapeMismatch` | `valid_mask` shape does not match raster array shape. |
+| `invalid_nodata` | `InvalidNodata` | Nodata list length mismatch, nonnumeric nodata, or non-finite nodata other than `NaN` for float sources. |
+| `unsupported_option` | `InvalidArgument` | Unsupported normalization method or future classification method request. |
+
+## Planning Steps
+
+- [ ] Confirm working tree state with `git status --short` before implementation starts.
+- [ ] Confirm current branch is synced to `origin/main` at or after `1189ad1b06227012db3a1f794a8d30e301945e19`.
+- [ ] Run `rg normalize_raster classify_raster python/forge3d/gis.py python/forge3d/gis.pyi src/py_module/functions/gis.rs src/gis/mod.rs` and confirm C6 is absent before editing.
+- [ ] Keep implementation to the files listed in "File-Level Deltas" unless `cargo check` proves a helper must move.
+
+## Implementation Steps
+
+- [ ] Create `tests/test_gis_thematic.py` with failing tests for the T-thematic cases listed below.
+- [ ] Add `src/gis/thematic.rs` with a small `ThematicResult` struct and shared stats struct.
+- [ ] Add source extraction in `src/gis/thematic.rs`: path or `RasterInfo` via `raster_info::read_raster`, dict via `array` plus optional `info`, and direct NumPy array via existing `extract_raster_array`.
+- [ ] Add synthetic `RasterInfo` for bare NumPy arrays with `driver="memory"`, dtype from `RasterArray::dtype()`, dimensions from the array, and no CRS/transform.
+- [ ] Validate source info shape against array shape and return `shape_mismatch` on mismatch.
+- [ ] Parse `nodata` as scalar or per-band list and include `invalid_nodata` in all nodata validation failures.
+- [ ] Parse `valid_mask` as bool NumPy array and accept either exact `(bands, height, width)` or 2D `(height, width)` broadcast across bands; reject anything else with `shape_mismatch`.
+- [ ] Build the valid-cell mask once from finite values, nodata, and `valid_mask`.
+- [ ] Compute `valid_count`, `nodata_count`, `min`, `max`, `mean`, and population `std` from valid cells only; fail with `empty_raster` if `valid_count == 0`.
+- [ ] Implement `normalize_raster` minmax: clamp valid values when `clip` is supplied, normalize `(value - min) / (max - min)`, output `0.0` for valid cells when `min == max`, and output `NaN` for invalid cells.
+- [ ] Implement `classify_raster` using explicit bins and NumPy digitize-compatible `right` semantics; assign invalid cells to class ID `0`.
+- [ ] Build `class_table` with nodata row first and valid class rows in class ID order.
+- [ ] Convert output arrays through existing Rust raster array to Python ndarray conversion helpers.
+- [ ] Return `warnings` as an empty list unless an existing raster warning is carried from source metadata.
+- [ ] Add PyO3 wrappers in `src/gis/thematic.rs` with exact Python-visible names and keyword-only signatures.
+- [ ] Register wrappers in `src/gis/mod.rs` and `src/py_module/functions/gis.rs`.
+- [ ] Add thin Python wrappers and `__all__` entries in `python/forge3d/gis.py`.
+- [ ] Add `.pyi` stubs in `python/forge3d/gis.pyi`.
+- [ ] Move C6 names into `EXPECTED_FUNCTIONS` in `tests/test_api_contracts.py`.
+- [ ] Update any hard-coded public GIS callable lists in `tests/test_gis_raster.py`.
+
+## Tests
+
+Add a T-thematic section in `tests/test_gis_thematic.py` with these minimum cases:
+
+- [ ] Minmax normalization on a tiny array.
+- [ ] Minmax normalization with `clip`.
+- [ ] Nodata excluded from stats.
+- [ ] `valid_mask=False` excluded from stats.
+- [ ] NaN handling for float arrays.
+- [ ] All invalid/all nodata input raises `empty_raster`.
+- [ ] Unsupported normalization method raises `unsupported_option`.
+- [ ] Unsupported classification dtype raises `unsupported_dtype`.
+- [ ] `valid_mask` shape mismatch raises `shape_mismatch`.
+- [ ] Classification with explicit bins.
+- [ ] Classification labels.
+- [ ] `right=False` boundary behavior matches `np.digitize(..., right=False)`.
+- [ ] `right=True` boundary behavior matches `np.digitize(..., right=True)`.
+- [ ] Bad bins: empty, non-finite, unsorted, duplicate.
+- [ ] Label count mismatch.
+- [ ] Output dtype too small.
+- [ ] `class_table` counts sum correctly.
+- [ ] Nodata/invalid pixels use class ID `0`.
+- [ ] Source as NumPy array.
+- [ ] Source as `read_raster`-style result dict.
+- [ ] No runtime Python GIS backend library use: assert implementation does not import or require `rasterio`, `geopandas`, `shapely`, `rioxarray`, `xarray`, or `terra`.
+
+NumPy reference policy:
+
+- [ ] Use NumPy only as the test oracle.
+- [ ] For normalization, compare valid cells with `np.testing.assert_allclose`; assert invalid cells are `np.nan`.
+- [ ] For classification, compare class IDs to `np.digitize` plus the reserved `0` invalid class policy.
+- [ ] Do not use rasterio, GDAL, GeoPandas, Shapely, rioxarray, xarray, or terra in C6 tests.
+
+Contract/API tests:
+
+- [ ] Update `tests/test_api_contracts.py` expected functions only for `normalize_raster` and `classify_raster`.
+- [ ] Update `python/forge3d/gis.py` `__all__`.
+- [ ] Update `python/forge3d/gis.pyi` stubs.
+- [ ] Add wrapper-surface tests proving both names are callable through `forge3d.gis`.
+- [ ] Add no-backend-Python-GIS-library tests.
+
+## Validation For C6 Implementation
+
+Run at minimum:
+
+- [ ] `git status --short`
+- [ ] `git diff --name-status`
+- [ ] `git diff --stat`
+- [ ] `git diff`
+- [ ] `git ls-files --others --exclude-standard`
+- [ ] `cargo fmt --check`
+- [ ] `cargo check`
+- [ ] `python -m py_compile python/forge3d/gis.py`
+- [ ] `python -m pytest tests/test_gis_thematic.py -q`
+- [ ] `python -m pytest tests/test_api_contracts.py tests/test_gis_raster.py -q`
+- [ ] `python -m pytest tests/test_gis_rasterize_mask.py -q`
+- [ ] Broader raster/vector tests only if touched files justify them.
+
+## Validation For This Planning Change-Set
+
+Run after adding this Markdown file:
+
+- [ ] `git status --short`
+- [ ] `git diff --name-status`
+- [ ] `git diff --stat`
+- [ ] `git diff`
+- [ ] `git ls-files --others --exclude-standard`
+- [ ] `python -m pytest tests/test_api_contracts.py tests/test_gis_raster.py tests/test_gis_rasterize_mask.py -q`
+
+## Review Bundle Requirement
+
+After the planning change-set validation, generate a fresh temporary review bundle outside the repo. Include:
+
+- [ ] `git status`
+- [ ] diff name-status
+- [ ] diff stat
+- [ ] full diff
+- [ ] untracked files
+- [ ] validation logs
+- [ ] command metadata and exit codes
+- [ ] branch
+- [ ] merge base
+- [ ] current commit
+- [ ] timestamp
+- [ ] cwd
+
+The review bundle is temporary evidence only. Never stage it, commit it, or include it in the PR.
+
+## Non-Goals
+
+- No runtime implementation in this planning change-set.
+- No C7 or later API planning beyond explicitly deferring it.
+- No color mapping, palettes, colormaps, rendering, shaders, examples, visual goldens, gallery goldens, or recipe manifests.
+- No quantile, natural breaks, Jenks, domain classification, landcover, DEM, population, building, Terrarium, OSM, slippy tile, remote/cache/fetch, MapScene, or named-domain helpers.
+- No vector writes.
+- No Python GIS backend behavior.
+- No new runtime backend dependency and no GDAL addition.
+
+## Backward Compatibility
+
+- Preserve all G-002a1/G-002b/G-002c C1-C5 APIs and behavior.
+- Do not alter raster read/write, CRS, affine, nodata/mask, resampling, alignment, reprojection, or window helper contracts.
+- Do not alter vector IO, vector CRS, geometry operation, overlay/topology, rasterization, geometry mask, or raster mask contracts.
+- Keep public functions importable and keep existing contract tests passing.
+
+## Open Questions
+
+None block C6. Conservative decisions above are binding for first implementation.

--- a/python/forge3d/gis.py
+++ b/python/forge3d/gis.py
@@ -297,6 +297,46 @@ def mask_raster(
     )
 
 
+def normalize_raster(
+    source: os.PathLike[str] | str | Any,
+    *,
+    method: str = "minmax",
+    valid_mask: Any | None = None,
+    nodata: float | list[float | None] | tuple[float | None, ...] | None = None,
+    clip: tuple[float, float] | None = None,
+):
+    """Normalize raster values through the native thematic backend."""
+    return _require_native().normalize_raster(
+        _path_or_self(source),
+        method=method,
+        valid_mask=valid_mask,
+        nodata=nodata,
+        clip=clip,
+    )
+
+
+def classify_raster(
+    source: os.PathLike[str] | str | Any,
+    *,
+    bins: Any = None,
+    labels: list[str] | tuple[str, ...] | None = None,
+    right: bool = False,
+    valid_mask: Any | None = None,
+    nodata: float | list[float | None] | tuple[float | None, ...] | None = None,
+    dtype: str = "uint16",
+):
+    """Classify raster values through the native thematic backend."""
+    return _require_native().classify_raster(
+        _path_or_self(source),
+        bins=bins,
+        labels=labels,
+        right=right,
+        valid_mask=valid_mask,
+        nodata=nodata,
+        dtype=dtype,
+    )
+
+
 def _path_or_self(value: Any):
     return os.fspath(value) if isinstance(value, (str, os.PathLike)) else value
 
@@ -619,6 +659,8 @@ __all__ = [
     "rasterize_vectors",
     "geometry_mask",
     "mask_raster",
+    "normalize_raster",
+    "classify_raster",
     "write_raster",
     "parse_crs",
     "inspect_crs",

--- a/python/forge3d/gis.pyi
+++ b/python/forge3d/gis.pyi
@@ -296,6 +296,28 @@ def mask_raster(
 ) -> dict[str, Any]: ...
 
 
+def normalize_raster(
+    source: os.PathLike[str] | str | np.ndarray | dict[str, Any],
+    *,
+    method: str = ...,
+    valid_mask: np.ndarray | None = ...,
+    nodata: float | list[float | None] | tuple[float | None, ...] | None = ...,
+    clip: tuple[float, float] | None = ...,
+) -> dict[str, Any]: ...
+
+
+def classify_raster(
+    source: os.PathLike[str] | str | np.ndarray | dict[str, Any],
+    *,
+    bins: Any = ...,
+    labels: list[str] | tuple[str, ...] | None = ...,
+    right: bool = ...,
+    valid_mask: np.ndarray | None = ...,
+    nodata: float | list[float | None] | tuple[float | None, ...] | None = ...,
+    dtype: str = ...,
+) -> dict[str, Any]: ...
+
+
 def write_raster(
     path: os.PathLike[str] | str,
     array: np.ndarray,

--- a/src/gis/mod.rs
+++ b/src/gis/mod.rs
@@ -7,6 +7,7 @@ pub(crate) mod py_json;
 pub mod raster_info;
 pub mod raster_write;
 pub mod rasterize;
+pub mod thematic;
 pub mod types;
 pub mod vector;
 pub mod warp;
@@ -35,6 +36,8 @@ pub use rasterize::{
 };
 #[cfg(feature = "extension-module")]
 pub use rasterize::{geometry_mask_py, mask_raster_py, rasterize_vectors_py};
+#[cfg(feature = "extension-module")]
+pub use thematic::{classify_raster_py, normalize_raster_py};
 pub use types::{AffineTransform, RasterBounds, RasterDType, RasterInfo, RasterWarning};
 pub use vector::{
     clip_vector, dissolve_vector, intersect_vectors, load_boundary, read_vector, read_vector_info,

--- a/src/gis/thematic.rs
+++ b/src/gis/thematic.rs
@@ -1,0 +1,757 @@
+#[cfg(feature = "extension-module")]
+pub use py::{classify_raster_py, normalize_raster_py};
+
+#[cfg(feature = "extension-module")]
+mod py {
+    use pyo3::prelude::*;
+    use pyo3::types::{PyAny, PyDict, PyDictMethods, PyList, PyTuple};
+    use pyo3::IntoPy;
+
+    use crate::gis::error::GisError;
+    use crate::gis::raster_info;
+    use crate::gis::raster_write::{RasterArray, RasterData};
+    use crate::gis::types::{RasterDType, RasterInfo, RasterWarning};
+
+    const EMPTY_RASTER: &str = "empty_raster";
+    const INVALID_ARGUMENT: &str = "invalid_argument";
+    const INVALID_NODATA: &str = "invalid_nodata";
+    const SHAPE_MISMATCH: &str = "shape_mismatch";
+    const UNSUPPORTED_DTYPE: &str = "unsupported_dtype";
+    const UNSUPPORTED_OPTION: &str = "unsupported_option";
+
+    struct RasterSource {
+        array: RasterArray,
+        info: RasterInfo,
+    }
+
+    struct Stats {
+        valid: Vec<bool>,
+        values: Vec<f64>,
+        valid_count: usize,
+        nodata_count: usize,
+        min: f64,
+        max: f64,
+        mean: f64,
+        std: f64,
+    }
+
+    #[pyfunction(
+        name = "normalize_raster",
+        signature = (source, *, method = "minmax", valid_mask = None, nodata = None, clip = None)
+    )]
+    pub fn normalize_raster_py(
+        py: Python<'_>,
+        source: &Bound<'_, PyAny>,
+        method: &str,
+        valid_mask: Option<&Bound<'_, PyAny>>,
+        nodata: Option<&Bound<'_, PyAny>>,
+        clip: Option<(f64, f64)>,
+    ) -> PyResult<PyObject> {
+        if method != "minmax" {
+            return Err(GisError::InvalidArgument(format!(
+                "{UNSUPPORTED_OPTION}: normalize_raster supports only method='minmax'"
+            ))
+            .into());
+        }
+        let clip = validate_clip(clip)?;
+        let source = raster_source_from_py(source)?;
+        let nodata = nodata_or_source(nodata, &source)?;
+        let mask = valid_mask_from_py(valid_mask, &source.array)?;
+        let stats = stats(&source.array, &nodata, mask.as_deref(), clip)?;
+
+        let mut out = Vec::with_capacity(stats.values.len());
+        let span = stats.max - stats.min;
+        for (index, value) in stats.values.iter().enumerate() {
+            if stats.valid[index] {
+                out.push(if span == 0.0 {
+                    0.0
+                } else {
+                    ((value - stats.min) / span) as f32
+                });
+            } else {
+                out.push(f32::NAN);
+            }
+        }
+        let array = RasterArray::new(
+            RasterData::F32(out),
+            &[source.array.bands, source.array.height, source.array.width],
+        )?;
+        let mut info = output_info(&source.info, &array, vec![Some(f64::NAN); array.bands]);
+        info.dtype_per_band = vec![RasterDType::Float32.name().to_string(); array.bands];
+        result_to_py(py, &array, &info, "minmax", &stats, None)
+    }
+
+    #[pyfunction(
+        name = "classify_raster",
+        signature = (source, *, bins = None, labels = None, right = false, valid_mask = None, nodata = None, dtype = "uint16")
+    )]
+    pub fn classify_raster_py(
+        py: Python<'_>,
+        source: &Bound<'_, PyAny>,
+        bins: Option<&Bound<'_, PyAny>>,
+        labels: Option<&Bound<'_, PyAny>>,
+        right: bool,
+        valid_mask: Option<&Bound<'_, PyAny>>,
+        nodata: Option<&Bound<'_, PyAny>>,
+        dtype: &str,
+    ) -> PyResult<PyObject> {
+        let bins = parse_bins(bins)?;
+        let labels = parse_labels(labels, bins.len() + 1)?;
+        let dtype = parse_class_dtype(dtype, bins.len() + 1)?;
+        let source = raster_source_from_py(source)?;
+        let nodata = nodata_or_source(nodata, &source)?;
+        let mask = valid_mask_from_py(valid_mask, &source.array)?;
+        let stats = stats(&source.array, &nodata, mask.as_deref(), None)?;
+
+        let mut counts = vec![0usize; bins.len() + 2];
+        let ids = stats
+            .values
+            .iter()
+            .enumerate()
+            .map(|(index, value)| {
+                let id = if stats.valid[index] {
+                    digitize(*value, &bins, right) + 1
+                } else {
+                    0
+                };
+                counts[id] += 1;
+                id as u32
+            })
+            .collect::<Vec<_>>();
+        let array = class_array(
+            dtype,
+            ids,
+            source.array.bands,
+            source.array.height,
+            source.array.width,
+        )?;
+        let info = output_info(&source.info, &array, vec![Some(0.0); array.bands]);
+        let table = class_table_py(py, &bins, &labels, right, &counts)?;
+        result_to_py(py, &array, &info, "explicit_bins", &stats, Some(table))
+    }
+
+    fn validate_clip(clip: Option<(f64, f64)>) -> PyResult<Option<(f64, f64)>> {
+        match clip {
+            Some((lo, hi)) if lo.is_finite() && hi.is_finite() && lo < hi => Ok(Some((lo, hi))),
+            Some(_) => Err(GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: clip must be finite and ordered as (min, max)"
+            ))
+            .into()),
+            None => Ok(None),
+        }
+    }
+
+    fn raster_source_from_py(value: &Bound<'_, PyAny>) -> PyResult<RasterSource> {
+        if let Ok(path) = value.extract::<String>() {
+            let result = raster_info::read_raster(path, None, None, false)?;
+            return Ok(RasterSource {
+                array: result.array,
+                info: result.info,
+            });
+        }
+        if let Ok(info) = value.extract::<PyRef<'_, RasterInfo>>() {
+            if info.path.is_empty() {
+                return Err(GisError::InvalidArgument(format!(
+                    "{INVALID_ARGUMENT}: RasterInfo source must include a path"
+                ))
+                .into());
+            }
+            let result = raster_info::read_raster(&info.path, None, None, false)?;
+            return Ok(RasterSource {
+                array: result.array,
+                info: result.info,
+            });
+        }
+        if let Ok(dict) = value.downcast::<PyDict>() {
+            let Some(array_value) = dict.get_item("array")? else {
+                return Err(GisError::InvalidArgument(format!(
+                    "{INVALID_ARGUMENT}: source dict must include array"
+                ))
+                .into());
+            };
+            let array = extract_source_array(&array_value)?;
+            let info = if let Some(info_value) = dict.get_item("info")? {
+                raster_info_from_py(&info_value)?
+            } else {
+                synthetic_info(&array)
+            };
+            validate_info_shape(&info, &array)?;
+            return Ok(RasterSource { array, info });
+        }
+        let array = extract_source_array(value)?;
+        let info = synthetic_info(&array);
+        Ok(RasterSource { array, info })
+    }
+
+    fn extract_source_array(value: &Bound<'_, PyAny>) -> PyResult<RasterArray> {
+        let dtype_name = value
+            .getattr("dtype")
+            .and_then(|dtype| dtype.getattr("name"))
+            .and_then(|name| name.extract::<String>())
+            .map_err(|_| {
+                GisError::UnsupportedDType(format!(
+                    "{UNSUPPORTED_DTYPE}: source must be a supported NumPy ndarray"
+                ))
+            })?;
+        match dtype_name.as_str() {
+            "uint8" | "int16" | "uint16" | "int32" | "uint32" | "float32" | "float64" => {
+                super::super::extract_raster_array(value)
+            }
+            other => Err(GisError::UnsupportedDType(format!(
+                "{UNSUPPORTED_DTYPE}: unsupported source dtype {other:?}"
+            ))
+            .into()),
+        }
+    }
+
+    fn raster_info_from_py(value: &Bound<'_, PyAny>) -> PyResult<RasterInfo> {
+        if let Ok(info) = value.extract::<PyRef<'_, RasterInfo>>() {
+            return Ok(info.clone());
+        }
+        let dict = value.downcast::<PyDict>().map_err(|_| {
+            GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: raster info must be RasterInfo or dict"
+            ))
+        })?;
+        let width = required_u32(dict, "width")?;
+        let height = required_u32(dict, "height")?;
+        let band_count = optional_u16(dict.get_item("band_count")?)?.unwrap_or(1);
+        let mut info = RasterInfo::new(
+            dict.get_item("path")?
+                .and_then(|value| value.extract::<String>().ok())
+                .unwrap_or_default()
+                .into(),
+            width,
+            height,
+            band_count,
+        );
+        info.driver = dict
+            .get_item("driver")?
+            .and_then(|value| value.extract::<String>().ok())
+            .unwrap_or_else(|| "memory".to_string());
+        info.dtype_per_band = dict
+            .get_item("dtype_per_band")?
+            .map(|value| value.extract::<Vec<String>>())
+            .transpose()?
+            .unwrap_or_else(|| vec!["uint8".to_string(); band_count as usize]);
+        info.nodata_per_band = dict
+            .get_item("nodata_per_band")?
+            .map(|value| value.extract::<Vec<Option<f64>>>())
+            .transpose()?
+            .unwrap_or_else(|| vec![None; band_count as usize]);
+        info.crs_wkt = optional_string(dict.get_item("crs_wkt")?)?;
+        info.crs_authority = dict
+            .get_item("crs_authority")?
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract().map(Some)
+                }
+            })
+            .transpose()?
+            .flatten();
+        info.transform = optional_tuple6(dict.get_item("transform")?)?;
+        info.bounds = optional_tuple4(dict.get_item("bounds")?)?;
+        info.resolution = optional_tuple2(dict.get_item("resolution")?)?;
+        info.warnings = warnings_from_py(dict.get_item("warnings")?)?;
+        info.is_georeferenced =
+            info.transform.is_some() && (info.crs_wkt.is_some() || info.crs_authority.is_some());
+        Ok(info)
+    }
+
+    fn synthetic_info(array: &RasterArray) -> RasterInfo {
+        let mut info = RasterInfo::new(
+            "".into(),
+            array.width as u32,
+            array.height as u32,
+            array.bands as u16,
+        );
+        info.driver = "memory".to_string();
+        info.dtype_per_band = vec![array.dtype().name().to_string(); array.bands];
+        info.nodata_per_band = vec![None; array.bands];
+        info
+    }
+
+    fn validate_info_shape(info: &RasterInfo, array: &RasterArray) -> PyResult<()> {
+        if info.width as usize != array.width
+            || info.height as usize != array.height
+            || info.band_count as usize != array.bands
+        {
+            return Err(GisError::ShapeMismatch(format!(
+                "{SHAPE_MISMATCH}: source info shape ({}, {}, {}) does not match array shape ({}, {}, {})",
+                info.band_count, info.height, info.width, array.bands, array.height, array.width
+            ))
+            .into());
+        }
+        Ok(())
+    }
+
+    fn nodata_or_source(
+        value: Option<&Bound<'_, PyAny>>,
+        source: &RasterSource,
+    ) -> PyResult<Vec<Option<f64>>> {
+        let nodata = match value {
+            Some(value) if !value.is_none() => parse_nodata(value, source.array.bands)?,
+            _ => normalize_nodata_len(source.info.nodata_per_band.clone(), source.array.bands)?,
+        };
+        for item in nodata.iter().flatten() {
+            validate_nodata(source.array.dtype(), *item)?;
+        }
+        Ok(nodata)
+    }
+
+    fn parse_nodata(value: &Bound<'_, PyAny>, bands: usize) -> PyResult<Vec<Option<f64>>> {
+        if let Ok(number) = value.extract::<f64>() {
+            return Ok(vec![Some(number); bands]);
+        }
+        if let Ok(list) = value.downcast::<PyList>() {
+            return nodata_from_iter(list.iter(), bands);
+        }
+        if let Ok(tuple) = value.downcast::<PyTuple>() {
+            return nodata_from_iter(tuple.iter(), bands);
+        }
+        Err(GisError::InvalidNodata(format!(
+            "{INVALID_NODATA}: nodata must be a scalar or per-band list"
+        ))
+        .into())
+    }
+
+    fn nodata_from_iter<'py>(
+        items: impl Iterator<Item = Bound<'py, PyAny>>,
+        bands: usize,
+    ) -> PyResult<Vec<Option<f64>>> {
+        let values = items
+            .map(|item| {
+                if item.is_none() {
+                    Ok(None)
+                } else {
+                    item.extract::<f64>().map(Some).map_err(|_| {
+                        GisError::InvalidNodata(format!(
+                            "{INVALID_NODATA}: nodata list values must be numeric or None"
+                        ))
+                        .into()
+                    })
+                }
+            })
+            .collect::<PyResult<Vec<_>>>()?;
+        normalize_nodata_len(values, bands).map_err(Into::into)
+    }
+
+    fn normalize_nodata_len(
+        mut values: Vec<Option<f64>>,
+        bands: usize,
+    ) -> Result<Vec<Option<f64>>, GisError> {
+        if values.is_empty() {
+            values = vec![None; bands];
+        }
+        if values.len() != bands {
+            return Err(GisError::InvalidNodata(format!(
+                "{INVALID_NODATA}: nodata length {} does not match band count {bands}",
+                values.len()
+            )));
+        }
+        Ok(values)
+    }
+
+    fn validate_nodata(dtype: RasterDType, value: f64) -> PyResult<()> {
+        if dtype.nodata_fits(value) {
+            Ok(())
+        } else {
+            Err(GisError::InvalidNodata(format!(
+                "{INVALID_NODATA}: nodata value {value} does not fit {}",
+                dtype.name()
+            ))
+            .into())
+        }
+    }
+
+    fn valid_mask_from_py(
+        value: Option<&Bound<'_, PyAny>>,
+        array: &RasterArray,
+    ) -> PyResult<Option<Vec<bool>>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        if value.is_none() {
+            return Ok(None);
+        }
+        let (mask, shape) = super::super::extract_typed_array::<bool>(value)?;
+        expand_mask(mask, &shape, array)
+            .map(Some)
+            .map_err(Into::into)
+    }
+
+    fn expand_mask(
+        mask: Vec<bool>,
+        shape: &[usize],
+        array: &RasterArray,
+    ) -> Result<Vec<bool>, GisError> {
+        let pixels = array.height * array.width;
+        match shape {
+            [height, width] if *height == array.height && *width == array.width => {
+                let mut out = Vec::with_capacity(array.bands * pixels);
+                for _ in 0..array.bands {
+                    out.extend(mask.iter().copied());
+                }
+                Ok(out)
+            }
+            [bands, height, width]
+                if *bands == array.bands && *height == array.height && *width == array.width =>
+            {
+                Ok(mask)
+            }
+            _ => Err(GisError::ShapeMismatch(format!(
+                "{SHAPE_MISMATCH}: valid_mask shape {:?} is not compatible with raster shape ({}, {}, {})",
+                shape, array.bands, array.height, array.width
+            ))),
+        }
+    }
+
+    fn stats(
+        array: &RasterArray,
+        nodata: &[Option<f64>],
+        explicit_mask: Option<&[bool]>,
+        clip: Option<(f64, f64)>,
+    ) -> PyResult<Stats> {
+        let mut values = raster_info::raster_to_f64(array);
+        let pixels = array.height * array.width;
+        let mut valid = vec![false; values.len()];
+        let mut observed = Vec::new();
+        for band in 0..array.bands {
+            let nodata = nodata.get(band).copied().flatten();
+            for pixel in 0..pixels {
+                let index = band * pixels + pixel;
+                let mask_valid = explicit_mask
+                    .and_then(|mask| mask.get(index))
+                    .copied()
+                    .unwrap_or(true);
+                let value = values[index];
+                let is_valid = mask_valid && value.is_finite() && !nodata_matches(value, nodata);
+                if is_valid {
+                    if let Some((lo, hi)) = clip {
+                        values[index] = values[index].clamp(lo, hi);
+                    }
+                    valid[index] = true;
+                    observed.push(values[index]);
+                }
+            }
+        }
+        if observed.is_empty() {
+            return Err(GisError::InvalidArgument(format!(
+                "{EMPTY_RASTER}: no valid raster cells remain"
+            ))
+            .into());
+        }
+        let valid_count = observed.len();
+        let nodata_count = values.len() - valid_count;
+        let min = observed.iter().copied().fold(f64::INFINITY, f64::min);
+        let max = observed.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let mean = observed.iter().sum::<f64>() / valid_count as f64;
+        let variance = observed
+            .iter()
+            .map(|value| {
+                let delta = value - mean;
+                delta * delta
+            })
+            .sum::<f64>()
+            / valid_count as f64;
+        Ok(Stats {
+            valid,
+            values,
+            valid_count,
+            nodata_count,
+            min,
+            max,
+            mean,
+            std: variance.sqrt(),
+        })
+    }
+
+    fn nodata_matches(value: f64, nodata: Option<f64>) -> bool {
+        nodata.is_some_and(|nodata| value == nodata || (value.is_nan() && nodata.is_nan()))
+    }
+
+    fn parse_bins(value: Option<&Bound<'_, PyAny>>) -> PyResult<Vec<f64>> {
+        let Some(value) = value else {
+            return Err(invalid_bins());
+        };
+        if value.is_none() {
+            return Err(invalid_bins());
+        }
+        let bins = if let Ok(values) = value.extract::<Vec<f64>>() {
+            values
+        } else if let Ok((values, shape)) = super::super::extract_typed_array::<f64>(value) {
+            if shape.len() != 1 {
+                return Err(invalid_bins());
+            }
+            values
+        } else {
+            return Err(invalid_bins());
+        };
+        if bins.is_empty()
+            || bins.iter().any(|value| !value.is_finite())
+            || bins.windows(2).any(|pair| pair[0] >= pair[1])
+        {
+            return Err(invalid_bins());
+        }
+        Ok(bins)
+    }
+
+    fn invalid_bins() -> PyErr {
+        GisError::InvalidArgument(format!(
+            "{INVALID_ARGUMENT}: bins must be a finite strictly increasing sequence"
+        ))
+        .into()
+    }
+
+    fn parse_labels(value: Option<&Bound<'_, PyAny>>, expected: usize) -> PyResult<Vec<String>> {
+        let labels = match value {
+            Some(value) if !value.is_none() => value.extract::<Vec<String>>().map_err(|_| {
+                GisError::InvalidArgument(format!(
+                    "{INVALID_ARGUMENT}: labels must be a sequence of strings"
+                ))
+            })?,
+            _ => (1..=expected)
+                .map(|class_id| format!("class_{class_id}"))
+                .collect(),
+        };
+        if labels.len() != expected {
+            return Err(GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: labels length {} does not match class count {expected}",
+                labels.len()
+            ))
+            .into());
+        }
+        Ok(labels)
+    }
+
+    fn parse_class_dtype(value: &str, max_class_id: usize) -> PyResult<RasterDType> {
+        let dtype = match value.to_ascii_lowercase().as_str() {
+            "uint8" => RasterDType::UInt8,
+            "uint16" => RasterDType::UInt16,
+            "int16" => RasterDType::Int16,
+            "uint32" => RasterDType::UInt32,
+            "int32" => RasterDType::Int32,
+            _ => {
+                return Err(GisError::UnsupportedDType(format!(
+                    "{UNSUPPORTED_DTYPE}: classify_raster dtype must be uint8, uint16, int16, uint32, or int32"
+                ))
+                .into())
+            }
+        };
+        let max_value = match dtype {
+            RasterDType::UInt8 => u8::MAX as usize,
+            RasterDType::UInt16 => u16::MAX as usize,
+            RasterDType::Int16 => i16::MAX as usize,
+            RasterDType::UInt32 => u32::MAX as usize,
+            RasterDType::Int32 => i32::MAX as usize,
+            RasterDType::Float32 | RasterDType::Float64 => unreachable!(),
+        };
+        if max_class_id > max_value {
+            return Err(GisError::UnsupportedDType(format!(
+                "{UNSUPPORTED_DTYPE}: dtype {} cannot store class id {max_class_id}",
+                dtype.name()
+            ))
+            .into());
+        }
+        Ok(dtype)
+    }
+
+    fn digitize(value: f64, bins: &[f64], right: bool) -> usize {
+        if right {
+            bins.iter().take_while(|&&bin| value > bin).count()
+        } else {
+            bins.iter().take_while(|&&bin| value >= bin).count()
+        }
+    }
+
+    fn class_array(
+        dtype: RasterDType,
+        ids: Vec<u32>,
+        bands: usize,
+        height: usize,
+        width: usize,
+    ) -> PyResult<RasterArray> {
+        let shape = [bands, height, width];
+        let data = match dtype {
+            RasterDType::UInt8 => RasterData::U8(ids.into_iter().map(|id| id as u8).collect()),
+            RasterDType::UInt16 => RasterData::U16(ids.into_iter().map(|id| id as u16).collect()),
+            RasterDType::Int16 => RasterData::I16(ids.into_iter().map(|id| id as i16).collect()),
+            RasterDType::UInt32 => RasterData::U32(ids),
+            RasterDType::Int32 => RasterData::I32(ids.into_iter().map(|id| id as i32).collect()),
+            RasterDType::Float32 | RasterDType::Float64 => unreachable!(),
+        };
+        RasterArray::new(data, &shape).map_err(Into::into)
+    }
+
+    fn output_info(
+        source: &RasterInfo,
+        array: &RasterArray,
+        nodata: Vec<Option<f64>>,
+    ) -> RasterInfo {
+        let mut info = source.clone();
+        info.width = array.width as u32;
+        info.height = array.height as u32;
+        info.band_count = array.bands as u16;
+        info.dtype_per_band = vec![array.dtype().name().to_string(); array.bands];
+        info.nodata_per_band = nodata;
+        info
+    }
+
+    fn result_to_py(
+        py: Python<'_>,
+        array: &RasterArray,
+        info: &RasterInfo,
+        method: &str,
+        stats: &Stats,
+        class_table: Option<PyObject>,
+    ) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item("array", super::super::raster_array_to_py(py, array)?)?;
+        dict.set_item("info", super::super::raster_info_to_py_dict(py, info)?)?;
+        dict.set_item("method", method)?;
+        dict.set_item("valid_count", stats.valid_count)?;
+        dict.set_item("nodata_count", stats.nodata_count)?;
+        dict.set_item("min", stats.min)?;
+        dict.set_item("max", stats.max)?;
+        dict.set_item("mean", stats.mean)?;
+        dict.set_item("std", stats.std)?;
+        match class_table {
+            Some(table) => dict.set_item("class_table", table)?,
+            None => dict.set_item("class_table", py.None())?,
+        }
+        dict.set_item(
+            "warnings",
+            super::super::warnings_to_py(py, &info.warnings)?,
+        )?;
+        Ok(dict.into_py(py))
+    }
+
+    fn class_table_py(
+        py: Python<'_>,
+        bins: &[f64],
+        labels: &[String],
+        right: bool,
+        counts: &[usize],
+    ) -> PyResult<PyObject> {
+        let mut rows = Vec::with_capacity(labels.len() + 1);
+        rows.push(class_row_py(
+            py, 0, "nodata", None, None, false, counts[0], true,
+        )?);
+        for class_id in 1..=labels.len() {
+            let left = if class_id == 1 {
+                None
+            } else {
+                Some(bins[class_id - 2])
+            };
+            let right_bound = bins.get(class_id - 1).copied();
+            rows.push(class_row_py(
+                py,
+                class_id,
+                &labels[class_id - 1],
+                left,
+                right_bound,
+                right,
+                counts[class_id],
+                false,
+            )?);
+        }
+        Ok(PyList::new_bound(py, rows).into_py(py))
+    }
+
+    fn class_row_py(
+        py: Python<'_>,
+        class_id: usize,
+        label: &str,
+        left: Option<f64>,
+        right: Option<f64>,
+        right_inclusive: bool,
+        count: usize,
+        nodata: bool,
+    ) -> PyResult<PyObject> {
+        let dict = PyDict::new_bound(py);
+        dict.set_item("class_id", class_id)?;
+        dict.set_item("label", label)?;
+        dict.set_item("left", left)?;
+        dict.set_item("right", right)?;
+        dict.set_item("right_inclusive", right_inclusive)?;
+        dict.set_item("count", count)?;
+        dict.set_item("nodata", nodata)?;
+        Ok(dict.into_py(py))
+    }
+
+    fn required_u32(dict: &Bound<'_, PyDict>, key: &'static str) -> PyResult<u32> {
+        dict.get_item(key)?
+            .ok_or_else(|| {
+                GisError::InvalidArgument(format!("{INVALID_ARGUMENT}: raster info missing {key}"))
+            })?
+            .extract()
+            .map_err(Into::into)
+    }
+
+    fn optional_u16(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<u16>> {
+        optional_extract(value)
+    }
+
+    fn optional_string(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<String>> {
+        optional_extract(value)
+    }
+
+    fn optional_tuple2(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<(f64, f64)>> {
+        optional_extract(value)
+    }
+
+    fn optional_tuple4(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<(f64, f64, f64, f64)>> {
+        optional_extract(value)
+    }
+
+    fn optional_tuple6(
+        value: Option<Bound<'_, PyAny>>,
+    ) -> PyResult<Option<(f64, f64, f64, f64, f64, f64)>> {
+        optional_extract(value)
+    }
+
+    fn optional_extract<T>(value: Option<Bound<'_, PyAny>>) -> PyResult<Option<T>>
+    where
+        T: for<'py> FromPyObject<'py>,
+    {
+        value
+            .map(|value| {
+                if value.is_none() {
+                    Ok(None)
+                } else {
+                    value.extract::<T>().map(Some)
+                }
+            })
+            .transpose()
+            .map(Option::flatten)
+    }
+
+    fn warnings_from_py(value: Option<Bound<'_, PyAny>>) -> PyResult<Vec<RasterWarning>> {
+        let Some(value) = value else {
+            return Ok(Vec::new());
+        };
+        if value.is_none() {
+            return Ok(Vec::new());
+        }
+        let Ok(list) = value.downcast::<PyList>() else {
+            return Ok(Vec::new());
+        };
+        let mut warnings = Vec::with_capacity(list.len());
+        for item in list.iter() {
+            let Ok(dict) = item.downcast::<PyDict>() else {
+                continue;
+            };
+            let Some(code) = optional_string(dict.get_item("code")?)? else {
+                continue;
+            };
+            warnings.push(RasterWarning {
+                code,
+                message: optional_string(dict.get_item("message")?)?.unwrap_or_default(),
+                field: optional_string(dict.get_item("field")?)?,
+            });
+        }
+        Ok(warnings)
+    }
+}

--- a/src/py_module/functions/gis.rs
+++ b/src/py_module/functions/gis.rs
@@ -28,6 +28,8 @@ pub(crate) fn register_gis_py_functions(m: &Bound<'_, PyModule>) -> PyResult<()>
     m.add_function(wrap_pyfunction!(crate::gis::rasterize_vectors_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::geometry_mask_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::mask_raster_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::normalize_raster_py, m)?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::classify_raster_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::parse_crs_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::inspect_crs_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::raster_crs_py, m)?)?;

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -150,6 +150,8 @@ class TestNativeModuleSymbols:
         "rasterize_vectors",
         "geometry_mask",
         "mask_raster",
+        "normalize_raster",
+        "classify_raster",
         # G-002b: Rust-backed GIS CRS/affine/warp operations
         "parse_crs",
         "inspect_crs",
@@ -183,10 +185,7 @@ class TestNativeModuleSymbols:
         "bounds",
     ]
 
-    LATER_GIS_FUNCTIONS = [
-        "normalize_raster",
-        "classify_raster",
-    ]
+    LATER_GIS_FUNCTIONS = []
 
     @pytest.mark.parametrize("fn_name", EXPECTED_FUNCTIONS)
     def test_registered_function_exists(self, fn_name: str):

--- a/tests/test_gis_raster.py
+++ b/tests/test_gis_raster.py
@@ -144,6 +144,8 @@ def test_public_gis_wrapper_surface():
         "rasterize_vectors",
         "geometry_mask",
         "mask_raster",
+        "normalize_raster",
+        "classify_raster",
         "write_raster",
         "parse_crs",
         "inspect_crs",
@@ -201,6 +203,8 @@ def test_public_gis_wrapper_surface():
     assert callable(gis.rasterize_vectors)
     assert callable(gis.geometry_mask)
     assert callable(gis.mask_raster)
+    assert callable(gis.normalize_raster)
+    assert callable(gis.classify_raster)
     assert callable(gis.write_raster)
     assert callable(gis.parse_crs)
     assert callable(gis.inspect_crs)

--- a/tests/test_gis_thematic.py
+++ b/tests/test_gis_thematic.py
@@ -1,0 +1,297 @@
+"""G-002c C6 thematic raster contract tests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import forge3d.gis as gis
+from forge3d._native import NATIVE_AVAILABLE, get_native_module
+
+
+pytestmark = pytest.mark.skipif(
+    not NATIVE_AVAILABLE,
+    reason="GIS thematic tests require the compiled _forge3d extension",
+)
+
+
+def _memory_info(array: np.ndarray) -> dict:
+    shape = array.shape
+    bands, height, width = (1, shape[0], shape[1]) if array.ndim == 2 else shape
+    return {
+        "path": "",
+        "driver": "memory",
+        "width": width,
+        "height": height,
+        "band_count": bands,
+        "dtype_per_band": [array.dtype.name] * bands,
+        "crs_wkt": None,
+        "crs_authority": None,
+        "transform": None,
+        "bounds": None,
+        "resolution": None,
+        "nodata_per_band": [None] * bands,
+        "warnings": [],
+    }
+
+
+def _expected_classes(values, bins, *, right=False, valid=None):
+    values = np.asarray(values)
+    valid = np.ones(values.shape, dtype=bool) if valid is None else valid
+    out = np.zeros(values.shape, dtype=np.uint16)
+    out[valid] = np.digitize(values[valid], bins, right=right).astype(np.uint16) + 1
+    return out
+
+
+def test_public_surface_exposes_thematic_functions():
+    native = get_native_module()
+
+    assert callable(gis.normalize_raster)
+    assert callable(gis.classify_raster)
+    assert callable(native.normalize_raster)
+    assert callable(native.classify_raster)
+    assert "normalize_raster" in gis.__all__
+    assert "classify_raster" in gis.__all__
+
+
+def test_normalize_minmax_numpy_array_stats_and_dtype():
+    source = np.array([[1, 3], [5, 9]], dtype=np.uint16)
+
+    result = gis.normalize_raster(source)
+
+    expected = np.array([[[0.0, 0.25], [0.5, 1.0]]], dtype=np.float32)
+    np.testing.assert_allclose(result["array"], expected)
+    assert result["array"].dtype == np.float32
+    assert result["method"] == "minmax"
+    assert result["class_table"] is None
+    assert result["valid_count"] == 4
+    assert result["nodata_count"] == 0
+    assert result["min"] == pytest.approx(1.0)
+    assert result["max"] == pytest.approx(9.0)
+    assert result["mean"] == pytest.approx(4.5)
+    assert result["std"] == pytest.approx(np.std(source.astype(np.float64)))
+    assert result["warnings"] == []
+    assert result["info"]["driver"] == "memory"
+    assert result["info"]["dtype_per_band"] == ["float32"]
+
+
+def test_normalize_clip_clamps_before_stats_and_scaling():
+    source = np.array([[0.0, 5.0, 10.0]], dtype=np.float32)
+
+    result = gis.normalize_raster(source, clip=(2.0, 8.0))
+
+    expected = np.array([[[0.0, 0.5, 1.0]]], dtype=np.float32)
+    np.testing.assert_allclose(result["array"], expected)
+    assert result["min"] == pytest.approx(2.0)
+    assert result["max"] == pytest.approx(8.0)
+
+
+def test_normalize_excludes_nodata_valid_mask_and_nan_cells():
+    source = np.array([[1.0, -9999.0], [np.nan, 7.0]], dtype=np.float32)
+    valid_mask = np.array([[True, True], [True, False]], dtype=bool)
+
+    result = gis.normalize_raster(source, nodata=-9999.0, valid_mask=valid_mask)
+
+    assert result["valid_count"] == 1
+    assert result["nodata_count"] == 3
+    assert result["min"] == pytest.approx(1.0)
+    assert result["max"] == pytest.approx(1.0)
+    assert result["array"][0, 0, 0] == pytest.approx(0.0)
+    assert np.isnan(result["array"][0, 0, 1])
+    assert np.isnan(result["array"][0, 1, 0])
+    assert np.isnan(result["array"][0, 1, 1])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"nodata": 0},
+        {"valid_mask": np.zeros((2, 2), dtype=bool)},
+    ],
+)
+def test_normalize_all_invalid_raises_empty_raster(kwargs):
+    source = np.zeros((2, 2), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="empty_raster"):
+        gis.normalize_raster(source, **kwargs)
+
+
+def test_normalize_unsupported_method_and_bad_clip():
+    source = np.ones((2, 2), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="unsupported_option"):
+        gis.normalize_raster(source, method="zscore")
+    with pytest.raises(ValueError, match="invalid_argument"):
+        gis.normalize_raster(source, clip=(2.0, 2.0))
+    with pytest.raises(ValueError, match="invalid_argument"):
+        gis.normalize_raster(source, clip=(0.0, np.inf))
+
+
+def test_valid_mask_shape_mismatch_raises_shape_mismatch():
+    source = np.ones((2, 2), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="shape_mismatch"):
+        gis.normalize_raster(source, valid_mask=np.ones((3, 3), dtype=bool))
+
+
+def test_valid_mask_one_band_3d_does_not_broadcast_to_multiband():
+    source = np.ones((2, 2, 2), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="shape_mismatch"):
+        gis.normalize_raster(source, valid_mask=np.ones((1, 2, 2), dtype=bool))
+
+
+def test_nodata_list_length_mismatch_raises_invalid_nodata():
+    source = np.ones((2, 2, 2), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="invalid_nodata"):
+        gis.normalize_raster(source, nodata=[0.0])
+
+
+def test_bad_source_diagnostics_include_expected_tokens():
+    with pytest.raises(ValueError, match="invalid_argument"):
+        gis.normalize_raster({"info": _memory_info(np.ones((2, 2), dtype=np.float32))})
+    with pytest.raises(TypeError, match="unsupported_dtype"):
+        gis.normalize_raster(np.ones((2, 2), dtype=bool))
+
+
+def test_classify_explicit_bins_boundary_semantics_and_counts():
+    source = np.array([[0.0, 1.0, 2.0, 3.0]], dtype=np.float32)
+    bins = [1.0, 2.0]
+
+    left_closed = gis.classify_raster(source, bins=bins, right=False)
+    right_closed = gis.classify_raster(source, bins=bins, right=True)
+
+    np.testing.assert_array_equal(
+        left_closed["array"],
+        _expected_classes(source.reshape(1, 1, 4), bins, right=False),
+    )
+    np.testing.assert_array_equal(
+        right_closed["array"],
+        _expected_classes(source.reshape(1, 1, 4), bins, right=True),
+    )
+    assert left_closed["method"] == "explicit_bins"
+    assert left_closed["array"].dtype == np.uint16
+    assert [row["count"] for row in left_closed["class_table"]] == [0, 1, 1, 2]
+    assert sum(row["count"] for row in left_closed["class_table"]) == source.size
+
+
+def test_classify_accepts_numpy_bins_array():
+    source = np.array([[0, 5, 10]], dtype=np.uint8)
+
+    result = gis.classify_raster(source, bins=np.array([5], dtype=np.int32))
+
+    np.testing.assert_array_equal(result["array"], np.array([[[1, 2, 2]]], dtype=np.uint16))
+
+
+def test_classify_labels_and_class_table_shape():
+    source = np.array([[0, 5, 10, 15]], dtype=np.uint8)
+
+    result = gis.classify_raster(
+        source,
+        bins=[5, 10],
+        labels=["low", "mid", "high"],
+        right=True,
+    )
+
+    table = result["class_table"]
+    assert table[0] == {
+        "class_id": 0,
+        "label": "nodata",
+        "left": None,
+        "right": None,
+        "right_inclusive": False,
+        "count": 0,
+        "nodata": True,
+    }
+    assert [row["label"] for row in table[1:]] == ["low", "mid", "high"]
+    assert [row["class_id"] for row in table] == [0, 1, 2, 3]
+    assert [row["right_inclusive"] for row in table[1:]] == [True, True, True]
+    assert table[1]["left"] is None
+    assert table[1]["right"] == pytest.approx(5.0)
+    assert table[2]["left"] == pytest.approx(5.0)
+    assert table[2]["right"] == pytest.approx(10.0)
+    assert table[3]["left"] == pytest.approx(10.0)
+    assert table[3]["right"] is None
+
+
+def test_classify_invalid_nodata_cells_use_zero_and_stats_exclude_them():
+    source = np.array([[1.0, -1.0], [np.nan, 9.0]], dtype=np.float32)
+    valid_mask = np.array([[True, False], [True, True]], dtype=bool)
+
+    result = gis.classify_raster(
+        source,
+        bins=[5.0],
+        nodata=-1.0,
+        valid_mask=valid_mask,
+        dtype="uint8",
+    )
+
+    np.testing.assert_array_equal(
+        result["array"],
+        np.array([[[1, 0], [0, 2]]], dtype=np.uint8),
+    )
+    assert result["valid_count"] == 2
+    assert result["nodata_count"] == 2
+    assert result["min"] == pytest.approx(1.0)
+    assert result["max"] == pytest.approx(9.0)
+    assert [row["count"] for row in result["class_table"]] == [2, 1, 1]
+
+
+@pytest.mark.parametrize(
+    "bins",
+    [None, [], [1.0, np.inf], [2.0, 1.0], [1.0, 1.0], np.array([[1.0, 2.0]])],
+)
+def test_classify_bad_bins_raise_invalid_argument(bins):
+    with pytest.raises(ValueError, match="invalid_argument"):
+        gis.classify_raster(np.ones((2, 2), dtype=np.float32), bins=bins)
+
+
+def test_classify_label_count_mismatch():
+    with pytest.raises(ValueError, match="invalid_argument"):
+        gis.classify_raster(
+            np.ones((2, 2), dtype=np.float32),
+            bins=[1.0, 2.0],
+            labels=["low", "high"],
+        )
+
+
+@pytest.mark.parametrize("dtype", ["float32", "int8", "bool", "not-a-dtype"])
+def test_classify_unsupported_dtype(dtype):
+    with pytest.raises(TypeError, match="unsupported_dtype"):
+        gis.classify_raster(np.ones((2, 2), dtype=np.float32), bins=[1.0], dtype=dtype)
+
+
+def test_classify_output_dtype_too_small():
+    bins = np.arange(255, dtype=np.float64)
+
+    with pytest.raises(TypeError, match="unsupported_dtype"):
+        gis.classify_raster(np.array([[1.0]], dtype=np.float32), bins=bins, dtype="uint8")
+
+
+def test_source_as_read_raster_style_dict():
+    source = np.array([[1, 2], [3, 4]], dtype=np.uint16)
+
+    result = gis.normalize_raster({"array": source, "info": _memory_info(source)})
+
+    np.testing.assert_allclose(
+        result["array"],
+        np.array([[[0.0, 1 / 3], [2 / 3, 1.0]]], dtype=np.float32),
+    )
+    assert result["info"]["width"] == 2
+    assert result["info"]["height"] == 2
+
+
+def test_no_runtime_python_gis_backend_library_usage():
+    repo = Path(__file__).resolve().parents[1]
+    files = [repo / "python/forge3d/gis.py", repo / "src/gis/thematic.rs"]
+    banned = ("rasterio", "geopandas", "shapely", "rioxarray", "xarray", "terra")
+
+    for path in files:
+        if not path.exists():
+            continue
+        source = path.read_text(encoding="utf-8")
+        for name in banned:
+            assert name not in source

--- a/tests/test_gis_vector_geom.py
+++ b/tests/test_gis_vector_geom.py
@@ -366,16 +366,3 @@ def test_no_python_gis_backend_imports_in_forge3d_gis():
         assert banned not in source
 
 
-def test_no_c6_api_names_in_gis_public_surfaces():
-    repo = Path(__file__).resolve().parents[1]
-    files = [
-        repo / "python/forge3d/gis.py",
-        repo / "python/forge3d/gis.pyi",
-        repo / "src/py_module/functions/gis.rs",
-    ]
-    banned = ["normalize_raster", "classify_raster"]
-
-    for path in files:
-        source = path.read_text(encoding="utf-8")
-        for name in banned:
-            assert name not in source, f"{name} leaked into {path}"


### PR DESCRIPTION
## Summary

Implements the G-002c C6 thematic raster plan with a Rust-backed thematic raster module and thin Python wrappers. The implementation adds explicit min/max normalization and explicit-bin classification while preserving the existing C1-C5 GIS surfaces.

## APIs implemented

- `normalize_raster`
- `classify_raster`

## Scope and non-goals

- No C7/later APIs.
- No color mapping, palettes, or rendering work.
- No remote, cache, OSM, Terrarium, slippy tile, or domain helpers.
- No Python GIS backend libraries.
- No new runtime dependency.

## Validation

- `cargo fmt --check`: passed
- `cargo check`: passed
- `cargo check --features extension-module,weighted-oit,enable-tbn,enable-gpu-instancing,copc_laz`: passed
- `python -m py_compile python/forge3d/gis.py`: passed
- `python -m pytest tests/test_gis_thematic.py -q`: 29 passed
- `python -m pytest tests/test_api_contracts.py tests/test_gis_raster.py -q`: 339 passed, 1 skipped
- `python -m pytest tests/test_gis_rasterize_mask.py -q`: 12 passed
- `python -m pytest tests/test_gis_vector_geom.py -q`: 26 passed

## Evidence

Post-commit evidence bundle:
`C:\Users\milos\AppData\Local\Temp\forge3d-c6-postcommit-20260702-125245`

The unrelated audit log `logs/.9a9fb3a1aee4abd4cecd121a192f7ef77e352837-audit.json` was not included.
