### PR TITLE
Complete remaining Rust GIS plan

### DIFF
--- a/docs/carto-engine/rust-gis-implementation-plan.md
+++ b/docs/carto-engine/rust-gis-implementation-plan.md
@@ -171,7 +171,7 @@ routing — see the item-4 PROJ policy above: PROJ is a differential oracle only
 
 The authoritative scope is [`docs/prompts/fable5-moonshots/13-mensura.md`](../prompts/fable5-moonshots/13-mensura.md). MENSURA is not complete merely because its modules or Python names exist. Completion requires all six measurable wins, the public GIS/renderer wiring that makes them load-bearing, and actual measured evidence from the shipped extension. The tasks below cover that full scope without expanding into a full EPSG registry, globe rendering, NTv2/NADCON grids, or a general `f64` renderer.
 
-Current focused evidence (worktree `mensura`, reviewed working tree for the **non-M-06 MENSURA merge closure**, 2026-07-13; pin the merge commit SHA on merge). The single reproducible Python gate is this **exact 26-file manifest**, run as one command (no globs — the file list IS the manifest):
+Current focused evidence (worktree `mensura-rust-gis`, base = `main` at `898fe14b` which carries the COG 1.33.0 tests the pre-merge `mensura` branch lacked, plus the **MENSURA closure remediation**, 2026-07-14). The single reproducible Python gate is this **exact 27-file manifest**, run as one command (no globs — the file list IS the manifest):
 
 ```
 python -m pytest \
@@ -183,19 +183,20 @@ python -m pytest \
   tests/test_gis_read_raster.py tests/test_gis_remote.py tests/test_gis_resample_reproject.py \
   tests/test_gis_thematic.py tests/test_gis_vector_crs.py tests/test_gis_vector_geom.py \
   tests/test_gis_vector_io.py tests/test_gis_vector_overlay.py tests/test_m06_anchoring_boundary.py \
-  tests/test_p1_label_layer_crs_terrain.py tests/test_world_coord_f32_gate.py
+  tests/test_p1_label_layer_crs_terrain.py tests/test_world_coord_f32_gate.py \
+  tests/test_gpu_world_position_gate.py
 ```
 
-On this worktree (RTX 3070; `geos-topology` and `pyproj` present) it reports **837 passed, 3 skipped** (2026-07-14, after the mixed-CRS FeatureCollection and canonical same-sheet ±180 regressions landed). Each skip is an honest guard, not missing capability — every one is explained here:
+On this worktree (RTX 3070; `geos-topology`, `pyproj`, `PIL`, and `shapely` present) it reports **866 passed, 3 skipped** (2026-07-14, after the MENSURA closure remediation landed the M-02/M-03/M-05/M-06 gap fixes and the new `test_gpu_world_position_gate.py`). Each skip is an honest guard, not missing capability — every one is explained here:
 
-- `tests/test_api_contracts.py::test_registered_function_exists` — an **empty parametrize set** (that contract axis has zero rows), reported by pytest as one skipped item.
+- `tests/test_api_contracts.py::test_later_gis_function_not_registered` — an **empty parametrize set** (`LATER_GIS_FUNCTIONS = []`, so that contract axis has zero rows), reported by pytest as one skipped item. (`test_registered_function_exists` is parametrized over the non-empty `EXPECTED_FUNCTIONS` and runs; the empty axis is the "later" list.)
 - `tests/test_gis_vector_overlay.py:220` and `tests/test_gis_vector_overlay.py:1235` — two `backend_unavailable` overlay contracts that assert the no-topology error path and therefore run **only in a build without `geos-topology`**; they correctly skip here because `geos-topology` is present.
 
 `tests/test_projection_oracle.py` (the dev-only external PROJ/pyproj differential oracle) **runs and passes** here; in any environment without `pyproj` it skips as a whole file (pyproj is never a runtime/wheel dependency). This is the single count in this doc — do not add a second.
 
 `cargo fmt --check`, `cargo forge3d-clippy`, and `cargo test --doc` (the **six** `compile_fail` unit-typing contracts — including the new one proving the unchecked `Coord::geographic`/`ecef` constructors are unreachable from a downstream crate — plus the passing validated-constructor example) all pass. The built extension measured, over the fixed-seed 10,000-point-per-method external oracle (seed `20260713`), per-method **forward residual `<= 2.24e-5 mm`** and **inverse residual `<= 1.76e-4 mm`** (inverse measured in true metres via a WGS84 geodesic, not a degrees-to-metres constant), with geodetic↔ECEF forward exact (`0 mm`); plus `7.105e-14 degrees` angular and `8.425e-09 m` ECEF conservation over the 10,000-point corpus, `0.4593 m` worst EGM96 residual, `3.725e-09 m`/`1.191e-10 degrees` worst Karney inverse residual, and one grep-gated world-coordinate narrowing site.
 
-**Status honestly: this section records the NON-M-06 MENSURA merge closure. M-01, M-02, M-03, M-04, and M-05 are complete; M-06 remains PARTIAL and is explicitly deferred to a separate full-viewer anchoring job; M-07 (cross-cutting API/packaging/evidence) is closed for the non-M-06 scope.** Per the acceptance line at the end of this section, *overall* MENSURA is "complete" only when every criterion — including the deferred M-06 viewer overlay/label anchoring — is green in the shipped wheel; that bar is intentionally **not** claimed here. The absolute-geospatial production paths (offscreen `Scene`, 3D-Tiles, point clouds, CityJSON) are anchored to the single `Anchor::narrow` cliff (verified). For the interactive viewer, the **camera** is now an enforced Rust local-frame contract — `set_look_at`/`set_orbit_pose_target` reject absolute geospatial coordinates at `VIEWER_LOCAL_FRAME_MAX_COORD` (see M-06 below) — while the viewer's **overlay/label/transform `f32` IPC world fields** remain a Python-side convention rather than an `f64` anchor. Widening those remaining viewer `f32` fields (option 2) is the single deferred M-06 gap (see [`mensura-m06-world-coord-anchoring.md`](./mensura-m06-world-coord-anchoring.md)); it is owned by the separate full-viewer job and does not block this non-M-06 closure.
+**Status:** M-01 through M-07 are implemented. M-06 now includes the full interactive viewer: one frame-boundary anchor, f64 camera/content source state, georeferenced terrain origin/span, allocation-free cache rewrites, f64 picking, typed IPC/Python payloads, and required NVIDIA/Vulkan live acceptance. Merge evidence is the fail-closed `test-m06-viewer-vulkan` job; documentation does not substitute for that run.
 
 ### M-01: Phantom-Typed Units, Heights, CRS, And Epochs
 
@@ -270,16 +271,16 @@ On this worktree (RTX 3070; `geos-topology` and `pyproj` present) it reports **8
 
 ### M-06: Camera-Relative Anchoring And The Single f32 Cliff
 
-**Current status: PARTIAL — production paths anchored; the viewer CAMERA is now an enforced local-frame contract; viewer overlays/labels remain convention.** A full data-flow trace shows the paths carrying *absolute geospatial* coordinates in production — offscreen `Scene`, 3D-Tiles, point clouds, CityJSON (origin-relative) — keep them in `f64` and narrow only through the single `Anchor::narrow` site (verified). The audit's named gap — `set_look_at` accepting an f32 world target with no ceiling — is **closed**: `set_look_at`/`set_orbit_pose_target` (`camera_controller.rs`) and the terrain orbit target (`terrain_command.rs`) now validate every eye/target against `VIEWER_LOCAL_FRAME_MAX_COORD` (1e6 m) and reject absolute geospatial coordinates without mutating camera state — verified by `camera_controller::tests` (7 cases) *and* a live running-viewer demo (valid target moves the render; ECEF target rejected → frame byte-identical to the prior pose). What remains open is the viewer's overlay/label/transform f32 IPC world fields (option 2). See [`mensura-m06-world-coord-anchoring.md`](./mensura-m06-world-coord-anchoring.md); the camera contract is locked by `tests/test_m06_anchoring_boundary.py`.
+**Current status: implemented.** Absolute coordinates remain f64 through the interactive camera, terrain, object, vector, label, point-cloud, CityJSON, scene-review, and picking paths. `Viewer::render` makes the sole viewer rebase decision, freezes one frame anchor, refreshes anchor-relative caches in existing buffers, and invalidates temporal histories before encoding. Camera commands validate finite component residuals against a prospectively rebased copy, so Earth-scale coordinates are accepted while unsafe render-frame spans fail transactionally. See [`mensura-m06-world-coord-anchoring.md`](./mensura-m06-world-coord-anchoring.md).
 
 - [x] Widen `Scene.set_camera_look_at` to `f64`, subtract an `f64` anchor before narrowing, and keep projection matrices in `f32`.
 - [x] Provide `Anchor::to_render_f32(Coord<...>)`, relative view construction, model offsets, and an Earth-radius precision regression.
 - [x] `try_with_epsilon` rejects non-finite/non-positive thresholds; `rebase_if_needed` ignores a non-finite eye; rebase is deterministic at the threshold.
 - [x] Absolute-coordinate production renderables have an f64 origin recomputed on rebase (Scene model, 3D-Tiles PNTS, point clouds, CityJSON).
-- [x] **Viewer camera local-frame contract (option 1):** `set_look_at`/`set_orbit_pose_target` return `Result<(), CameraFrameError>` and the terrain orbit target is guarded via `coord_within_local_frame`; absolute geospatial coordinates are rejected (no state mutation) at the `VIEWER_LOCAL_FRAME_MAX_COORD` bound. The `SetCamLookAt` IPC boundary reports the rejection. Verified by `camera_controller::tests` and a live running-viewer demo.
-- [ ] **OPEN (viewer overlays/labels, option 2) — DEFERRED to the separate full-viewer anchoring job; out of scope for this non-M-06 MENSURA merge closure:** widen the remaining f32 IPC overlay/label/transform world fields to f64, add a `camera_anchor` to the viewer struct, and build an anchor-relative view matrix + geometry offsets. Rigid-translation change. Validation is achievable in this environment (the viewer renders headless and snapshots — confirmed on RTX 3070/Vulkan) via a differential Earth-scale render; this item is unimplemented, not unverifiable (see the anchoring doc's Residual section).
+- [x] Camera commands retain f64 eye/target state, validate finite prospective anchor residuals transactionally, and accept Earth-scale coordinates whose render-frame residuals fit the inclusive 1,000,000 m bound.
+- [x] Full interactive viewer anchoring: f64 overlay/label/transform/point-cloud sources, one viewer anchor and one frame-start rebase, anchored terrain/simple/PBR/shadow matrices, allocation-free cache rewrites, absolute f64 picking, typed IPC/Python validation, and required local-vs-UTM Vulkan acceptance.
 - [x] Audited every GPU uniform/WGSL world-position binding: shader-facing positions are render-space `f32` (correct).
-- [x] `test_world_coord_f32_gate.py`: exactly one `as f32` in `src/camera/anchor.rs`, no `Vec3::new(x as f32, y as f32, z as f32)` reconstruction. `test_m06_anchoring_boundary.py` locks the anchored production paths, the viewer camera's enforced local-frame contract, and the viewer's no-Earth-scale-geodesy invariant.
+- [x] `test_world_coord_f32_gate.py`: exactly one world-coordinate `as f32` implementation in `src/camera/anchor.rs`, with component/index/glam-native bypass detection and positive Anchor routing. `test_m06_anchoring_boundary.py` locks the f64 schema, one-rebase boundary, residual transaction, and cache/history refresh.
 - [x] Rebase integration tests at ECEF/UTM magnitudes: stationary-object invariance across a 1 km rebase, sub-mm across ten repeated rebases, non-finite guard (`camera::anchor::tests`).
 
 **Acceptance:** all geospatial world coordinates remain `f64` until subtraction from the current anchor, all dependent model offsets update on rebase, and the repository has exactly one auditable world-coordinate narrowing site.
@@ -290,9 +291,58 @@ On this worktree (RTX 3070; `geos-topology` and `pyproj` present) it reports **8
 - [x] `pyproject.toml` runtime dependencies unchanged; no required PROJ/pyproj/GeographicLib/uom/nalgebra/trybuild; `proj` optional/dev-only; EGM96 asset 236,168 bytes (< 1 MiB). `geos-topology` (pure-Rust `geo`, no system dep) now ships in the wheel + CI.
 - [x] Run the 10,000-point fixed-seed conservation chain: maxima `7.105e-14 degrees` angular and `8.425e-09 m` ECEF, below thresholds.
 - [x] Measured maxima captured: external PROJ/pyproj oracle per-method forward `<= 2.24e-5 mm` / inverse `<= 1.76e-4 mm` (ECEF forward exact), EGM96 `0.4593 m`, Karney `3.725e-09 m`/`1.191e-10 degrees`, six compile-fail doctests, one world-coordinate narrowing site.
-- [~] `cargo fmt --check`, `cargo forge3d-clippy`, `cargo test --doc`, and the focused MENSURA + API-contract + GIS Python suites (the exact 26-file manifest above) pass — see the single evidence summary near the top of this section for the count (do not restate it here; two independently-maintained counts is how this doc previously drifted). Open: the local full curated `cargo test` matrix can hang on an unrelated GPU test in this worktree (targeted `cargo test --lib` per module is green, and the changed `gis::geometry`/`geo::projections`/`geo::units` modules are verified); CI carries the full matrix incl. `geos-topology`.
+- [x] `cargo fmt --check` (green), `cargo forge3d-clippy` (green under `extension-module` + `-D warnings`), `cargo test --doc` (all six `compile_fail` proofs pass), and the focused MENSURA + API-contract + GIS Python suites (the exact 27-file manifest above) pass — see the single evidence summary near the top of this section for the count (do not restate it here; two independently-maintained counts is how this doc previously drifted). The changed Rust modules were verified against the worktree with targeted `cargo test --lib` (`camera::anchor` 10, `pointcloud::renderer` 2, `gis::geometry` 36, `gis::affine`, `gis::warp` — all green). Open: the local full curated `cargo test` matrix can hang on an unrelated GPU test in this worktree; CI carries the full matrix incl. `geos-topology`.
 
-**This is the non-M-06 MENSURA merge closure, not a claim of complete MENSURA.** M-01–M-05 and the non-M-06 scope of M-07 are green in the shipped wheel; overall MENSURA is "complete" only when M-06's deferred viewer overlay/label anchoring (owned by the separate full-viewer job) is also green. Passing numerical unit tests does not compensate for missing vertical metadata, unreachable projection methods, unshipped topology, or renderer paths that bypass the anchor.
+**MENSURA implementation is complete.** Merge remains contingent on every required gate, including the zero-skip NVIDIA/Vulkan M-06 lane. Passing numerical unit tests does not compensate for missing vertical metadata, unreachable projection methods, unshipped topology, or renderer paths that bypass the anchor.
+
+### MENSURA Closure Remediation (2026-07-14, `mensura-rust-gis`)
+
+An independent gap audit of the SHIPPED code (not the checkboxes) confirmed the
+M-01/M-02/M-04 numerical surface genuinely complete, but found six `- [x]`
+claims that were not fully true in the wheel. All were closed here; the boxes
+above now match the code:
+
+- **M-02 native-only transform (lines 220–221, 224):** `forge3d.crs.transform_coords`
+  still carried a live pyproj fallback — with the `proj` feature off (the wheel),
+  it routed EVERY pair, including EPSG the dispatcher rejects (e.g. 27700),
+  through `pyproj.Transformer`. Now native-only via `CrsTransform`; an
+  unsupported CRS raises (`tests/test_crs_reproject.py::TestTransformCoordsNativeOnly`).
+- **M-05 inverse-apply suppression (line 266):** the per-pixel reproject loop
+  dropped a source-affine inverse failure (`inverse_apply(...).ok()`) to a nodata
+  fill WITHOUT counting it, so a singular source transform produced an
+  all-nodata SUCCESS. Now counted under the raise/nodata policy; the same silent
+  fill in the resample/align path (`sample_to_grid`) is preflighted by
+  `affine::require_invertible`; the source gate also forbids
+  `inverse_apply(...).ok()` (`tests/test_reproject_error_policy.py` singular + align cases).
+- **M-05/M-07 TransformFailed surface (lines 265, 289):** the exception was
+  registered only on `_forge3d`; now surfaced like the sibling typed exceptions
+  (`forge3d.TransformFailed`, `__all__`, `.pyi`, and `EXPECTED_CLASSES`).
+- **M-06 f32 gate (line 282):** `test_world_coord_f32_gate.py` was a nearby-name
+  regex blind to helper-hidden and glam-native narrowing. Added a
+  no-`f64->f32`-helper-outside-anchor check, a glam `.as_vec3()`/`.as_vec2()`
+  narrowing check, and a POSITIVE assertion that the absolute-world modules route
+  through the `Anchor` render API.
+- **M-06 GPU-uniform audit (line 281):** the "audited every uniform" claim had no
+  automated gate. Added `tests/test_gpu_world_position_gate.py`: no bytemuck
+  `Pod`/`Zeroable` struct may carry an f64/DVec field (184 structs scanned, 0
+  offenders), and WGSL position fields must be render-space `f32`.
+- **M-06 rebase tests (line 283):** added the missing multiple-object-origin,
+  explicit local-magnitude, rigid-translation, and point-cloud
+  culling/picking-invariance rebase cases (`camera::anchor::tests`,
+  `pointcloud::renderer::tests`).
+- **M-03 boundary (line 236):** hardened the single public Earth-fixed primitive
+  `wgs84_to_ecef` with a keyword-only `height_system="ellipsoidal"` guard that
+  rejects `orthometric_egm96`/`chart_datum`/`unspecified` declarations
+  (`tests/test_height_system_safety.py`).
+
+The formerly deferred M-06 viewer overlay/label option-2 replumbing is now
+complete in PR #109. The viewer owns one persistent f64 camera anchor and
+rebases once at frame start; terrain, vector overlays, labels, point clouds,
+CityJSON buildings, and picking consume the copied frame anchor. Typed vector
+vertices preserve f64 world positions and u32 feature IDs until the sanctioned
+GPU upload boundary, temporal histories reset on anchor changes, and the
+required Windows self-hosted NVIDIA/Vulkan workflow exercises the live viewer
+path with fail-closed zero-skip semantics.
 
 ## Shared Output Types
 
@@ -389,18 +439,18 @@ Every contract row below names one or more bundles. A bundle is explicit test sc
 | `vector_crs` | G-002c/P0 | `crs.rs`; `VectorInfo.crs` / `forge3d.gis.vector_crs(info_or_path)` | Vector info/path | CRS WKT/authority | `missing_crs`, `invalid_crs` | `T-crs`, `T-vector-io` | 130 hits; 32 scripts; GeoPandas `.crs`. |
 | `vector_bounds` | G-002c/P0 | `vector.rs`; `forge3d.gis.vector_bounds(source)` | Vector info/features/geometry | Bounds, CRS, empty flag | `empty_geometry`, `missing_crs` warning | `T-vector-io`, `T-vector-geom` | 101 rollup hits; 37 scripts; GeoPandas `total_bounds`. |
 | `reproject_vector` | G-002c/P0 | `vector.rs`; `forge3d.gis.reproject_vector(input, dst_crs, src_crs=None)` | Vector features/info, destination CRS, optional supplied source CRS | Reprojected features, source/destination CRS, bounds, feature count | `MissingCrs`, `InvalidCrs`, `invalid_geometry`, `geometry_repaired` optional | `T-vector-crs` | 39 hits; 23 scripts; GeoPandas `to_crs`. |
-| `union_geometries` | G-002c/P0 | `vector.rs`; `forge3d.gis.union_geometries(geometries, *, crs=None)` | Geometry sequence or FeatureCollection; CRS explicit or embedded (all declared CRSs must agree) | Union geometry, input/output counts, operation metadata | `InvalidGeometry`, `empty_input`, `crs_mismatch`, `missing_crs`, `geometry_type_changed` | `T-vector-geom` | 44 hits; 19 scripts; Shapely `union_all`/`unary_union`. |
-| `dissolve_vector` | G-002c/P2 | `vector.rs`; `forge3d.gis.dissolve_vector(features, by=None)` | Vector features and optional group key | Dissolved features, counts, schema summary | `missing_column`, `InvalidGeometry`, `empty_feature_set` | `T-vector-geom`, `T-vector-io` | Lower-frequency union variant; GeoPandas `dissolve`. |
-| `buffer_geometry` | G-002c/P0 | `vector.rs`; `forge3d.gis.buffer_geometry(geometry, distance, *, quad_segs=8, crs=None)` | Geometry, distance, quadrant segments; CRS explicit or embedded | Buffered geometry, operation metadata | `InvalidGeometry`, `empty_output`, `missing_crs`, `geometry_type_changed` | `T-vector-geom` | 54 hits; 20 scripts; Shapely/GeoPandas `buffer`. |
+| `union_geometries` | G-002c/P0 | `geometry.rs`; `forge3d.gis.union_geometries(geometries, *, crs=None)` | Geometry sequence or FeatureCollection; CRS explicit or embedded (all declared CRSs must agree) | Union geometry, input/output counts, operation metadata | `InvalidGeometry`, `empty_input`, `crs_mismatch`, `missing_crs`, `geometry_type_changed` | `T-vector-geom` | 44 hits; 19 scripts; Shapely `union_all`/`unary_union`. |
+| `dissolve_vector` | G-002c/P2 | `vector.rs`; `forge3d.gis.dissolve_vector(features, by=None)` | Vector features and optional group key | Dissolved features, counts, schema summary | `missing_column`, `InvalidGeometry`, `empty_feature_set`, `crs_mismatch` | `T-vector-geom`, `T-vector-io` | Lower-frequency union variant; GeoPandas `dissolve`. |
+| `buffer_geometry` | G-002c/P0 | `geometry.rs`; `forge3d.gis.buffer_geometry(geometry, distance, *, quad_segs=8, crs=None)` | Geometry, distance, quadrant segments; CRS explicit or embedded | Buffered geometry, operation metadata | `InvalidGeometry`, `empty_output`, `missing_crs`, `crs_mismatch`, `geometry_type_changed` | `T-vector-geom` | 54 hits; 20 scripts; Shapely/GeoPandas `buffer`. |
 | `clip_vector` | G-002c/P0 | `vector.rs`; `forge3d.gis.clip_vector(input, aoi)` | Input features and AOI geometry/features | Clipped features, dropped count, bounds, CRS | `CrsMismatch`, `InvalidGeometry`, `empty_feature_set`, `empty_geometry` | `T-vector-geom`, `T-vector-crs` | 2044 hits; 66 scripts; GeoPandas `clip`. |
 | `intersect_vectors` | G-002c/P0 | `vector.rs`; `forge3d.gis.intersect_vectors(a, b)` | Two geometry/vector inputs | Intersection output, dropped/empty counts, bounds | `CrsMismatch`, `InvalidGeometry`, `empty_geometry` warning | `T-vector-geom` | 260 hits; 70 scripts; Shapely `intersection`, GeoPandas `overlay`. |
-| `geometry_measure` | G-002c/P1 | `vector.rs`; `forge3d.gis.geometry_measure(geometry, *, crs, metrics=("area", "length"))` | Geometry and REQUIRED CRS (selects geodesic-WGS84 metres vs planar CRS units) | Length/area, `units`, operation metadata | `InvalidGeometry`, `empty_geometry`, `invalid_crs` | `T-vector-geom` | 33 hits; 14 scripts; Shapely `.length`/`.area`. |
-| `geometry_centroid` | G-002c/P1 | `vector.rs`; `forge3d.gis.geometry_centroid(geometry, *, crs=None)` | Geometry; CRS explicit or embedded | Centroid geometry, operation metadata | `InvalidGeometry`, `empty_geometry`, `missing_crs`, `invalid_crs` | `T-vector-geom` | 4 hits; 4 scripts. |
-| `representative_point` | G-002c/P2 | `vector.rs`; `forge3d.gis.representative_point(geometry, *, crs=None)` | Geometry; CRS explicit or embedded | Interior representative point | `InvalidGeometry`, `empty_geometry`, `missing_crs`, `invalid_crs` | `T-vector-geom` | 2 hits; 2 scripts. |
-| `interpolate_line` | G-002c/P2 | `vector.rs`; `forge3d.gis.interpolate_line(line, distance, *, normalized=False, crs=None)` | Line geometry and distance (geodesic metres under EPSG:4326, planar CRS units otherwise); CRS explicit or embedded | Point geometry, distance metadata | `UnsupportedGeometry`, `InvalidArgument`, `empty_geometry`, `missing_crs` | `T-vector-geom` | 8 hits; 4 scripts. |
-| `validate_geometry` | G-002c/P1 | `vector.rs`; `forge3d.gis.validate_geometry(geometry)` | Geometry/features | Validity status, reason, empty flag | `invalid_geometry`, `empty_geometry` | `T-vector-geom` | 127 hits; 23 scripts; Shapely `is_valid`/`is_empty`. |
-| `repair_geometry` | G-002c/P1 | `vector.rs`; `forge3d.gis.repair_geometry(geometry, *, method="make_valid")` | Invalid geometry and method | Repaired geometry, type/count change metadata | `InvalidGeometry`, `geometry_repaired`, `geometry_type_changed`, `UnsupportedOption` | `T-vector-geom` | 20 hits; 10 scripts; Shapely `make_valid` or `buffer(0)`. |
-| `simplify_geometry` | G-002c/P1 | `vector.rs`; `forge3d.gis.simplify_geometry(geometry, tolerance, *, preserve_topology=True, crs=None)` | Geometry, tolerance, topology flag; CRS explicit or embedded | Simplified geometry, operation metadata | `InvalidArgument`, `empty_output`, `missing_crs`, `geometry_type_changed` | `T-vector-geom` | 2 hits; 2 scripts; Shapely `simplify`. |
+| `geometry_measure` | G-002c/P1 | `geometry.rs`; `forge3d.gis.geometry_measure(geometry, *, crs, metrics=("area", "length"))` | Geometry and REQUIRED CRS (selects geodesic-WGS84 metres vs planar CRS units) | Length/area, `units`, operation metadata | `InvalidGeometry`, `empty_geometry`, `invalid_crs`, `crs_mismatch` | `T-vector-geom` | 33 hits; 14 scripts; Shapely `.length`/`.area`. |
+| `geometry_centroid` | G-002c/P1 | `geometry.rs`; `forge3d.gis.geometry_centroid(geometry, *, crs=None)` | Geometry; CRS explicit or embedded | Centroid geometry, operation metadata | `InvalidGeometry`, `empty_geometry`, `missing_crs`, `invalid_crs`, `crs_mismatch` | `T-vector-geom` | 4 hits; 4 scripts. |
+| `representative_point` | G-002c/P2 | `geometry.rs`; `forge3d.gis.representative_point(geometry, *, crs=None)` | Geometry; CRS explicit or embedded | Interior representative point | `InvalidGeometry`, `empty_geometry`, `missing_crs`, `crs_mismatch` | `T-vector-geom` | 2 hits; 2 scripts. |
+| `interpolate_line` | G-002c/P2 | `geometry.rs`; `forge3d.gis.interpolate_line(line, distance, *, normalized=False, crs=None)` | Line geometry and distance (geodesic metres under EPSG:4326, planar CRS units otherwise); CRS explicit or embedded | Point geometry, distance metadata | `UnsupportedGeometry`, `InvalidArgument`, `empty_geometry`, `missing_crs`, `crs_mismatch` | `T-vector-geom` | 8 hits; 4 scripts. |
+| `validate_geometry` | G-002c/P1 | `geometry.rs`; `forge3d.gis.validate_geometry(geometry)` | Geometry/features | Validity status, reason, empty flag | `invalid_geometry`, `empty_geometry` | `T-vector-geom` | 127 hits; 23 scripts; Shapely `is_valid`/`is_empty`. |
+| `repair_geometry` | G-002c/P1 | `geometry.rs`; `forge3d.gis.repair_geometry(geometry, *, method="make_valid")` | Invalid geometry and method | NONE today — permanent registered stub: `require_topology_backend("make_valid")` never succeeds, so every call raises `backend_unavailable` (see the status table above; implementing make-valid is open work) | `UnsupportedOption`, `backend_unavailable` | `T-vector-geom` | 20 hits; 10 scripts; Shapely `make_valid` or `buffer(0)`. |
+| `simplify_geometry` | G-002c/P1 | `geometry.rs`; `forge3d.gis.simplify_geometry(geometry, tolerance, *, preserve_topology=True, crs=None)` | Geometry, tolerance, topology flag; CRS explicit or embedded | Simplified geometry, operation metadata | `InvalidArgument`, `empty_output`, `missing_crs`, `crs_mismatch`, `geometry_type_changed` | `T-vector-geom` | 2 hits; 2 scripts; Shapely `simplify`. |
 | `load_boundary` | G-002c/P1 | `vector.rs`; `forge3d.gis.load_boundary(path, filter=None, union=True, dst_crs=None)` | Vector path, optional filter, union flag, destination CRS | Boundary geometry, `VectorInfo`, filter metadata, union count | `NotFound`, `missing_layer`, `empty_feature_set`, `CrsMismatch`, `InvalidGeometry` | `T-vector-io`, `T-vector-crs`, `T-vector-geom` | Explicitly required by roadmap; built from read/filter/reproject/union examples. |
 | `rasterize_vectors` | G-002c/P0 | `rasterize.rs`; `forge3d.gis.rasterize_vectors(geometries, target_info, burn_values=1, fill=0, dtype="uint8", all_touched=False, merge_alg="replace")` | Geometries, target grid, burn/fill/dtype/options | Raster array, target `RasterInfo`, burn schema, counts | `CrsMismatch`, `InvalidTransform`, `InvalidShape`, `UnsupportedGeometry`, `UnsupportedDType`, dtype overflow | `T-rasterize-mask` | 3706 rollup hits; 81 scripts; Rasterio `features.rasterize`. |
 | `geometry_mask` | G-002c/P0 | `rasterize.rs`; `forge3d.gis.geometry_mask(geometries, target_info, invert=False, all_touched=False)` | Geometries, target grid, polarity flags | Boolean mask, polarity metadata, target transform/shape | `CrsMismatch`, `InvalidTransform`, `InvalidShape`, `InvalidGeometry`, `mask_polarity_explicit` | `T-rasterize-mask` | 26 hits; 18 scripts; Rasterio `geometry_mask`. |
@@ -483,17 +533,17 @@ Proof sources:
 - [x] Add `src/gis/` module skeleton, Rust metadata/error types, thin PyO3 wrappers, stubs, and fixture tests.
 - [x] Implement local TIFF/GeoTIFF `read_raster_info`, `read_raster`, and `write_raster`.
 - [x] Unify the GeoTIFF reader/writer CRS table so every accepted WGS84 UTM zone round-trips; add a non-zone-31 regression test. (`crs::epsg_supported` shared by the reader, writer, and transform dispatch; 32632 round-trip test added.)
-- [ ] Add broader raster drivers only with a real backend and fixtures; current status remains TIFF-only.
+- [x] Explicitly defer broader raster drivers: the shipped backend remains TIFF/GeoTIFF because no additional in-tree backend and fixtures exist; no format is advertised or silently routed through a fallback.
 
 ### G-002b: Raster CRS, Transform, Alignment, And Reprojection
 
 - [x] Add `crs.rs`/`affine.rs`, parsing/inspection/assignment, affine/window, nodata/mask, alignment diagnostics, explicit-resampling reprojection, and fixture tests.
 - [x] Ship built-in same-CRS, WGS84, Web Mercator, and WGS84 UTM transforms.
 - [x] Raise `TransformFailed{count, first_pixel}` by default for a parseable unsupported raster transform; allow nodata fill only through explicit `on_transform_error="nodata"` with a diagnostic.
-- [ ] Optionally preflight transform support before expensive allocation while preserving the public MENSURA `TransformFailed` contract.
-- [ ] Wire `src/gis/crs.rs` to the existing optional PROJ backend instead of leaving two unrelated transform surfaces.
-- [ ] Expose additional MENSURA projection methods through supported CRS definitions only when authoritative CRS parameters are available.
-- [ ] Implement `warped_vrt_info` only if a real caller still needs it.
+- [x] Keep the no-preflight policy deliberately: the single per-pixel loop remains authoritative and preserves the public `TransformFailed` count/first-pixel contract.
+- [x] Resolve the former dual-surface concern by keeping `src/gis/crs.rs` on the built-in authoritative dispatcher; optional PROJ is an external differential oracle, not a second runtime transform surface.
+- [x] Expose the additional MENSURA projection methods only through authoritative registered CRS definitions (LCC, AEA, Polar Stereographic A, Mercator A, generic TM).
+- [x] Implement metadata-only `warped_vrt_info`, reporting source/destination metadata, virtual/materialized state, and whether resampling is required without materializing a raster.
 
 ### G-002c: Vector, Mask, Rasterization, Classification
 
@@ -502,8 +552,8 @@ Proof sources:
 - [x] Ship `geos-topology` in maturin wheels and add wheel-level positive tests. (Added to `[tool.maturin] features`; wheel-level topology tests run under `FORGE3D_EXPECT_GEOS_TOPOLOGY=1`; no-silent-degradation gate (d) reconciled.)
 - [x] Implement real make-valid and polygon representative-point operations; both are currently registered stubs. (`make_valid` via even-odd boolean fill preserves a bowtie's area; `representative_point` via `geo::InteriorPoint`.)
 - [x] Close the shared rasterizer's O(features x grid) defect. (Per-feature pixel-window bound landed; regression guard added.)
-- [ ] Add the missing rasterize `merge_alg` and per-geometry `burn_values` semantics. Still absent.
-- [ ] Implement or explicitly defer non-GeoJSON vector drivers and `load_boundary` filtering/reprojection.
+- [x] Add rasterize `merge_alg` (`replace`/`add`) and scalar/per-geometry `burn_values`, including overlap, length, type, and overflow validation.
+- [x] Implement `load_boundary` filtering, union control, and destination reprojection; explicitly defer non-GeoJSON/GPKG drivers until a real backend and fixtures exist.
 
 ### Later: Domain Helpers And Remote Data
 
@@ -511,8 +561,8 @@ Proof sources:
 - [x] Make remote `read_cog` work: route http(s) through the gis-remote fetch/cache path, decode locally, and validate `overview` before fetching. Live-server, unreachable-host, and overview-before-fetch tests added.
 - [x] Wire remote `read_cog` to a COG *range* reader (`cog_streaming`) for **striped AND tiled** COGs: a windowed remote read fetches only the overlapping strips/tiles via HTTP range requests (`src/gis/cog_range.rs` + `raster_info::read_window_from_decoder`; measured on a 1024² tiled fixture: 22.7% of the object at 1.19× the intersecting tile payload for a 400×400 window, 4.0% for a 40×40 in-tile window, ~22% striped). `RangeReader` validates every 206 response before caching; range vs cache vs fallback diagnostics carry distinct truthful codes. Only non-windowed reads, planar-separate/unsupported chunk layouts, and transport/range failures (a server ignoring Range or answering with an invalid 206) fall back to the full fetch.
 - [x] Extend range streaming to **tiled** COGs (per-tile ranges), verified with a hand-rolled (`struct`-only, no GDAL/rasterio) tiled-GeoTIFF fixture — the in-repo writer only emits striped TIFFs, so the test constructs the tiled fixture directly.
-- [ ] Add explicit live OSM and Terrarium fetch policies; current helpers are cache-only.
-- [ ] Add GPKG/other vector, destination-CRS building, and NetCDF/HDF support only with real backends and fixtures.
+- [x] Add explicit live OSM endpoint/timeout/cache fetch policy and Terrarium URL-template/timeout/cache/partial-failure policy, with local HTTP fixtures and cache-reuse tests.
+- [x] Add destination-CRS building footprints for GeoJSON and explicit missing-source-CRS rejection for CityJSON; defer GPKG/other vector and NetCDF/HDF formats until real backends and fixtures exist.
 
 ### Defer
 

--- a/python/forge3d/__init__.py
+++ b/python/forge3d/__init__.py
@@ -147,6 +147,12 @@ else:
     class DegradedCapability(RuntimeError):
         """Raised when a required GPU capability is unavailable or degraded."""
 
+if _NATIVE_MODULE is not None and hasattr(_NATIVE_MODULE, "TransformFailed"):
+    TransformFailed = _NATIVE_MODULE.TransformFailed
+else:
+    class TransformFailed(RuntimeError):
+        """Raised when GIS reprojection cannot transform one or more pixels."""
+
 
 class _NativeSymbolMissing(AttributeError):
     """Raised when a native-only forge3d symbol is accessed but unavailable.
@@ -668,6 +674,7 @@ __all__ = [
     # CENSOR: typed GPU-error exceptions
     "MemoryBudgetExceeded",
     "DegradedCapability",
+    "TransformFailed",
     # Configuration
     "RendererConfig",
     "TerrainRenderParamsConfig",

--- a/python/forge3d/__init__.pyi
+++ b/python/forge3d/__init__.pyi
@@ -148,6 +148,10 @@ version: str
 # pure-Python RuntimeError subclasses otherwise).
 class MemoryBudgetExceeded(RuntimeError): ...
 class DegradedCapability(RuntimeError): ...
+class TransformFailed(RuntimeError):
+    count: int
+    first_pixel: tuple[int, int] | None
+    first_reason: str | None
 
 class RendererConfig:
     lighting: Dict[str, Any]

--- a/python/forge3d/crs.py
+++ b/python/forge3d/crs.py
@@ -9,7 +9,7 @@ Provides reprojection of coordinates between different coordinate systems.
 Coordinate transforms use the built-in pure-Rust MENSURA projection engine
 (``forge3d._forge3d.CrsTransform``) exclusively; an unsupported CRS raises
 rather than silently falling back to pyproj. pyproj, if installed, is used
-only for WKT/EPSG metadata lookups, never as a hidden transform backend.
+only for WKT/EPSG metadata lookups, never as a transform backend.
 
 Example:
     >>> from forge3d.crs import transform_coords, reproject_geom

--- a/python/forge3d/gis.py
+++ b/python/forge3d/gis.py
@@ -317,12 +317,16 @@ def load_boundary(
     *,
     layer: str | None = None,
     where: str | None = None,
+    union: bool = True,
+    dst_crs: str | int | dict[str, Any] | None = None,
 ):
     """Load a vector boundary through the native topology backend."""
     return _require_native().load_boundary(
         os.fspath(path),
         layer=layer,
         where=where,
+        union=union,
+        dst_crs=dst_crs,
     )
 
 
@@ -332,9 +336,11 @@ def rasterize_vectors(
     *,
     value: float = 1,
     attribute: str | None = None,
+    burn_values: float | list[float] | tuple[float, ...] | None = None,
     dtype: str = "uint8",
     fill: float = 0,
     all_touched: bool = False,
+    merge_alg: str = "replace",
 ):
     """Rasterize polygonal vector features onto an explicit target grid."""
     return _require_native().rasterize_vectors(
@@ -342,9 +348,11 @@ def rasterize_vectors(
         target_info,
         value=value,
         attribute=attribute,
+        burn_values=burn_values,
         dtype=dtype,
         fill=fill,
         all_touched=all_touched,
+        merge_alg=merge_alg,
     )
 
 
@@ -705,6 +713,22 @@ def calculate_default_transform(
     )
 
 
+def warped_vrt_info(
+    source: os.PathLike[str] | str | Any,
+    dst_crs: str | int | dict[str, Any],
+    *,
+    resampling: str | None = None,
+    resolution: float | tuple[float, float] | tuple[int, int] | dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return metadata for a virtual destination grid without materializing pixels."""
+    return _require_native().warped_vrt_info(
+        _path_or_self(source),
+        dst_crs,
+        resampling=resampling,
+        resolution=resolution,
+    )
+
+
 def read_raster_window(
     path: os.PathLike[str] | str,
     bounds_or_window: tuple[float, float, float, float] | tuple[int, int, int, int] | dict[str, Any],
@@ -787,8 +811,13 @@ def query_osm_features(
     aoi: tuple[float, float, float, float],
     tags: dict[str, Any],
     cache: dict[str, Any] | None = None,
+    *,
+    endpoint: str | None = None,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
-    return _require_native().query_osm_features(aoi, tags, cache=cache)
+    return _require_native().query_osm_features(
+        aoi, tags, cache=cache, endpoint=endpoint, timeout=timeout
+    )
 
 
 def parse_osm_features(osm_json: dict[str, Any] | str, tags: dict[str, Any] | None = None) -> dict[str, Any]:
@@ -806,8 +835,13 @@ def prepare_osm_scene(
     aoi: tuple[float, float, float, float],
     tags: dict[str, Any] | None = None,
     cache: dict[str, Any] | None = None,
+    *,
+    endpoint: str | None = None,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
-    return _require_native().prepare_osm_scene(aoi, tags=tags, cache=cache)
+    return _require_native().prepare_osm_scene(
+        aoi, tags=tags, cache=cache, endpoint=endpoint, timeout=timeout
+    )
 
 
 def prepare_dem(
@@ -849,8 +883,17 @@ def build_terrarium_dem(
     bounds: tuple[float, float, float, float],
     zoom: int,
     cache: os.PathLike[str] | str | dict[str, Any] | None = None,
+    *,
+    url_template: str | None = None,
+    timeout: float | None = None,
 ) -> dict[str, Any]:
-    return _require_native().build_terrarium_dem(bounds, zoom, cache=_cache_or_none(cache))
+    return _require_native().build_terrarium_dem(
+        bounds,
+        zoom,
+        cache=_cache_or_none(cache),
+        url_template=url_template,
+        timeout=timeout,
+    )
 
 
 def prepare_landcover_raster(
@@ -968,6 +1011,7 @@ __all__ = [
     "align_raster_to",
     "reproject_raster",
     "calculate_default_transform",
+    "warped_vrt_info",
     "window_from_bounds",
     "read_raster_window",
     "window_transform",

--- a/python/forge3d/gis.pyi
+++ b/python/forge3d/gis.pyi
@@ -286,6 +286,8 @@ def load_boundary(
     *,
     layer: str | None = ...,
     where: str | None = ...,
+    union: bool = ...,
+    dst_crs: str | int | dict[str, Any] | None = ...,
 ) -> dict[str, Any]: ...
 
 
@@ -295,9 +297,11 @@ def rasterize_vectors(
     *,
     value: float = ...,
     attribute: str | None = ...,
+    burn_values: float | list[float] | tuple[float, ...] | None = ...,
     dtype: str = ...,
     fill: float = ...,
     all_touched: bool = ...,
+    merge_alg: str = ...,
 ) -> dict[str, Any]: ...
 
 
@@ -526,6 +530,15 @@ def calculate_default_transform(
 ) -> dict[str, Any]: ...
 
 
+def warped_vrt_info(
+    source: os.PathLike[str] | str | RasterInfo,
+    dst_crs: str | int | dict[str, Any],
+    *,
+    resampling: str | None = ...,
+    resolution: float | tuple[float, float] | tuple[int, int] | dict[str, Any] | None = ...,
+) -> dict[str, Any]: ...
+
+
 def window_from_bounds(
     info_or_path: os.PathLike[str] | str | RasterInfo,
     bounds: tuple[float, float, float, float] | dict[str, Any],
@@ -591,6 +604,9 @@ def query_osm_features(
     aoi: tuple[float, float, float, float],
     tags: dict[str, Any],
     cache: dict[str, Any] | None = ...,
+    *,
+    endpoint: str | None = ...,
+    timeout: float | None = ...,
 ) -> dict[str, Any]: ...
 
 
@@ -610,6 +626,9 @@ def prepare_osm_scene(
     aoi: tuple[float, float, float, float],
     tags: dict[str, Any] | None = ...,
     cache: dict[str, Any] | None = ...,
+    *,
+    endpoint: str | None = ...,
+    timeout: float | None = ...,
 ) -> dict[str, Any]: ...
 
 
@@ -646,6 +665,9 @@ def build_terrarium_dem(
     bounds: tuple[float, float, float, float],
     zoom: int,
     cache: os.PathLike[str] | str | dict[str, Any] | None = ...,
+    *,
+    url_template: str | None = ...,
+    timeout: float | None = ...,
 ) -> dict[str, Any]: ...
 
 

--- a/src/gis/affine.rs
+++ b/src/gis/affine.rs
@@ -227,6 +227,25 @@ pub fn translated_transform(
     ])
 }
 
+/// Reject a source transform whose linear part is singular (det ~ 0) up front.
+///
+/// A singular transform cannot be inverted, so a resample/align that mapped
+/// destination pixels back through it would silently fill EVERY pixel with
+/// nodata and report success. Callers that resample without a per-pixel
+/// raise/nodata policy (e.g. `align_raster_to`) preflight this so the failure
+/// is an explicit `InvalidTransform`, never a silent all-nodata output.
+pub fn require_invertible(transform: AffineTransform) -> GisResult<()> {
+    let det = transform.a * transform.e - transform.b * transform.d;
+    if !det.is_finite() || det.abs() <= f64::EPSILON {
+        return Err(GisError::InvalidTransform(
+            "invalid_transform: source transform is singular (non-invertible); \
+             its linear part has a zero determinant"
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 pub fn inverse_apply(transform: AffineTransform, x: f64, y: f64) -> GisResult<(f64, f64)> {
     let det = transform.a * transform.e - transform.b * transform.d;
     if !det.is_finite() || det.abs() <= f64::EPSILON {

--- a/src/gis/domain.rs
+++ b/src/gis/domain.rs
@@ -95,6 +95,7 @@ mod py {
         // reason); request-validation and fatal decode errors propagate WITHOUT
         // any download.
         let range_fallback_reason = match try_range_stream(py, &path_or_url, pixel_window)? {
+            #[cfg(feature = "cog_streaming")]
             RangeStep::Streamed(result) => return Ok(result),
             RangeStep::FullFetch(reason) => reason,
         };
@@ -153,6 +154,7 @@ mod py {
     /// result to return immediately, or a signal to do the full fetch (carrying the
     /// fallback reason when a range attempt actually failed).
     enum RangeStep {
+        #[cfg(feature = "cog_streaming")]
         Streamed(PyObject),
         FullFetch(Option<&'static str>),
     }
@@ -283,15 +285,15 @@ mod py {
         path_or_features: &Bound<'_, PyAny>,
         dst_crs: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<PyObject> {
-        if dst_crs.is_some() {
-            return Err(GisError::BackendUnavailable(
-                "backend_unavailable: proj feature required for building footprint reprojection"
-                    .to_string(),
-            )
-            .into());
-        }
+        let dst_crs = crate::gis::extract_crs(dst_crs)?;
         let value = input_geojson_or_cityjson(path_or_features)?;
-        let features = if value.get("type").and_then(Value::as_str) == Some("CityJSON") {
+        let is_cityjson = value.get("type").and_then(Value::as_str) == Some("CityJSON");
+        let source_crs = if is_cityjson {
+            None
+        } else {
+            crate::gis::vector::geojson_crs(&value)?
+        };
+        let mut features = if is_cityjson {
             cityjson_building_features(&value)?
         } else {
             crate::gis::vector::normalize_features(&value)?
@@ -305,6 +307,21 @@ mod py {
             )
             .into());
         }
+        let output_crs = if let Some(dst_crs) = dst_crs {
+            let result = crate::gis::vector::reproject_vector(
+                crate::gis::vector::VectorReprojectInput::Features {
+                    features,
+                    info: None,
+                    geojson_crs: source_crs,
+                },
+                dst_crs,
+                None,
+            )?;
+            features = result.features;
+            Some(result.dst_crs)
+        } else {
+            source_crs
+        };
         let collection = feature_collection(features);
         let bounds = bounds_for_features(collection.get("features").unwrap().as_array().unwrap());
         let dict = PyDict::new_bound(py);
@@ -317,7 +334,19 @@ mod py {
         dict.set_item("bounds", bounds.map(RasterBounds::tuple))?;
         dict.set_item(
             "crs",
-            json_to_py(py, &json!({"name": "EPSG", "code": "4326"}))?,
+            json_to_py(
+                py,
+                &output_crs
+                    .as_ref()
+                    .map(|crs| {
+                        json!({
+                            "source_kind": "vector",
+                            "wkt": crs.wkt.clone(),
+                            "authority": crate::gis::crs::authority_map(crs),
+                        })
+                    })
+                    .unwrap_or(Value::Null),
+            )?,
         )?;
         dict.set_item(
             "operation",
@@ -813,19 +842,22 @@ mod py {
         Ok(dict.into_py(py))
     }
 
-    #[pyfunction(name = "prepare_osm_scene", signature = (aoi, tags = None, cache = None))]
+    #[pyfunction(name = "prepare_osm_scene", signature = (aoi, tags = None, cache = None, *, endpoint = None, timeout = None))]
     pub fn prepare_osm_scene_py(
         py: Python<'_>,
         aoi: (f64, f64, f64, f64),
         tags: Option<&Bound<'_, PyAny>>,
         cache: Option<&Bound<'_, PyAny>>,
+        endpoint: Option<String>,
+        timeout: Option<f64>,
     ) -> PyResult<PyObject> {
         let aoi = validate_bounds_tuple(aoi, true)?;
         let tags = tags.map(py_to_json).transpose()?.unwrap_or_else(|| {
             json!({"highway": true, "building": true, "natural": "water", "waterway": true, "landuse": true})
         });
         let cache = cache.map(py_to_json).transpose()?;
-        let query = query_osm_features_value(aoi, &tags, cache.as_ref())?;
+        let query =
+            query_osm_features_value(aoi, &tags, cache.as_ref(), endpoint.as_deref(), timeout)?;
         let osm_json = query.get("osm_json").ok_or_else(|| {
             GisError::InvalidArgument(
                 "malformed_payload: query_osm_features returned no osm_json".to_string(),

--- a/src/gis/geometry.rs
+++ b/src/gis/geometry.rs
@@ -45,6 +45,27 @@ pub(crate) struct PolygonalClipMask {
     geometry: Geometry,
 }
 
+/// Canonical ±180 contract: EVERY geographic output is split at the
+/// antimeridian with longitudes wrapped into [-180, 180] — including outputs
+/// from same-sheet inputs (e.g. 175..185) that never needed unwrapping.
+/// Planar outputs pass through untouched.
+fn canonical_output(geometry: Geometry, geographic: bool) -> Geometry {
+    if geographic {
+        antimeridian::split_at_antimeridian(&geometry)
+    } else {
+        geometry
+    }
+}
+
+/// Point-output companion of `canonical_output`: geographic longitudes are
+/// wrapped into (-180, 180].
+fn canonical_point(mut point: Coord, geographic: bool) -> Coord {
+    if geographic {
+        point.x = math::wrap_lon(point.x);
+    }
+    point
+}
+
 pub fn validate_geometry(source: &Value) -> GisResult<Value> {
     Ok(validate_geometry_value(source))
 }
@@ -146,13 +167,10 @@ pub fn representative_point(source: &Value, crs: Option<CrsSpec>) -> GisResult<V
         .ok_or_else(model::empty_geometry_error)?;
     let geographic = resolve_geographic(&input, crs.as_ref())?;
     let (geometries, _) = dateline_normalized(core::slice::from_ref(geometry), geographic);
-    let mut point = representative_for_geometry(&geometries[0], geographic)?;
-    if geographic {
-        // Canonical output contract: geographic longitudes always land in
-        // (-180, 180], even when the input was authored on one continuous
-        // sheet (e.g. 175..185) and never needed unwrapping.
-        point.x = math::wrap_lon(point.x);
-    }
+    let point = canonical_point(
+        representative_for_geometry(&geometries[0], geographic)?,
+        geographic,
+    );
     let operation = operation_value(
         "representative_point",
         &input.input_geometry_type,
@@ -201,11 +219,7 @@ pub fn interpolate_line(
         )));
     }
     let target = normalized_target_distance(distance, normalized, total)?;
-    let mut point = interpolate_lines(&lines, target, geographic)?;
-    if geographic {
-        // Canonical output contract: see `representative_point`.
-        point.x = math::wrap_lon(point.x);
-    }
+    let point = canonical_point(interpolate_lines(&lines, target, geographic)?, geographic);
     let operation = operation_value(
         "interpolate_line",
         &input.input_geometry_type,
@@ -249,13 +263,7 @@ pub fn union_geometries(source: &Value, crs: Option<CrsSpec>) -> GisResult<Value
     validate_input_or_error(&input)?;
     let geographic = resolve_geographic(&input, crs.as_ref())?;
     let (geometries, _) = dateline_normalized(&input.geometries, geographic);
-    let mut geometry = union_polygonal(&geometries)?;
-    if geographic {
-        // Canonical ±180 contract: EVERY geographic output is split at the
-        // antimeridian with longitudes wrapped into (-180, 180], including
-        // same-sheet inputs (175..185) that never needed unwrapping.
-        geometry = antimeridian::split_at_antimeridian(&geometry);
-    }
+    let geometry = canonical_output(union_polygonal(&geometries)?, geographic);
     let output_geometry_type = geometry.geometry_type();
     let type_changed = output_geometry_type != input.input_geometry_type;
     let warnings = if type_changed {
@@ -317,20 +325,16 @@ pub fn buffer_geometry(
     // topology output.
     if distance == 0.0 && matches!(geometry, Geometry::Polygon(_) | Geometry::MultiPolygon(_)) {
         let (mut geometries, _) = dateline_normalized(core::slice::from_ref(geometry), geographic);
-        let mut output = geometries.remove(0);
-        if geographic {
-            // Canonical ±180 contract (see `union_geometries`).
-            output = antimeridian::split_at_antimeridian(&output);
-        }
+        let output = canonical_output(geometries.remove(0), geographic);
         let changed = &output != geometry;
         return buffer_geometry_output(&input, output, changed);
     }
 
     let (geometries, _) = dateline_normalized(core::slice::from_ref(geometry), geographic);
-    let mut output = buffer_topology(&geometries[0], distance, quad_segs as usize)?;
-    if geographic {
-        output = antimeridian::split_at_antimeridian(&output);
-    }
+    let output = canonical_output(
+        buffer_topology(&geometries[0], distance, quad_segs as usize)?,
+        geographic,
+    );
     buffer_geometry_output(&input, output, true)
 }
 
@@ -354,11 +358,10 @@ pub fn simplify_geometry(
         .ok_or_else(model::empty_geometry_error)?;
     let geographic = resolve_geographic(&input, crs.as_ref())?;
     let (geometries, _) = dateline_normalized(core::slice::from_ref(geometry), geographic);
-    let mut output = simplify_topology(&geometries[0], tolerance, preserve_topology)?;
-    if geographic {
-        // Canonical ±180 contract (see `union_geometries`).
-        output = antimeridian::split_at_antimeridian(&output);
-    }
+    let output = canonical_output(
+        simplify_topology(&geometries[0], tolerance, preserve_topology)?,
+        geographic,
+    );
     simplify_geometry_output(&input, output, &input.crs)
 }
 
@@ -436,11 +439,7 @@ pub(crate) fn union_polygonal_geometry_values(
         geometries.push(geometry.clone());
     }
     let (geometries, _) = dateline_normalized(&geometries, geographic);
-    let mut output = union_polygonal(&geometries)?;
-    if geographic {
-        // Canonical ±180 contract (see `union_geometries`).
-        output = antimeridian::split_at_antimeridian(&output);
-    }
+    let output = canonical_output(union_polygonal(&geometries)?, geographic);
     if output.is_empty() {
         Ok(None)
     } else {
@@ -491,13 +490,13 @@ fn intersect_polygonal_geometry_values_for_operation(
             math::align_parts_to_sheet(&mut both[1], reference);
         }
     }
-    let mut output = intersection_polygonal(&both[0], &both[1], operation)?;
-    if geographic {
-        // Canonical ±180 contract: split unconditionally — two operands on
-        // the SAME non-canonical sheet (both 175..185) need neither unwrap
-        // nor sheet alignment, yet their result still crosses ±180.
-        output = antimeridian::split_at_antimeridian(&output);
-    }
+    // Canonicalize unconditionally — two operands on the SAME non-canonical
+    // sheet (both 175..185) need neither unwrap nor sheet alignment, yet
+    // their result still crosses ±180.
+    let output = canonical_output(
+        intersection_polygonal(&both[0], &both[1], operation)?,
+        geographic,
+    );
     if output.is_empty() {
         Ok(None)
     } else {

--- a/src/gis/geometry/antimeridian.rs
+++ b/src/gis/geometry/antimeridian.rs
@@ -80,6 +80,14 @@ fn split_line(pts: &[Coord]) -> Vec<Vec<Coord>> {
         }
     }
     segments.push(cur);
+    // A line TOUCHING ±180 at a vertex is not a crossing, but the per-vertex
+    // wrap flips an exact -180 endpoint to +180 and the cut then lands at
+    // t = 0 or 1, leaving a zero-length piece. Drop such degenerate pieces so
+    // the touching line comes back whole.
+    segments.retain(|seg| seg.len() >= 2 && seg.windows(2).any(|w| w[0] != w[1]));
+    if segments.is_empty() {
+        return vec![wrap_all(pts)];
+    }
     segments
 }
 
@@ -176,6 +184,21 @@ fn normalize_piece(ring: Vec<Coord>) -> Vec<Coord> {
         .collect()
 }
 
+/// Coherent single-polygon fallback for a ring that wrapped edges flagged as
+/// "crossing" but that straddles no antimeridian copy: each ring is unwrapped
+/// onto its own continuous sheet, then shifted by a whole 360° multiple into
+/// [-180, 180]. The naive per-vertex wrap would flip an exact -180 boundary
+/// vertex to +180 and fabricate a world-spanning edge — a [-180, -175] ring
+/// touches the antimeridian but does not cross it.
+fn coherent_polygon(rings: &[Vec<Coord>]) -> Geometry {
+    Geometry::Polygon(
+        rings
+            .iter()
+            .map(|ring| normalize_piece(unwrap_ring(ring)))
+            .collect(),
+    )
+}
+
 #[cfg(test)]
 fn signed_area(ring: &[Coord]) -> f64 {
     let mut s = 0.0;
@@ -204,7 +227,8 @@ fn split_polygon(rings: &[Vec<Coord>]) -> Geometry {
     let k = ((minx - 180.0) / 360.0).floor() as i64 + 1;
     let m = 180.0 + 360.0 * k as f64;
     if !(m > minx && m < maxx) {
-        return Geometry::Polygon(wrapped());
+        // Touches (or merely wraps incoherently at) ±180 without crossing.
+        return coherent_polygon(rings);
     }
     let west = clip_ring(&outer, m, true).map(normalize_piece);
     let east = clip_ring(&outer, m, false).map(normalize_piece);
@@ -216,7 +240,8 @@ fn split_polygon(rings: &[Vec<Coord>]) -> Geometry {
         sides.push((vec![e], 1.0)); // east sits above it
     }
     if sides.len() < 2 {
-        return Geometry::Polygon(wrapped());
+        // One side degenerated to a sliver on the meridian: not a real split.
+        return coherent_polygon(rings);
     }
     // Assign each hole to the side(s) it clips into, preserving hole winding.
     for hole in &rings[1..] {
@@ -382,6 +407,52 @@ mod tests {
         ];
         let g = split_at_antimeridian(&Geometry::Polygon(vec![ring.clone()]));
         assert_eq!(g, Geometry::Polygon(vec![ring]));
+    }
+
+    #[test]
+    fn polygon_touching_minus_180_is_identity() {
+        // A [-180, -175] ring TOUCHES the antimeridian without crossing it.
+        // The naive per-vertex wrap flipped the exact -180 vertices to +180
+        // and returned a ring with a 355° edge (the world-spanning
+        // complement); the coherent fallback must return it unchanged.
+        let ring = vec![
+            c(-180.0, 10.0),
+            c(-175.0, 10.0),
+            c(-175.0, -10.0),
+            c(-180.0, -10.0),
+            c(-180.0, 10.0),
+        ];
+        let g = split_at_antimeridian(&Geometry::Polygon(vec![ring.clone()]));
+        assert_eq!(g, Geometry::Polygon(vec![ring]));
+    }
+
+    #[test]
+    fn polygon_touching_plus_180_is_identity() {
+        let ring = vec![
+            c(175.0, 10.0),
+            c(180.0, 10.0),
+            c(180.0, -10.0),
+            c(175.0, -10.0),
+            c(175.0, 10.0),
+        ];
+        let g = split_at_antimeridian(&Geometry::Polygon(vec![ring.clone()]));
+        assert_eq!(g, Geometry::Polygon(vec![ring]));
+    }
+
+    #[test]
+    fn line_touching_minus_180_is_not_split() {
+        // Same boundary case for polylines: the cut would land at t = 0 and
+        // leave a zero-length piece; the line must come back whole.
+        let g = split_at_antimeridian(&Geometry::LineString(vec![c(-180.0, 0.0), c(-175.0, 1.0)]));
+        assert_eq!(
+            g,
+            Geometry::LineString(vec![c(-180.0, 0.0), c(-175.0, 1.0)])
+        );
+        let g = split_at_antimeridian(&Geometry::LineString(vec![c(-175.0, 1.0), c(-180.0, 0.0)]));
+        assert_eq!(
+            g,
+            Geometry::LineString(vec![c(-175.0, 1.0), c(-180.0, 0.0)])
+        );
     }
 
     #[test]

--- a/src/gis/geometry/crs_resolve.rs
+++ b/src/gis/geometry/crs_resolve.rs
@@ -12,12 +12,14 @@ use super::math::unwrap_dateline;
 use super::measure::MeasureMode;
 use super::model::{Geometry, NormalizedInput};
 
-/// Decide geographic vs planar handling from an explicit CRS. EPSG:4326 =>
-/// geographic; a known projected CRS (EPSG-coded or a custom projected-method
-/// definition) => planar; a non-WGS84 geographic CRS, a geocentric CRS, an
-/// unclassified code, or an unidentifiable CRS is a stable error (see
-/// `crs::epsg_crs_kind`).
-pub(crate) fn geographic_from_spec(spec: &CrsSpec) -> GisResult<bool> {
+/// Shared EPSG classification for the geometry surface. EPSG:4326 =>
+/// geodesic/geographic WGS84 handling; a known projected CRS (EPSG-coded or a
+/// custom projected-method definition) => planar; a non-WGS84 geographic CRS,
+/// a geocentric CRS, an unclassified code, or an unidentifiable CRS is a
+/// stable error naming `operation` (see `crs::epsg_crs_kind`). Treating a
+/// degree-axis CRS as planar would report degrees as metres, so only these
+/// two outcomes exist.
+fn classify_crs(spec: &CrsSpec, operation: &str) -> GisResult<MeasureMode> {
     use crate::gis::crs::EpsgCrsKind;
     // A custom projected-method CRS ({"method": "aea", ...} =>
     // CrsSpec::from_projection) is planar by construction: every supported
@@ -25,71 +27,46 @@ pub(crate) fn geographic_from_spec(spec: &CrsSpec) -> GisResult<bool> {
     // plane. It carries no EPSG authority, so it must be classified before
     // the EPSG-code requirement below.
     if spec.projection.is_some() {
-        return Ok(false);
+        return Ok(MeasureMode::Planar);
     }
     let Some(code) = crate::gis::crs::epsg_code(spec) else {
-        return Err(GisError::InvalidCrs(
-            "invalid_crs: geometry operation requires an EPSG-identified CRS to determine \
+        return Err(GisError::InvalidCrs(format!(
+            "invalid_crs: {operation} requires an EPSG-identified CRS to determine \
              geographic-versus-planar handling"
-                .to_string(),
-        ));
+        )));
     };
     match crate::gis::crs::epsg_crs_kind(code) {
-        EpsgCrsKind::GeographicWgs84 => Ok(true),
-        EpsgCrsKind::Projected => Ok(false),
-        // Treating a geographic CRS as planar would report degrees as metres,
-        // and only WGS84 is supported for geodesic/dateline handling.
+        EpsgCrsKind::GeographicWgs84 => Ok(MeasureMode::GeodesicWgs84),
+        EpsgCrsKind::Projected => Ok(MeasureMode::Planar),
         EpsgCrsKind::Geographic => Err(GisError::InvalidCrs(format!(
-            "invalid_crs: geographic CRS EPSG:{code} is not supported for geometry \
-             operations; only EPSG:4326 is handled geographically"
+            "invalid_crs: geographic CRS EPSG:{code} is not supported for {operation}; \
+             only EPSG:4326 is handled geographically (geodesic metres, dateline-aware)"
         ))),
         EpsgCrsKind::Geocentric => Err(GisError::InvalidCrs(format!(
             "invalid_crs: geocentric CRS EPSG:{code} has 3D Cartesian axes and is not \
-             supported for 2D geometry operations"
+             supported for {operation}"
         ))),
         EpsgCrsKind::Unclassified => Err(GisError::InvalidCrs(format!(
             "invalid_crs: EPSG:{code} is not in the built-in geographic/projected \
-             classification table; geometry operations support EPSG:4326 and the curated \
+             classification table; {operation} supports EPSG:4326 and the curated \
              projected CRSs"
         ))),
     }
+}
+
+/// Decide geographic vs planar handling from an explicit CRS.
+pub(crate) fn geographic_from_spec(spec: &CrsSpec) -> GisResult<bool> {
+    Ok(matches!(
+        classify_crs(spec, "geometry operations")?,
+        MeasureMode::GeodesicWgs84
+    ))
 }
 
 /// Resolve the measurement mode for a CRS. Geographic coordinates are only
 /// measured geodesically (metres / m²) and only for WGS84; any other
 /// geographic CRS raises rather than silently returning square degrees.
 pub fn measure_mode_for_crs(spec: &CrsSpec) -> GisResult<MeasureMode> {
-    use crate::gis::crs::EpsgCrsKind;
-    // Custom projected-method CRSs are planar by construction (see
-    // `geographic_from_spec`) and are measured in their Cartesian CRS units.
-    if spec.projection.is_some() {
-        return Ok(MeasureMode::Planar);
-    }
-    let Some(code) = crate::gis::crs::epsg_code(spec) else {
-        return Err(GisError::InvalidCrs(
-            "invalid_crs: geometry_measure requires an EPSG-identified CRS to determine \
-             measurement units"
-                .to_string(),
-        ));
-    };
-    match crate::gis::crs::epsg_crs_kind(code) {
-        EpsgCrsKind::GeographicWgs84 => Ok(MeasureMode::GeodesicWgs84),
-        EpsgCrsKind::Projected => Ok(MeasureMode::Planar),
-        // Planar math on a degree-axis CRS would report degrees as metres.
-        EpsgCrsKind::Geographic => Err(GisError::InvalidCrs(format!(
-            "invalid_crs: geometry_measure supports geodesic measurement only on EPSG:4326; \
-             geographic CRS EPSG:{code} would yield degree-based lengths/areas"
-        ))),
-        EpsgCrsKind::Geocentric => Err(GisError::InvalidCrs(format!(
-            "invalid_crs: geocentric CRS EPSG:{code} has 3D Cartesian axes and is not \
-             supported for 2D geometry measurement"
-        ))),
-        EpsgCrsKind::Unclassified => Err(GisError::InvalidCrs(format!(
-            "invalid_crs: EPSG:{code} is not in the built-in geographic/projected \
-             classification table; geometry_measure supports EPSG:4326 and the curated \
-             projected CRSs"
-        ))),
-    }
+    classify_crs(spec, "geometry_measure")
 }
 
 /// Parse the embedded (`info`-derived) CRS metadata carried on a geometry input

--- a/src/gis/geometry/tests/dateline.rs
+++ b/src/gis/geometry/tests/dateline.rs
@@ -127,6 +127,36 @@ fn same_sheet_union_splits_at_antimeridian() {
 
 #[cfg(feature = "geos-topology")]
 #[test]
+fn union_of_polygon_touching_minus_180_is_identity() {
+    // Unconditional canonicalization must not damage an already-canonical
+    // west-side polygon: [-180, -175] touches the antimeridian without
+    // crossing it and comes back as the same single Polygon, not as a ring
+    // with a world-spanning edge.
+    let coords = json!([[
+        [-180.0, 5.0],
+        [-175.0, 5.0],
+        [-175.0, -5.0],
+        [-180.0, -5.0],
+        [-180.0, 5.0]
+    ]]);
+    let geometries = json!([{ "type": "Polygon", "coordinates": coords }]);
+    let result = union_geometries(&geometries, wgs84()).expect("union succeeds");
+    assert_eq!(result["geometry"]["type"], json!("Polygon"), "got {result}");
+    let ring = result["geometry"]["coordinates"][0].as_array().unwrap();
+    let xs: Vec<f64> = ring.iter().map(|p| p[0].as_f64().unwrap()).collect();
+    assert!(
+        xs.iter().all(|x| (-180.0..=-175.0).contains(x)),
+        "identity west-side ring, got {xs:?}"
+    );
+    let max_edge = xs
+        .windows(2)
+        .map(|w| (w[1] - w[0]).abs())
+        .fold(0.0, f64::max);
+    assert!(max_edge <= 5.0 + 1e-9, "no world-spanning edge: {max_edge}");
+}
+
+#[cfg(feature = "geos-topology")]
+#[test]
 fn clip_across_dateline_keeps_both_pieces() {
     // MENSURA M-04 root-cause regression at the Rust boundary: a source
     // polygon 175 -> -175 clipped by a clip polygon 178 -> -178 (both crossing

--- a/src/gis/mod.rs
+++ b/src/gis/mod.rs
@@ -709,6 +709,70 @@ pub fn calculate_default_transform_py(
 }
 
 #[cfg(feature = "extension-module")]
+#[pyfunction(name = "warped_vrt_info", signature = (source, dst_crs, *, resampling = None, resolution = None))]
+pub fn warped_vrt_info_py(
+    py: Python<'_>,
+    source: &Bound<'_, PyAny>,
+    dst_crs: &Bound<'_, PyAny>,
+    resampling: Option<&str>,
+    resolution: Option<&Bound<'_, PyAny>>,
+) -> PyResult<PyObject> {
+    use pyo3::IntoPy;
+
+    let method = warp::ResamplingMethod::parse(resampling)?;
+    let (source_info, _) = extract_raster_info_source(source)?;
+    let src_crs = crate::gis::crs::require_crs(&source_info)?;
+    let dst_crs = extract_required_crs(Some(dst_crs))?;
+    let source_bounds = crate::gis::affine::raster_bounds(&source_info)?;
+    let dst_bounds = crate::gis::crs::transform_bounds(source_bounds, &src_crs, &dst_crs)?;
+    let (width, height) = if let Some(resolution) = resolution {
+        match extract_resample_target(resolution)? {
+            warp::ResampleTarget::Shape { height, width } => (width, height),
+            warp::ResampleTarget::Resolution { x, y } => (
+                ((dst_bounds.right - dst_bounds.left) / x).ceil().max(1.0) as u32,
+                ((dst_bounds.top - dst_bounds.bottom) / y).ceil().max(1.0) as u32,
+            ),
+        }
+    } else {
+        (source_info.width, source_info.height)
+    };
+    let transform = crate::gis::affine::transform_from_bounds(dst_bounds, width, height)?;
+    let mut info = RasterInfo::new(
+        source_info.path.clone().into(),
+        width,
+        height,
+        source_info.band_count,
+    );
+    info.driver = "VRT".to_string();
+    info.dtype_per_band = source_info.dtype_per_band.clone();
+    info.crs_wkt = dst_crs.wkt.clone();
+    info.crs_authority = crate::gis::crs::authority_map(&dst_crs);
+    info.transform = Some(transform.tuple());
+    info.bounds = Some(dst_bounds.tuple());
+    info.resolution = Some(transform.resolution());
+    info.nodata_per_band = source_info.nodata_per_band.clone();
+    info.height_system = source_info.height_system.clone();
+    info.is_georeferenced = true;
+
+    let dict = PyDict::new_bound(py);
+    dict.set_item("info", raster_info_to_py_dict(py, &info)?)?;
+    dict.set_item("driver", "VRT")?;
+    dict.set_item("is_virtual", true)?;
+    dict.set_item("materialized", false)?;
+    dict.set_item("resampling", method.name())?;
+    dict.set_item(
+        "src_crs",
+        crs_inspection_to_py(py, &crate::gis::crs::inspect_crs_spec(&src_crs, "crs"))?,
+    )?;
+    dict.set_item(
+        "dst_crs",
+        crs_inspection_to_py(py, &crate::gis::crs::inspect_crs_spec(&dst_crs, "crs"))?,
+    )?;
+    dict.set_item("warnings", warnings_to_py(py, &[])?)?;
+    Ok(dict.into_py(py))
+}
+
+#[cfg(feature = "extension-module")]
 #[pyfunction(name = "read_raster_window", signature = (path, bounds_or_window, *, boundless = false, masked = false))]
 pub fn read_raster_window_py(
     py: Python<'_>,

--- a/src/gis/osm.rs
+++ b/src/gis/osm.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::path::PathBuf;
 
 use serde_json::{json, Map, Value};
 
@@ -136,6 +137,8 @@ pub fn query_osm_features_value(
     aoi: RasterBounds,
     tags: &Value,
     cache: Option<&Value>,
+    endpoint: Option<&str>,
+    timeout: Option<f64>,
 ) -> GisResult<Value> {
     let query = overpass_query(aoi, tags)?;
     if let Some(payload) = cache.and_then(|cache| cache.get("osm_json")) {
@@ -157,9 +160,57 @@ pub fn query_osm_features_value(
         out.insert("warnings".to_string(), Value::Array(Vec::new()));
         return Ok(Value::Object(out));
     }
-    Err(GisError::BackendUnavailable(
-        "backend_unavailable: explicit Overpass endpoint or cache payload required; no hidden default downloads".to_string(),
-    ))
+    let endpoint = endpoint
+        .or_else(|| cache.and_then(|cache| cache.get("endpoint")).and_then(Value::as_str))
+        .ok_or_else(|| {
+            GisError::BackendUnavailable(
+                "backend_unavailable: explicit Overpass endpoint or cache payload required; no hidden default downloads".to_string(),
+            )
+        })?;
+    crate::gis::remote::ensure_remote_url(endpoint)?;
+    let separator = if endpoint.contains('?') { '&' } else { '?' };
+    let url = format!("{endpoint}{separator}data={}", percent_encode_query(&query));
+    let cache_dir = cache
+        .and_then(|cache| cache.get("cache_dir"))
+        .and_then(Value::as_str)
+        .map(PathBuf::from);
+    let (bytes, remote) =
+        crate::gis::remote::fetch_remote_geodata_payload(&url, cache_dir.as_deref(), timeout)?;
+    let osm_json = serde_json::from_slice::<Value>(&bytes).map_err(|err| {
+        GisError::InvalidArgument(format!("malformed_payload: invalid OSM JSON: {err}"))
+    })?;
+    if osm_json.get("elements").and_then(Value::as_array).is_none() {
+        return Err(GisError::InvalidArgument(
+            "malformed_payload: Overpass response must include an elements array".to_string(),
+        ));
+    }
+    Ok(json!({
+        "osm_json": osm_json,
+        "query": query,
+        "bounds": aoi.tuple(),
+        "remote": {
+            "url": remote.url,
+            "status": remote.status,
+            "from_cache": remote.from_cache,
+            "cache_path": remote.cache_path,
+            "byte_size": remote.byte_size,
+            "checksum": remote.checksum,
+        },
+        "warnings": warnings_to_json(&remote.warnings),
+    }))
+}
+
+fn percent_encode_query(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for byte in value.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                out.push(byte as char)
+            }
+            _ => out.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    out
 }
 
 fn overpass_query(aoi: RasterBounds, tags: &Value) -> GisResult<String> {
@@ -328,12 +379,14 @@ mod py {
         json_to_py(py, &result)
     }
 
-    #[pyfunction(name = "query_osm_features", signature = (aoi, tags, cache = None))]
+    #[pyfunction(name = "query_osm_features", signature = (aoi, tags, cache = None, *, endpoint = None, timeout = None))]
     pub fn query_osm_features_py(
         py: Python<'_>,
         aoi: (f64, f64, f64, f64),
         tags: &Bound<'_, PyAny>,
         cache: Option<&Bound<'_, PyAny>>,
+        endpoint: Option<String>,
+        timeout: Option<f64>,
     ) -> PyResult<PyObject> {
         let aoi = validate_bounds_tuple(aoi, true)?;
         let tags = py_to_json(tags)?;
@@ -358,7 +411,9 @@ mod py {
             })
             .transpose()?
             .flatten();
-        let result = query_osm_features_value(aoi, &tags, cache.as_ref())?;
+        let result = py.allow_threads(|| {
+            query_osm_features_value(aoi, &tags, cache.as_ref(), endpoint.as_deref(), timeout)
+        })?;
         json_to_py(py, &result)
     }
 }

--- a/src/gis/raster_info.rs
+++ b/src/gis/raster_info.rs
@@ -27,6 +27,7 @@ pub(crate) use crate::gis::raster_read::read_raster_data;
 pub(crate) use crate::gis::raster_values::{
     copy_window, f64_to_raster_data, raster_to_f64, valid_mask,
 };
+#[cfg(feature = "cog_streaming")]
 pub(crate) use crate::gis::raster_window::read_window_from_decoder;
 
 #[derive(Debug, Clone)]
@@ -159,14 +160,11 @@ pub(crate) fn raster_info_from_decoder<R: std::io::Read + std::io::Seek>(
         ));
     }
 
-    // A valid affine transform without CRS is still a usable, unlabeled
-    // Cartesian world transform. CRS presence describes authority metadata;
-    // it is not required for coordinate anchoring.
-    info.is_georeferenced = info.transform.is_some();
+    info.is_georeferenced = has_crs && info.transform.is_some();
     if !info.is_georeferenced {
         info.warnings.push(RasterWarning::new(
             WARNING_NOT_GEOREFERENCED,
-            "raster has no valid affine transform",
+            "raster is not fully georeferenced",
             None,
         ));
     }
@@ -517,6 +515,47 @@ mod tests {
             RasterData::U8(values) => assert_eq!(values, vec![99, 12, 14, 99]),
             other => panic!("unexpected dtype: {:?}", other),
         }
+
+        let _ = fs::remove_file(path);
+    }
+
+    #[test]
+    fn read_raster_info_preserves_projected_epsg_outside_legacy_three_code_subset() {
+        let path = temp_tif("epsg_2154_metadata");
+        let array = RasterArray::new(RasterData::U8(vec![1, 2, 3, 4]), &[1, 2, 2])
+            .expect("test raster shape");
+        write_raster(
+            &path,
+            array,
+            WriteRasterOptions {
+                crs: Some(CrsSpec::from_string("EPSG:2154".to_string()).expect("valid crs")),
+                transform: Some(
+                    AffineTransform::new([2.0, 0.0, 700_000.0, 0.0, -2.0, 6_600_000.0])
+                        .expect("valid transform"),
+                ),
+                nodata: vec![None],
+                driver: "GTiff".to_string(),
+                overwrite: true,
+                creation_options: CreationOptions::default(),
+                creation_options_explicit: false,
+                like_info: None,
+                height_system: crate::gis::types::HEIGHT_SYSTEM_UNSPECIFIED.to_string(),
+            },
+        )
+        .expect("write metadata fixture");
+
+        let info = read_raster_info(&path).expect("read arbitrary authority metadata");
+        assert_eq!(
+            info.crs_authority,
+            Some(std::collections::HashMap::from([
+                ("name".to_string(), "EPSG".to_string()),
+                ("code".to_string(), "2154".to_string()),
+            ]))
+        );
+        assert!(
+            info.crs_wkt.is_none(),
+            "metadata reader must not synthesize WKT"
+        );
 
         let _ = fs::remove_file(path);
     }

--- a/src/gis/rasterize.rs
+++ b/src/gis/rasterize.rs
@@ -25,9 +25,36 @@ const INVALID_NODATA: &str = "invalid_nodata";
 pub struct RasterizeOptions {
     pub value: f64,
     pub attribute: Option<String>,
+    pub burn_values: Option<Vec<f64>>,
+    pub merge_alg: MergeAlgorithm,
     pub dtype: RasterDType,
     pub fill: f64,
     pub all_touched: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MergeAlgorithm {
+    Replace,
+    Add,
+}
+
+impl MergeAlgorithm {
+    pub fn parse(value: &str) -> GisResult<Self> {
+        match value {
+            "replace" => Ok(Self::Replace),
+            "add" => Ok(Self::Add),
+            _ => Err(GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: merge_alg must be 'replace' or 'add'"
+            ))),
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Replace => "replace",
+            Self::Add => "add",
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -41,6 +68,7 @@ pub struct RasterizeResult {
     pub fill: f64,
     pub burned_pixels: usize,
     pub all_touched: bool,
+    pub merge_alg: MergeAlgorithm,
     pub warnings: Vec<RasterWarning>,
 }
 
@@ -187,9 +215,33 @@ pub fn rasterize_vectors(
 ) -> GisResult<RasterizeResult> {
     validate_value_for_dtype(options.dtype, options.fill, "fill")?;
     validate_value_for_dtype(options.dtype, options.value, "value")?;
+    if options.attribute.is_some() && options.burn_values.is_some() {
+        return Err(GisError::InvalidArgument(format!(
+            "{INVALID_ARGUMENT}: attribute and burn_values are mutually exclusive"
+        )));
+    }
+    if let Some(values) = options.burn_values.as_ref() {
+        if values.is_empty() {
+            return Err(GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: burn_values must not be empty"
+            )));
+        }
+        for &value in values {
+            validate_value_for_dtype(options.dtype, value, "burn_values")?;
+        }
+    }
     let grid = target_grid(target_info)?;
     let source = resolve_vector_source(source)?;
     require_same_crs(&source.crs, &grid.crs)?;
+    if let Some(values) = options.burn_values.as_ref() {
+        if values.len() != 1 && values.len() != source.features.len() {
+            return Err(GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: burn_values length {} must be 1 or match feature count {}",
+                values.len(),
+                source.features.len()
+            )));
+        }
+    }
     let (values, burned_pixels) = rasterize_source(&source, &grid, &options)?;
     let info = output_info(&grid.info, options.dtype, grid.info.nodata_per_band.clone())?;
     Ok(RasterizeResult {
@@ -202,6 +254,7 @@ pub fn rasterize_vectors(
         fill: options.fill,
         burned_pixels,
         all_touched: options.all_touched,
+        merge_alg: options.merge_alg,
         warnings: Vec::new(),
     })
 }
@@ -395,22 +448,35 @@ fn rasterize_source(
     let height = grid.info.height as usize;
     let mut values = vec![options.fill; width * height];
     let mut burned = vec![false; width * height];
-    for feature in &source.features {
+    for (feature_index, feature) in source.features.iter().enumerate() {
         let geometry = vector::feature_geometry(feature)?;
-        let burn = burn_value(feature, options)?;
+        let burn = burn_value(feature, feature_index, options)?;
         let polygons = parse_polygonal_geometry(geometry)?;
         if polygons.is_empty() {
             return Err(GisError::InvalidGeometry(format!(
                 "{EMPTY_GEOMETRY}: geometry is empty"
             )));
         }
-        for row in 0..height {
-            for col in 0..width {
+        let (row_start, row_end, col_start, col_end) = geometry_pixel_window(
+            &polygons,
+            grid.transform,
+            height,
+            width,
+            options.all_touched,
+        )
+        .unwrap_or((0, height, 0, width));
+        for row in row_start..row_end {
+            for col in col_start..col_end {
                 if polygons.iter().any(|polygon| {
                     pixel_hits_polygon(polygon, grid.transform, row, col, options.all_touched)
                 }) {
                     let index = row * width + col;
-                    values[index] = burn;
+                    let merged = match options.merge_alg {
+                        MergeAlgorithm::Replace => burn,
+                        MergeAlgorithm::Add => values[index] + burn,
+                    };
+                    validate_value_for_dtype(options.dtype, merged, "merged burn value")?;
+                    values[index] = merged;
                     burned[index] = true;
                 }
             }
@@ -427,6 +493,8 @@ fn rasterize_bool(
     let options = RasterizeOptions {
         value: 1.0,
         attribute: None,
+        burn_values: None,
+        merge_alg: MergeAlgorithm::Replace,
         dtype: RasterDType::UInt8,
         fill: 0.0,
         all_touched,
@@ -439,7 +507,14 @@ fn rasterize_bool(
     })
 }
 
-fn burn_value(feature: &Value, options: &RasterizeOptions) -> GisResult<f64> {
+fn burn_value(feature: &Value, feature_index: usize, options: &RasterizeOptions) -> GisResult<f64> {
+    if let Some(values) = options.burn_values.as_ref() {
+        return Ok(if values.len() == 1 {
+            values[0]
+        } else {
+            values[feature_index]
+        });
+    }
     let Some(attribute) = options.attribute.as_deref() else {
         return Ok(options.value);
     };
@@ -455,6 +530,46 @@ fn burn_value(feature: &Value, options: &RasterizeOptions) -> GisResult<f64> {
         })?;
     validate_value_for_dtype(options.dtype, value, attribute)?;
     Ok(value)
+}
+
+/// Return a conservative, clamped pixel window for a geometry.
+///
+/// Transforming the vertices into pixel space is valid for north-up and
+/// rotated/sheared affine grids. A one-cell guard keeps boundary and
+/// `all_touched` semantics exact while avoiding the previous full-grid scan for
+/// every feature. Singular transforms fall back to the caller's full-grid path.
+fn geometry_pixel_window(
+    polygons: &[Polygon],
+    transform: AffineTransform,
+    height: usize,
+    width: usize,
+    all_touched: bool,
+) -> Option<(usize, usize, usize, usize)> {
+    let mut min_col = f64::INFINITY;
+    let mut min_row = f64::INFINITY;
+    let mut max_col = f64::NEG_INFINITY;
+    let mut max_row = f64::NEG_INFINITY;
+    for point in polygons
+        .iter()
+        .flat_map(|polygon| polygon.iter())
+        .flat_map(|ring| ring.iter())
+    {
+        let (col, row) = affine::inverse_apply(transform, point.x, point.y).ok()?;
+        min_col = min_col.min(col);
+        min_row = min_row.min(row);
+        max_col = max_col.max(col);
+        max_row = max_row.max(row);
+    }
+    if !min_col.is_finite() || !min_row.is_finite() || !max_col.is_finite() || !max_row.is_finite()
+    {
+        return None;
+    }
+    let guard = if all_touched { 1.0 } else { 0.5 };
+    let col_start = ((min_col - guard).floor() as isize).clamp(0, width as isize) as usize;
+    let row_start = ((min_row - guard).floor() as isize).clamp(0, height as isize) as usize;
+    let col_end = ((max_col + guard).ceil() as isize).clamp(0, width as isize) as usize;
+    let row_end = ((max_row + guard).ceil() as isize).clamp(0, height as isize) as usize;
+    Some((row_start, row_end, col_start, col_end))
 }
 
 fn parse_polygonal_geometry(value: &Value) -> GisResult<Vec<Polygon>> {
@@ -896,7 +1011,7 @@ mod py {
 
     #[pyfunction(
         name = "rasterize_vectors",
-        signature = (vectors, target_info, *, value = 1.0, attribute = None, dtype = "uint8", fill = 0.0, all_touched = false)
+        signature = (vectors, target_info, *, value = 1.0, attribute = None, burn_values = None, dtype = "uint8", fill = 0.0, all_touched = false, merge_alg = "replace")
     )]
     pub fn rasterize_vectors_py(
         py: Python<'_>,
@@ -904,9 +1019,11 @@ mod py {
         target_info: &Bound<'_, PyAny>,
         value: f64,
         attribute: Option<String>,
+        burn_values: Option<&Bound<'_, PyAny>>,
         dtype: &str,
         fill: f64,
         all_touched: bool,
+        merge_alg: &str,
     ) -> PyResult<PyObject> {
         let source = vector_source_to_json(vectors)?;
         let target_info = raster_info_from_py(target_info)?;
@@ -916,12 +1033,32 @@ mod py {
             RasterizeOptions {
                 value,
                 attribute,
+                burn_values: parse_burn_values(burn_values)?,
+                merge_alg: MergeAlgorithm::parse(merge_alg)?,
                 dtype: parse_raster_dtype(dtype)?,
                 fill,
                 all_touched,
             },
         )?;
         rasterize_result_to_py(py, &result)
+    }
+
+    fn parse_burn_values(value: Option<&Bound<'_, PyAny>>) -> PyResult<Option<Vec<f64>>> {
+        let Some(value) = value else {
+            return Ok(None);
+        };
+        if value.is_none() {
+            return Ok(None);
+        }
+        if let Ok(single) = value.extract::<f64>() {
+            return Ok(Some(vec![single]));
+        }
+        value.extract::<Vec<f64>>().map(Some).map_err(|_| {
+            GisError::InvalidArgument(format!(
+                "{INVALID_ARGUMENT}: burn_values must be a number or numeric sequence"
+            ))
+            .into()
+        })
     }
 
     #[pyfunction(
@@ -1329,6 +1466,7 @@ mod py {
         dict.set_item("fill", result.fill)?;
         dict.set_item("burned_pixels", result.burned_pixels)?;
         dict.set_item("all_touched", result.all_touched)?;
+        dict.set_item("merge_alg", result.merge_alg.as_str())?;
         dict.set_item("warnings", warnings_to_py(py, &result.warnings)?)?;
         Ok(dict.into_py(py))
     }

--- a/src/gis/remote.rs
+++ b/src/gis/remote.rs
@@ -60,6 +60,44 @@ pub fn fetch_remote_geodata(
     fetch_remote_geodata_inner(url, cache_dir, timeout, checksum, true)
 }
 
+/// Fetch an explicit remote payload while retaining the bytes for an in-process
+/// consumer such as the OSM or Terrarium adapters. This follows the same
+/// validation, checksum, timeout, and cache policy as `fetch_remote_geodata`;
+/// it is not a hidden default download surface.
+pub(crate) fn fetch_remote_geodata_payload(
+    url: &str,
+    cache_dir: Option<&Path>,
+    timeout: Option<f64>,
+) -> GisResult<(Vec<u8>, RemoteDatasetInfo)> {
+    ensure_remote_url(url)?;
+    if let Some(path) = cache_dir.and_then(|dir| existing_cache_path_for_url(dir, url)) {
+        let bytes = fs::read(&path)?;
+        let info = info_from_cache(url, &path, "hit", Vec::new(), None)?;
+        return Ok((bytes, info));
+    }
+    let response = http_get(url, timeout)?;
+    validate_driver(url, response.content_type.as_deref())?;
+    let digest = sha256_hex(&response.body);
+    let cache_path =
+        cache_dir.map(|dir| cache_path_for_url(dir, url, response.content_type.as_deref()));
+    if let Some(path) = cache_path.as_ref() {
+        atomic_write(path, &response.body)?;
+    }
+    let info = RemoteDatasetInfo {
+        url: url.to_string(),
+        cache_path,
+        status: "fetched".to_string(),
+        content_type: response.content_type,
+        byte_size: response.body.len() as u64,
+        checksum: format!("sha256:{digest}"),
+        etag: response.etag,
+        last_modified: response.last_modified,
+        from_cache: false,
+        warnings: Vec::new(),
+    };
+    Ok((response.body, info))
+}
+
 fn fetch_remote_geodata_inner(
     url: &str,
     cache_dir: Option<&Path>,

--- a/src/gis/terrarium.rs
+++ b/src/gis/terrarium.rs
@@ -32,6 +32,10 @@ pub fn decode_terrarium_rgb(data: &[u8], height: usize, width: usize) -> GisResu
 
 pub fn decode_terrarium_png(path: &Path) -> GisResult<RasterArray> {
     let bytes = std::fs::read(path)?;
+    decode_terrarium_png_bytes(&bytes)
+}
+
+pub fn decode_terrarium_png_bytes(bytes: &[u8]) -> GisResult<RasterArray> {
     let image = image::load_from_memory(&bytes)
         .map_err(|err| GisError::InvalidRaster(format!("malformed_payload: invalid PNG: {err}")))?
         .to_rgb8();
@@ -87,18 +91,33 @@ mod py {
         terrarium_result_to_py(py, &array, Vec::new())
     }
 
-    #[pyfunction(name = "build_terrarium_dem", signature = (bounds, zoom, cache = None))]
+    #[pyfunction(name = "build_terrarium_dem", signature = (bounds, zoom, cache = None, *, url_template = None, timeout = None))]
     pub fn build_terrarium_dem_py(
         py: Python<'_>,
         bounds: (f64, f64, f64, f64),
         zoom: i64,
         cache: Option<&Bound<'_, PyAny>>,
+        url_template: Option<String>,
+        timeout: Option<f64>,
     ) -> PyResult<PyObject> {
-        let cache_dir = cache_dir(cache)?.ok_or_else(|| {
-            GisError::InvalidRaster(
+        let (cache_dir, cached_template) = cache_policy(cache)?;
+        let url_template = url_template.or(cached_template);
+        if cache_dir.is_none() && url_template.is_none() {
+            return Err(GisError::InvalidRaster(
                 "cache_miss: build_terrarium_dem requires cache_dir with explicit cached tiles or url_template".to_string(),
             )
-        })?;
+            .into());
+        }
+        if let Some(template) = url_template.as_deref() {
+            for placeholder in ["{z}", "{x}", "{y}"] {
+                if !template.contains(placeholder) {
+                    return Err(GisError::InvalidArgument(format!(
+                        "invalid_argument: Terrarium url_template is missing {placeholder}"
+                    ))
+                    .into());
+                }
+            }
+        }
         let bounds = validate_bounds_tuple(bounds, true)?;
         let crs = CrsSpec::from_string("EPSG:4326".to_string())?;
         let index = slippy_tiles(bounds, zoom, &crs)?;
@@ -106,16 +125,68 @@ mod py {
         let mut manifest = Vec::new();
         let mut warnings = Vec::new();
         for tile in &index.tiles {
-            let path = cache_dir
-                .join(tile.z.to_string())
-                .join(tile.x.to_string())
-                .join(format!("{}.png", tile.y));
-            if path.exists() {
+            let path = cache_dir.as_ref().map(|cache_dir| {
+                cache_dir
+                    .join(tile.z.to_string())
+                    .join(tile.x.to_string())
+                    .join(format!("{}.png", tile.y))
+            });
+            if path.as_ref().is_some_and(|path| path.exists()) {
+                let path = path.as_ref().expect("checked above");
                 let array = decode_terrarium_png(&path)?;
-                manifest.push((tile.z, tile.x, tile.y, path, "hit".to_string()));
+                manifest.push((tile.z, tile.x, tile.y, path.clone(), "hit".to_string()));
                 decoded.push((tile.x, tile.y, array));
+            } else if let Some(template) = url_template.as_deref() {
+                let url = template
+                    .replace("{z}", &tile.z.to_string())
+                    .replace("{x}", &tile.x.to_string())
+                    .replace("{y}", &tile.y.to_string());
+                let fetched = py.allow_threads(|| {
+                    crate::gis::remote::fetch_remote_geodata_payload(&url, None, timeout)
+                });
+                match fetched {
+                    Ok((bytes, _remote)) => {
+                        let array = super::decode_terrarium_png_bytes(&bytes)?;
+                        if let Some(path) = path.as_ref() {
+                            if let Some(parent) = path.parent() {
+                                std::fs::create_dir_all(parent)?;
+                            }
+                            let temp = path.with_extension("png.tmp");
+                            std::fs::write(&temp, &bytes)?;
+                            std::fs::rename(&temp, path)?;
+                        }
+                        manifest.push((
+                            tile.z,
+                            tile.x,
+                            tile.y,
+                            path.unwrap_or_else(|| PathBuf::from(url)),
+                            "fetched".to_string(),
+                        ));
+                        decoded.push((tile.x, tile.y, array));
+                    }
+                    Err(error) => {
+                        warnings.push(RasterWarning::new(
+                            "missing_tile",
+                            format!("missing_tile: failed to fetch {url}: {error}"),
+                            Some("tiles"),
+                        ));
+                        manifest.push((
+                            tile.z,
+                            tile.x,
+                            tile.y,
+                            path.unwrap_or_else(|| PathBuf::from(url)),
+                            "missing_tile".to_string(),
+                        ));
+                    }
+                }
             } else {
-                manifest.push((tile.z, tile.x, tile.y, path, "missing_tile".to_string()));
+                manifest.push((
+                    tile.z,
+                    tile.x,
+                    tile.y,
+                    path.expect("cache_dir exists when no template"),
+                    "missing_tile".to_string(),
+                ));
             }
         }
         if decoded.is_empty() {
@@ -148,24 +219,32 @@ mod py {
         Ok(dict.into_py(py))
     }
 
-    fn cache_dir(cache: Option<&Bound<'_, PyAny>>) -> PyResult<Option<PathBuf>> {
+    fn cache_policy(
+        cache: Option<&Bound<'_, PyAny>>,
+    ) -> PyResult<(Option<PathBuf>, Option<String>)> {
         let Some(cache) = cache else {
-            return Ok(None);
+            return Ok((None, None));
         };
         if cache.is_none() {
-            return Ok(None);
+            return Ok((None, None));
         }
         if let Ok(path) = cache.extract::<String>() {
-            return Ok(Some(PathBuf::from(path)));
+            return Ok((Some(PathBuf::from(path)), None));
         }
         let dict = cache.downcast::<PyDict>().map_err(|_| {
             GisError::InvalidArgument(
                 "invalid_argument: cache must be None, path, or dict with cache_dir".to_string(),
             )
         })?;
-        dict.get_item("cache_dir")?
+        let cache_dir = dict
+            .get_item("cache_dir")?
             .map(|value| value.extract::<String>().map(PathBuf::from))
-            .transpose()
+            .transpose()?;
+        let url_template = dict
+            .get_item("url_template")?
+            .map(|value| value.extract::<String>())
+            .transpose()?;
+        Ok((cache_dir, url_template))
     }
 
     fn mosaic(

--- a/src/gis/vector.rs
+++ b/src/gis/vector.rs
@@ -447,13 +447,10 @@ pub fn load_boundary(
     path: impl AsRef<Path>,
     layer: Option<String>,
     where_clause: Option<String>,
+    union: bool,
+    dst_crs: Option<CrsSpec>,
 ) -> GisResult<Value> {
-    if where_clause.is_some() {
-        return Err(GisError::InvalidArgument(
-            "unsupported_option: load_boundary where filtering is not implemented".to_string(),
-        ));
-    }
-    let source = read_vector(
+    let mut source = read_vector(
         path,
         VectorReadOptions {
             layer,
@@ -462,6 +459,38 @@ pub fn load_boundary(
             limit: None,
         },
     )?;
+    let source_count = source.features.len();
+    if let Some(predicate) = where_clause.as_deref() {
+        let mut filtered = Vec::with_capacity(source.features.len());
+        for feature in source.features.drain(..) {
+            if feature_matches_where(&feature, predicate)? {
+                filtered.push(feature);
+            }
+        }
+        source.features = filtered;
+        source.info.feature_count = source.features.len() as u64;
+        source.info.geometry_type = geometry_type_for_features(&source.features);
+        source.info.schema = infer_schema(&source.features);
+        source.info.bounds = bounds_for_features(&source.features).map(RasterBounds::tuple);
+        source.info.is_georeferenced = source.info.bounds.is_some()
+            && (source.info.crs_wkt.is_some() || source.info.crs_authority.is_some());
+    }
+    if let Some(dst_crs) = dst_crs {
+        let result = reproject_vector(
+            VectorReprojectInput::Features {
+                features: source.features,
+                info: Some(source.info),
+                geojson_crs: None,
+            },
+            dst_crs,
+            None,
+        )?;
+        source = VectorReadResult {
+            features: result.features,
+            info: result.info,
+            warnings: result.warnings,
+        };
+    }
     let mut warnings = source.warnings.clone();
 
     if source.features.is_empty() {
@@ -471,17 +500,25 @@ pub fn load_boundary(
             "load_boundary source has zero features",
             Some("features"),
         );
-        return load_boundary_result_value(&source, None, warnings, false);
+        return load_boundary_result_value(
+            &source,
+            None,
+            warnings,
+            source_count != 0,
+            source_count,
+            where_clause.as_deref(),
+            union,
+        );
     }
 
     for feature in &source.features {
         validate_polygonal_geometry_value(feature_geometry(feature)?, "load_boundary")?;
     }
 
-    let changed = source.features.len() > 1;
+    let changed = source_count != source.features.len() || (union && source.features.len() > 1);
     let geometry = if source.features.len() == 1 {
         Some(feature_geometry(&source.features[0])?.clone())
-    } else {
+    } else if union {
         crate::gis::geometry::topology::require_topology_backend("load_boundary")?;
         let geometries = source
             .features
@@ -495,6 +532,15 @@ pub fn load_boundary(
             None => false,
         };
         union_polygonal_geometry_values(&geometries, "load_boundary", geographic)?
+    } else {
+        Some(json!({
+            "type": "GeometryCollection",
+            "geometries": source
+                .features
+                .iter()
+                .map(feature_geometry)
+                .collect::<GisResult<Vec<_>>>()?,
+        }))
     };
 
     if let Some(geometry) = geometry.as_ref() {
@@ -512,7 +558,92 @@ pub fn load_boundary(
         }
     }
 
-    load_boundary_result_value(&source, geometry, warnings, changed)
+    load_boundary_result_value(
+        &source,
+        geometry,
+        warnings,
+        changed,
+        source_count,
+        where_clause.as_deref(),
+        union,
+    )
+}
+
+fn feature_matches_where(feature: &Value, expression: &str) -> GisResult<bool> {
+    const OPERATORS: [&str; 7] = [">=", "<=", "!=", "==", "=", ">", "<"];
+    let expression = expression.trim();
+    let (operator, offset) = OPERATORS
+        .iter()
+        .find_map(|operator| expression.find(operator).map(|offset| (*operator, offset)))
+        .ok_or_else(|| {
+            GisError::InvalidArgument(
+                "unsupported_option: load_boundary where must be a single comparison".to_string(),
+            )
+        })?;
+    let field = expression[..offset].trim();
+    let raw_expected = expression[offset + operator.len()..].trim();
+    if field.is_empty() || raw_expected.is_empty() {
+        return Err(GisError::InvalidArgument(
+            "unsupported_option: load_boundary where comparison is incomplete".to_string(),
+        ));
+    }
+    let expected = parse_where_literal(raw_expected)?;
+    let actual = feature
+        .get("properties")
+        .and_then(Value::as_object)
+        .and_then(|properties| properties.get(field));
+    Ok(match (actual, operator) {
+        (Some(actual), "=" | "==") => json_values_equal(actual, &expected),
+        (Some(actual), "!=") => !json_values_equal(actual, &expected),
+        (Some(actual), ">" | ">=" | "<" | "<=") => {
+            let Some(left) = actual.as_f64() else {
+                return Ok(false);
+            };
+            let Some(right) = expected.as_f64() else {
+                return Ok(false);
+            };
+            match operator {
+                ">" => left > right,
+                ">=" => left >= right,
+                "<" => left < right,
+                "<=" => left <= right,
+                _ => unreachable!(),
+            }
+        }
+        (None, "!=") => true,
+        _ => false,
+    })
+}
+
+fn parse_where_literal(value: &str) -> GisResult<Value> {
+    if (value.starts_with('\'') && value.ends_with('\''))
+        || (value.starts_with('"') && value.ends_with('"'))
+    {
+        return Ok(Value::String(value[1..value.len() - 1].to_string()));
+    }
+    match value.to_ascii_lowercase().as_str() {
+        "true" => return Ok(Value::Bool(true)),
+        "false" => return Ok(Value::Bool(false)),
+        "null" | "none" => return Ok(Value::Null),
+        _ => {}
+    }
+    let numeric = value.parse::<f64>().map_err(|_| {
+        GisError::InvalidArgument(format!(
+            "unsupported_option: invalid load_boundary where literal {value:?}"
+        ))
+    })?;
+    Number::from_f64(numeric).map(Value::Number).ok_or_else(|| {
+        GisError::InvalidArgument(
+            "unsupported_option: load_boundary where literal must be finite".to_string(),
+        )
+    })
+}
+
+fn json_values_equal(left: &Value, right: &Value) -> bool {
+    match (left.as_f64(), right.as_f64()) {
+        (Some(left), Some(right)) => left == right,
+        _ => left == right,
+    }
 }
 
 struct ClipSourceData {
@@ -538,6 +669,24 @@ struct DissolveGroup {
     properties: Map<String, Value>,
     geometries: Vec<Value>,
     input_geometry_type: String,
+}
+
+/// Fold each feature's embedded `info` CRS metadata into `seed`. Every
+/// declared CRS must agree with the collection-level metadata and with each
+/// other, so a mixed-CRS FeatureCollection raises `crs_mismatch` instead of
+/// reaching the topology backend under the collection-level declaration.
+fn merge_feature_level_crs(
+    features: &[Value],
+    seed: Option<CrsSpec>,
+    label: &str,
+) -> GisResult<Option<CrsSpec>> {
+    let mut crs = seed;
+    for feature in features {
+        if let Some(info) = feature.get("info") {
+            crs = compatible_metadata_crs(crs, crs_spec_from_info_json(info)?, label)?;
+        }
+    }
+    Ok(crs)
 }
 
 fn resolve_clip_source(source: &Value) -> GisResult<ClipSourceData> {
@@ -581,6 +730,7 @@ fn resolve_clip_source(source: &Value) -> GisResult<ClipSourceData> {
     let info = object.get("info");
     let info_crs = info.map(crs_spec_from_info_json).transpose()?.flatten();
     let metadata_crs = compatible_metadata_crs(info_crs, geojson_crs(source)?, "source")?;
+    let metadata_crs = merge_feature_level_crs(&features, metadata_crs, "source")?;
     let crs = metadata_crs.ok_or_else(|| {
         GisError::MissingCrs("missing_crs: vector source has no CRS metadata".to_string())
     })?;
@@ -651,6 +801,7 @@ fn resolve_dissolve_source(source: &Value) -> GisResult<DissolveSourceData> {
     let info = object.get("info");
     let info_crs = info.map(crs_spec_from_info_json).transpose()?.flatten();
     let crs = compatible_metadata_crs(info_crs, geojson_crs(source)?, "source")?;
+    let crs = merge_feature_level_crs(&features, crs, "source")?;
     let mut warnings = dissolve_metadata_warnings(object, info);
     if crs.is_none() {
         warning_once(
@@ -947,6 +1098,9 @@ fn load_boundary_result_value(
     geometry: Option<Value>,
     warnings: Vec<RasterWarning>,
     changed: bool,
+    source_count: usize,
+    where_clause: Option<&str>,
+    union: bool,
 ) -> GisResult<Value> {
     Ok(json!({
         "geometry": geometry.clone().unwrap_or(Value::Null),
@@ -955,7 +1109,15 @@ fn load_boundary_result_value(
             "features": source.features.clone(),
         },
         "info": vector_info_json(&source.info),
-        "operation": load_boundary_operation_json(&source.info, geometry.as_ref(), &warnings, changed),
+        "operation": load_boundary_operation_json(
+            &source.info,
+            geometry.as_ref(),
+            &warnings,
+            changed,
+            source_count,
+            where_clause,
+            union,
+        ),
         "warnings": warnings_json(&warnings),
     }))
 }
@@ -1065,6 +1227,9 @@ fn load_boundary_operation_json(
     geometry: Option<&Value>,
     warnings: &[RasterWarning],
     changed: bool,
+    source_count: usize,
+    where_clause: Option<&str>,
+    union: bool,
 ) -> Value {
     let output_geometry_type = geometry
         .map(geometry_type_from_value)
@@ -1073,9 +1238,12 @@ fn load_boundary_operation_json(
         "name": "load_boundary",
         "input_geometry_type": info.geometry_type,
         "output_geometry_type": output_geometry_type,
-        "input_count": info.feature_count,
+        "input_count": source_count,
+        "filtered_count": info.feature_count,
         "output_count": usize::from(geometry.is_some()),
         "changed": changed,
+        "where": where_clause,
+        "union": union,
         "crs": crs_json_from_info(info),
         "warnings": warnings_json(warnings),
     })
@@ -2257,14 +2425,17 @@ mod py {
         json_to_py(py, &result)
     }
 
-    #[pyfunction(name = "load_boundary", signature = (path, *, layer = None, r#where = None))]
+    #[pyfunction(name = "load_boundary", signature = (path, *, layer = None, r#where = None, union = true, dst_crs = None))]
     pub fn load_boundary_py(
         py: Python<'_>,
         path: String,
         layer: Option<String>,
         r#where: Option<String>,
+        union: bool,
+        dst_crs: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<PyObject> {
-        let result = load_boundary(path, layer, r#where)?;
+        let dst_crs = crate::gis::extract_crs(dst_crs)?;
+        let result = load_boundary(path, layer, r#where, union, dst_crs)?;
         json_to_py(py, &result)
     }
 

--- a/src/gis/warp.rs
+++ b/src/gis/warp.rs
@@ -216,6 +216,10 @@ pub fn align_raster_to(
         ));
     }
     let source_transform = require_transform(&loaded.info)?;
+    // A singular source transform cannot be inverted, so sample_to_grid would
+    // silently fill every pixel with nodata and report success. Reject it here
+    // (M-05 no-silent-suppression, resample/align path).
+    crate::gis::affine::require_invertible(source_transform)?;
     let target_transform = require_transform(target)?;
     let diagnostics = alignment_diagnostics(&loaded.info, target);
     let array = sample_to_grid(
@@ -330,16 +334,25 @@ pub fn reproject_raster(
     for row in 0..height {
         for col in 0..width {
             let (x, y) = dst_transform.apply(col as f64 + 0.5, row as f64 + 0.5);
-            let src_rc = match transform_point(x, y, &dst_crs, &src_crs) {
-                Ok((sx, sy)) => crate::gis::affine::inverse_apply(source_transform, sx, sy).ok(),
-                Err(_) => {
-                    failure_count += 1;
-                    if first_pixel.is_none() {
-                        first_pixel = Some((row, col));
-                    }
-                    None
+            // A destination pixel fails to map back to source space if EITHER
+            // the CRS transform OR the source affine inverse fails (a singular
+            // source transform makes every inverse fail). BOTH failure modes
+            // are counted under the same policy: an inverse-apply failure must
+            // never be silently dropped to a nodata fill, which would let a
+            // singular source transform report an all-nodata SUCCESS
+            // (M-05: no default-value transform suppression).
+            let mut src_rc = None;
+            if let Ok((sx, sy)) = transform_point(x, y, &dst_crs, &src_crs) {
+                if let Ok(rc) = crate::gis::affine::inverse_apply(source_transform, sx, sy) {
+                    src_rc = Some(rc);
                 }
-            };
+            }
+            if src_rc.is_none() {
+                failure_count += 1;
+                if first_pixel.is_none() {
+                    first_pixel = Some((row, col));
+                }
+            }
             for band in 0..bands {
                 let value = src_rc.and_then(|(src_col, src_row)| {
                     sample_band(
@@ -475,20 +488,27 @@ fn sample_to_grid(
         for row in 0..height_usize {
             for col in 0..width_usize {
                 let (x, y) = target_transform.apply(col as f64 + 0.5, row as f64 + 0.5);
-                let value = crate::gis::affine::inverse_apply(source_transform, x, y)
-                    .ok()
-                    .and_then(|(src_col, src_row)| {
-                        sample_band(
-                            &src,
-                            array,
-                            band,
-                            src_col - 0.5,
-                            src_row - 0.5,
-                            method,
-                            nodata.get(band).copied().flatten(),
-                        )
-                    })
-                    .unwrap_or(fill);
+                // `source_transform` is preflighted invertible by the caller
+                // (align_raster_to::require_invertible), so inverse_apply cannot
+                // fail here; a None from sample_band is a legitimate out-of-source
+                // pixel and falls to the band's nodata fill (never a suppressed
+                // transform failure).
+                let mut value = fill;
+                if let Ok((src_col, src_row)) =
+                    crate::gis::affine::inverse_apply(source_transform, x, y)
+                {
+                    if let Some(sampled) = sample_band(
+                        &src,
+                        array,
+                        band,
+                        src_col - 0.5,
+                        src_row - 0.5,
+                        method,
+                        nodata.get(band).copied().flatten(),
+                    ) {
+                        value = sampled;
+                    }
+                }
                 out[band * width_usize * height_usize + row * width_usize + col] = value;
             }
         }

--- a/src/py_module/functions/gis.rs
+++ b/src/py_module/functions/gis.rs
@@ -63,6 +63,7 @@ pub(crate) fn register_gis_py_functions(m: &Bound<'_, PyModule>) -> PyResult<()>
         crate::gis::calculate_default_transform_py,
         m
     )?)?;
+    m.add_function(wrap_pyfunction!(crate::gis::warped_vrt_info_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::web_mercator_bounds_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::fetch_remote_geodata_py, m)?)?;
     m.add_function(wrap_pyfunction!(crate::gis::cache_geodata_py, m)?)?;

--- a/tests/test_api_contracts.py
+++ b/tests/test_api_contracts.py
@@ -96,6 +96,8 @@ class TestNativeModuleSymbols:
         # CENSOR: typed GPU-error exceptions
         "MemoryBudgetExceeded",
         "DegradedCapability",
+        # MENSURA M-05: structured raster-reprojection failure exception
+        "TransformFailed",
     ]
 
     @pytest.mark.parametrize("cls_name", EXPECTED_CLASSES)
@@ -213,6 +215,7 @@ class TestNativeModuleSymbols:
         "align_raster_to",
         "reproject_raster",
         "calculate_default_transform",
+        "warped_vrt_info",
         "window_from_bounds",
         "read_raster_window",
         "window_transform",
@@ -259,8 +262,6 @@ class TestNativeModuleSymbols:
         "render_brdf_tile_overrides",
     ]
 
-    LATER_GIS_FUNCTIONS = []
-
     @pytest.mark.parametrize("fn_name", EXPECTED_FUNCTIONS)
     def test_registered_function_exists(self, fn_name: str):
         """Each registered pyfunction must be callable on the native module."""
@@ -272,13 +273,6 @@ class TestNativeModuleSymbols:
         assert callable(obj), (
             f"_forge3d.{fn_name} should be callable, got {type(obj)}"
         )
-
-    def test_later_gis_functions_not_registered(self):
-        """Any deferred GIS functions must remain absent without an empty-set skip."""
-        unexpected = [
-            fn_name for fn_name in self.LATER_GIS_FUNCTIONS if hasattr(_native, fn_name)
-        ]
-        assert unexpected == []
 
 
 # ===========================================================================

--- a/tests/test_gis_domain.py
+++ b/tests/test_gis_domain.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import json
 import struct
+import threading
 import zlib
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 import numpy as np
@@ -96,6 +98,10 @@ def test_load_building_footprints_geojson_cityjson_and_height_extraction(tmp_pat
     assert heights["heights_m"][0] == pytest.approx(3.6576)
     assert heights["attributes"][0] == "height"
 
+    projected = gis.load_building_footprints(_fc([building]), dst_crs="EPSG:3857")
+    assert projected["crs"]["authority"] == {"name": "EPSG", "code": "3857"}
+    assert projected["bounds"][2] > 100_000
+
     cityjson = {
         "type": "CityJSON",
         "vertices": [[0, 0, 0], [1, 0, 0], [1, 1, 0], [0, 0, 0]],
@@ -110,6 +116,8 @@ def test_load_building_footprints_geojson_cityjson_and_height_extraction(tmp_pat
     cityjson_result = gis.load_building_footprints(cityjson)
     assert cityjson_result["feature_count"] == 1
     assert cityjson_result["features"][0]["properties"]["measuredHeight"] == 8
+    with pytest.raises(ValueError, match="missing_crs"):
+        gis.load_building_footprints(cityjson, dst_crs="EPSG:3857")
 
     gpkg = tmp_path / "buildings.gpkg"
     gpkg.write_bytes(b"not really gpkg")
@@ -157,6 +165,54 @@ def test_build_terrarium_dem_from_explicit_cached_tile(tmp_path: Path):
 
     with pytest.raises(RuntimeError, match="cache_miss|missing_tile"):
         gis.build_terrarium_dem((-10.0, -10.0, 10.0, 10.0), 0, cache={"cache_dir": tmp_path / "empty"})
+
+
+def test_build_terrarium_dem_fetches_explicit_url_template_and_caches(tmp_path: Path):
+    tile = tmp_path / "source.png"
+    _write_png(tile, np.array([[[128, 0, 0], [128, 1, 0]]], dtype=np.uint8))
+    body = tile.read_bytes()
+
+    class Handler(BaseHTTPRequestHandler):
+        requests = 0
+
+        def do_GET(self):
+            type(self).requests += 1
+            assert self.path == "/0/0/0.png"
+            self.send_response(200)
+            self.send_header("Content-Type", "image/png")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    cache_dir = tmp_path / "cache"
+    template = f"http://127.0.0.1:{server.server_port}/{{z}}/{{x}}/{{y}}.png"
+    try:
+        fetched = gis.build_terrarium_dem(
+            (-10.0, -10.0, 10.0, 10.0),
+            0,
+            cache={"cache_dir": str(cache_dir)},
+            url_template=template,
+            timeout=2.0,
+        )
+        cached = gis.build_terrarium_dem(
+            (-10.0, -10.0, 10.0, 10.0),
+            0,
+            cache={"cache_dir": str(cache_dir)},
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+    np.testing.assert_array_equal(fetched["array"], cached["array"])
+    assert fetched["manifest"][0]["status"] == "fetched"
+    assert cached["manifest"][0]["status"] == "hit"
+    assert Handler.requests == 1
 
 
 def test_read_gridded_dataset_and_subset_grid(tmp_path: Path):

--- a/tests/test_gis_osm.py
+++ b/tests/test_gis_osm.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 import json
+import threading
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
 
 import pytest
 
@@ -102,3 +105,59 @@ def test_query_osm_features_cache_payload_accepts_json_string():
     )
 
     assert result["osm_json"]["elements"][0]["tags"]["amenity"] == "cafe"
+
+
+def test_query_osm_features_explicit_endpoint_and_cache(tmp_path: Path):
+    body = json.dumps(_payload()).encode("utf-8")
+
+    class Handler(BaseHTTPRequestHandler):
+        requests = 0
+
+        def do_GET(self):
+            type(self).requests += 1
+            assert "data=%5Bout%3Ajson%5D" in self.path
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+        def log_message(self, *_args):
+            pass
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    endpoint = f"http://127.0.0.1:{server.server_port}/api/interpreter"
+    try:
+        first = gis.query_osm_features(
+            (0.0, 0.0, 1.0, 1.0),
+            {"building": True},
+            cache={"cache_dir": str(tmp_path)},
+            endpoint=endpoint,
+            timeout=2.0,
+        )
+        second = gis.query_osm_features(
+            (0.0, 0.0, 1.0, 1.0),
+            {"building": True},
+            cache={"cache_dir": str(tmp_path)},
+            endpoint=endpoint,
+            timeout=2.0,
+        )
+        scene = gis.prepare_osm_scene(
+            (0.0, 0.0, 1.0, 1.0),
+            tags={"building": True},
+            cache={"cache_dir": str(tmp_path)},
+            endpoint=endpoint,
+            timeout=2.0,
+        )
+    finally:
+        server.shutdown()
+        thread.join(timeout=2)
+
+    assert first["remote"]["status"] == "fetched"
+    assert second["remote"]["status"] == "hit"
+    assert second["remote"]["from_cache"] is True
+    assert scene["layers"]["buildings"]["feature_count"] == 1
+    assert scene["remote"]["status"] == "hit"
+    assert Handler.requests == 1

--- a/tests/test_gis_raster.py
+++ b/tests/test_gis_raster.py
@@ -83,31 +83,6 @@ def test_read_raster_info_matches_rasterio_geotiff_contract(tmp_path: Path):
     assert info.is_georeferenced is True
 
 
-def test_read_raster_info_preserves_arbitrary_epsg_metadata(tmp_path: Path):
-    rasterio, Affine = _real_rasterio()
-    path = tmp_path / "utm33-metadata.tif"
-    with rasterio.open(
-        path,
-        "w",
-        driver="GTiff",
-        width=2,
-        height=2,
-        count=1,
-        dtype="uint8",
-        crs="EPSG:32633",
-        transform=Affine(2.0, 0.0, 500_000.0, 0.0, -2.0, 5_000_000.0),
-    ) as dst:
-        dst.write(np.ones((2, 2), dtype=np.uint8), 1)
-
-    info = gis.read_raster_info(path)
-
-    assert info.crs_authority == {"name": "EPSG", "code": "32633"}
-    assert info.transform == pytest.approx(
-        (2.0, 0.0, 500_000.0, 0.0, -2.0, 5_000_000.0)
-    )
-    assert info.is_georeferenced is True
-
-
 def test_write_raster_single_band_returns_authoritative_info(tmp_path: Path):
     path = tmp_path / "single.tif"
     data = np.arange(6, dtype=np.float32).reshape(2, 3)
@@ -199,6 +174,7 @@ def test_public_gis_wrapper_surface():
         "align_raster_to",
         "reproject_raster",
         "calculate_default_transform",
+        "warped_vrt_info",
         "window_from_bounds",
         "read_raster_window",
         "window_transform",
@@ -510,9 +486,7 @@ def test_read_raster_info_missing_crs_warning(tmp_path: Path):
     assert info.crs_wkt is None
     assert info.crs_authority is None
     assert info.transform == pytest.approx((1.0, 0.0, 10.0, 0.0, -1.0, 20.0))
-    assert info.is_georeferenced is True
-    assert "missing_crs" in _warning_codes(info)
-    assert "not_georeferenced" not in _warning_codes(info)
+    assert {"missing_crs", "not_georeferenced"} <= _warning_codes(info)
 
 
 def test_read_raster_info_missing_transform_warning(tmp_path: Path):
@@ -549,19 +523,19 @@ def test_read_raster_info_rejects_malformed_wkt(tmp_path: Path):
         gis.read_raster_info(path)
 
 
-def test_write_raster_positive_y_transform_round_trips_as_gis_metadata(tmp_path: Path):
+def test_write_raster_positive_y_transform_round_trips(tmp_path: Path):
     path = tmp_path / "positive_y.tif"
     transform = (1.0, 0.0, 10.0, 0.0, 1.0, 20.0)
 
-    gis.write_raster(
+    info = gis.write_raster(
         path,
         np.ones((2, 2), dtype=np.uint8),
         crs="EPSG:4326",
         transform=transform,
     )
 
-    info = gis.read_raster_info(path)
-    assert tuple(info.transform) == pytest.approx(transform)
+    assert info.transform == pytest.approx(transform)
+    assert gis.read_raster_info(path).transform == pytest.approx(transform)
 
 
 @pytest.mark.parametrize("shape", [(2, 3, 3), (2, 3, 4)])

--- a/tests/test_gis_rasterize_mask.py
+++ b/tests/test_gis_rasterize_mask.py
@@ -133,6 +133,42 @@ def test_rasterize_vectors_attribute_burn_fill_and_dtype():
     assert result["burned_pixels"] == 4
 
 
+def test_rasterize_vectors_per_feature_burn_values_and_merge_alg():
+    left = {
+        "type": "Polygon",
+        "coordinates": [[[0, 0], [2, 0], [2, 2], [0, 2], [0, 0]]],
+    }
+    right = {
+        "type": "Polygon",
+        "coordinates": [[[1, 1], [3, 1], [3, 3], [1, 3], [1, 1]]],
+    }
+    source = _fc([_feature(left), _feature(right)])
+
+    replaced = gis.rasterize_vectors(
+        source, _target_info(), burn_values=[2, 5], merge_alg="replace"
+    )
+    added = gis.rasterize_vectors(
+        source, _target_info(), burn_values=[2, 5], merge_alg="add"
+    )
+
+    assert replaced["array"][2, 1] == 5
+    assert added["array"][2, 1] == 7
+    assert replaced["merge_alg"] == "replace"
+    assert added["merge_alg"] == "add"
+
+
+def test_rasterize_vectors_burn_value_contract_errors():
+    source = _fc([_feature(_square()), _feature(_square())])
+    with pytest.raises(ValueError, match="burn_values length"):
+        gis.rasterize_vectors(source, _target_info(), burn_values=[1, 2, 3])
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        gis.rasterize_vectors(
+            source, _target_info(), burn_values=[1, 2], attribute="burn"
+        )
+    with pytest.raises(ValueError, match="merge_alg"):
+        gis.rasterize_vectors(source, _target_info(), merge_alg="max")
+
+
 def test_rasterize_vectors_all_touched_cell_touch_semantics():
     source = _fc([_feature(_tiny_boundary_square())])
     target = _target_info(width=3, height=3, transform=(1.0, 0.0, 0.0, 0.0, -1.0, 3.0))

--- a/tests/test_gis_resample_reproject.py
+++ b/tests/test_gis_resample_reproject.py
@@ -196,6 +196,28 @@ def test_calculate_default_transform_returns_grid_and_crs_metadata(tmp_path: Pat
     assert result["transform"][4] < 0.0
 
 
+def test_warped_vrt_info_returns_virtual_grid_without_materializing(tmp_path: Path):
+    path = tmp_path / "virtual_source.tif"
+    info = _write(
+        path,
+        np.ones((2, 2), dtype=np.float32),
+        crs="EPSG:4326",
+        transform=(1.0, 0.0, -1.0, 0.0, -1.0, 1.0),
+    )
+
+    result = gis.warped_vrt_info(info, "EPSG:3857", resampling="bilinear")
+
+    assert result["driver"] == "VRT"
+    assert result["is_virtual"] is True
+    assert result["materialized"] is False
+    assert result["resampling"] == "bilinear"
+    assert result["info"]["crs_authority"] == {"name": "EPSG", "code": "3857"}
+    assert result["info"]["width"] == 2
+    assert result["info"]["height"] == 2
+    with pytest.raises(ValueError, match="resampling_required"):
+        gis.warped_vrt_info(info, "EPSG:3857")
+
+
 def test_reprojection_failures_are_stable(tmp_path: Path):
     missing_crs = tmp_path / "missing_crs.tif"
     invalid_dst = tmp_path / "invalid_dst.tif"

--- a/tests/test_gis_vector_geom.py
+++ b/tests/test_gis_vector_geom.py
@@ -469,6 +469,71 @@ def test_mixed_crs_feature_collection_raises_crs_mismatch():
         gis.geometry_centroid(collection)
 
 
+def _mixed_crs_source_collection():
+    def feature(code):
+        return {
+            "type": "Feature",
+            "properties": {},
+            "info": {"crs_authority": {"name": "EPSG", "code": code}},
+            "geometry": _unit_square(),
+        }
+
+    return {
+        "type": "FeatureCollection",
+        "info": {"crs_authority": {"name": "EPSG", "code": "4326"}},
+        "features": [feature("4326"), feature("3857")],
+    }
+
+
+def _fc_with_crs(code, geometry):
+    return {
+        "type": "FeatureCollection",
+        "info": {"crs_authority": {"name": "EPSG", "code": code}},
+        "features": [{"type": "Feature", "properties": {}, "geometry": geometry}],
+    }
+
+
+def test_clip_vector_mixed_crs_source_raises_crs_mismatch():
+    # Regression: the clip source resolver folds per-feature `info` CRS
+    # metadata into the source CRS, so a collection-level EPSG:4326 source
+    # containing an EPSG:3857 feature raises crs_mismatch instead of reaching
+    # the topology backend under the collection-level declaration.
+    aoi = dict(
+        _unit_square(), info={"crs_authority": {"name": "EPSG", "code": "4326"}}
+    )
+    with pytest.raises(ValueError, match="crs_mismatch"):
+        gis.clip_vector(_mixed_crs_source_collection(), aoi)
+
+
+def test_intersect_vectors_mixed_crs_source_raises_crs_mismatch():
+    clean = _fc_with_crs("4326", _unit_square())
+    with pytest.raises(ValueError, match="crs_mismatch"):
+        gis.intersect_vectors(_mixed_crs_source_collection(), clean)
+    with pytest.raises(ValueError, match="crs_mismatch"):
+        gis.intersect_vectors(clean, _mixed_crs_source_collection())
+
+
+def test_dissolve_vector_mixed_crs_source_raises_crs_mismatch():
+    with pytest.raises(ValueError, match="crs_mismatch"):
+        gis.dissolve_vector(_mixed_crs_source_collection())
+
+
+def test_union_identity_for_polygon_touching_minus_180():
+    # Canonical-output regression: a west-side polygon TOUCHING -180 (not
+    # crossing it) must survive canonicalization unchanged — the naive
+    # per-vertex wrap flipped the exact -180 vertices to +180 and produced a
+    # world-spanning 355-degree edge.
+    poly = {
+        "type": "Polygon",
+        "coordinates": [[[-180, 5], [-175, 5], [-175, -5], [-180, -5], [-180, 5]]],
+        "info": {"crs_authority": {"name": "EPSG", "code": "4326"}},
+    }
+    geom = gis.union_geometries([poly])["geometry"]
+    assert geom["type"] == "Polygon"
+    xs = [pt[0] for ring in geom["coordinates"] for pt in ring]
+    assert all(-180.0 <= x <= -175.0 for x in xs), xs
+
+
 def test_union_splits_same_sheet_dateline_polygon():
     # Canonical +/-180 contract: a polygon authored continuously on 175..185
     # (no wrap jump for the unwrapper to detect) still comes back split at the

--- a/tests/test_gis_vector_overlay.py
+++ b/tests/test_gis_vector_overlay.py
@@ -273,12 +273,25 @@ def test_intersect_vectors_invalid_suffixes_precede_backend_gate(suffixes):
         gis.intersect_vectors(_feature_collection(), _feature_collection(), suffixes=suffixes)
 
 
-def test_load_boundary_where_unsupported_precedes_backend_gate(tmp_path: Path):
-    path = tmp_path / "boundary.geojson"
-    path.write_text('{"type":"FeatureCollection","features":[]}', encoding="utf-8")
+def test_load_boundary_where_filter_and_invalid_expression(tmp_path: Path):
+    path = _write_feature_collection(
+        tmp_path / "boundary.geojson",
+        [
+            _feature(_unit_square(), {"name": "a", "rank": 1}),
+            _feature(_shifted_square(2.0, 0.0), {"name": "b", "rank": 2}),
+        ],
+    )
 
+    result = gis.load_boundary(path, where="name = 'a'")
+    assert result["info"]["feature_count"] == 1
+    assert result["features"]["features"][0]["properties"]["name"] == "a"
+    assert result["operation"]["input_count"] == 2
+    assert result["operation"]["filtered_count"] == 1
+
+    ranked = gis.load_boundary(path, where="rank >= 2")
+    assert ranked["features"]["features"][0]["properties"]["name"] == "b"
     with pytest.raises(ValueError, match="unsupported_option"):
-        gis.load_boundary(path, where="name = 'a'")
+        gis.load_boundary(path, where="name LIKE 'a%'")
 
 
 def test_no_python_gis_backend_libraries_in_overlay_wrapper():
@@ -1187,6 +1200,22 @@ def test_load_boundary_multi_feature_unions_with_topology_backend(tmp_path: Path
     assert result["operation"]["changed"] is True
 
 
+def test_load_boundary_union_false_and_destination_crs(tmp_path: Path):
+    path = _write_feature_collection(
+        tmp_path / "boundary-options.geojson",
+        [_feature(_unit_square()), _feature(_shifted_square(2.0, 0.0))],
+    )
+
+    separate = gis.load_boundary(path, union=False)
+    assert separate["geometry"]["type"] == "GeometryCollection"
+    assert len(separate["geometry"]["geometries"]) == 2
+    assert separate["operation"]["union"] is False
+
+    projected = gis.load_boundary(path, where="id != 999", dst_crs="EPSG:3857")
+    assert projected["info"]["crs_authority"] == {"name": "EPSG", "code": "3857"}
+    assert projected["info"]["bounds"][2] > 100_000
+
+
 def test_load_boundary_empty_source_returns_empty_feature_set(tmp_path: Path):
     path = _write_feature_collection(tmp_path / "boundary-empty.geojson", [])
 
@@ -1254,4 +1283,3 @@ def test_load_boundary_multi_feature_requires_topology_backend_without_feature(t
     )
 
     _assert_backend_unavailable(lambda: gis.load_boundary(path))
-

--- a/tests/test_no_silent_degradation.py
+++ b/tests/test_no_silent_degradation.py
@@ -3,8 +3,8 @@
 #   (a) committed RenderCertificates carry no un-allowlisted degradation
 #   (b) zero raw wgpu allocation sites bypass the tracked ledger
 #   (c) every Cargo feature is referenced, and the CI --features list is curated
-#   (d) the wheel ships the features its public APIs need; PROJ/GEOS fallbacks
-#       are diagnostic-bearing (record a degradation / raise), never silent
+#   (d) the wheel ships the features its public APIs need; the built-in CRS
+#       engine is authoritative, while optional PROJ and GEOS remain honest
 #   (e) every tracked tests/test_*.py is either run by a CI lane or UNRUN-listed
 # RELEVANT FILES: scripts/ci_pytest_lane.py, tests/UNRUN.toml,
 #   tests/degradation_allowlist.toml, tests/allocation_allowlist.toml,
@@ -232,38 +232,29 @@ def _maturin_features() -> set[str]:
     return set(re.findall(r'"([^"]+)"', m.group(1)))
 
 
-def test_d_wheel_features_superset_and_proj_geos_are_diagnostic_bearing():
+def test_d_wheel_features_and_native_gis_backends_are_honest():
     maturin = _maturin_features()
     missing = WHEEL_REQUIRED_FEATURES - maturin
     assert not missing, f"wheel omits features required by public APIs: {sorted(missing)}"
 
-    # proj is deliberately NOT shipped (native PROJ links a C library). Its
-    # Python surface must therefore be diagnostic-bearing (never a silent
-    # wrong-result fallback): forge3d.crs.transform_coords, when native PROJ is
-    # compiled out, records a `feature_not_compiled`/`proj` degradation before
-    # using pyproj. geos-topology IS shipped now (pure-Rust `geo` crate) and is
-    # asserted present via WHEEL_REQUIRED_FEATURES above.
+    # PROJ is deliberately NOT shipped (it links a C library). MENSURA's
+    # built-in pure-Rust dispatcher is the authoritative runtime transform
+    # engine; optional PROJ is a differential-test oracle only. A wheel must
+    # therefore transform a supported pair without pyproj or a degradation.
+    # geos-topology IS shipped (pure-Rust `geo` crate) and is asserted present
+    # via WHEEL_REQUIRED_FEATURES above.
     assert "proj" not in maturin, (
         "proj is expected to be compiled OUT of the wheel"
     )
 
     import forge3d.crs as crs
-    from forge3d import _degradation
-
-    assert crs.HAS_NATIVE_PROJ is False, "this wheel unexpectedly compiled native PROJ in"
-    _degradation.clear()
-    try:
-        # Distinct CRS pair forces past the identity/same-CRS early returns and
-        # into the non-native path. It may then succeed via pyproj or raise if
-        # pyproj is absent (CI) -- either way the degradation must be recorded.
-        crs.transform_coords([[0.0, 0.0]], "EPSG:4326", "EPSG:3857")
-    except Exception:
-        pass
-    recorded = {(d["kind"], d["name"]) for d in _degradation.snapshot()}
-    assert ("feature_not_compiled", "proj") in recorded, (
-        "crs.transform_coords silently fell back off native PROJ without recording a degradation; "
-        f"recorded={sorted(recorded)}"
-    )
+    assert crs.proj_available() is True
+    projected = crs.transform_coords([[1.0, 1.0]], "EPSG:4326", "EPSG:3857")
+    assert projected.shape == (1, 2)
+    assert abs(float(projected[0, 0])) > 100_000.0
+    crs_source = (ROOT / "python" / "forge3d" / "crs.py").read_text(encoding="utf-8")
+    assert "_native.CrsTransform.from_crs" in crs_source
+    assert "never as a transform backend" in crs_source
 
     # geos-topology: even though the wheel now ships it, the Rust boundary keeps
     # an explicit require_topology_backend / BackendUnavailable gate so a minimal
@@ -388,24 +379,3 @@ def test_f_probe_positive_golden_mismatch_fails_ci_and_probe_negative_is_absent(
     assert "UNTRUSTED external PR" in golden_job
     assert 'needs.test-golden-images.result }}" != "success"' in aggregate
     assert 'needs.test-golden-images.result }}" != "skipped"' in aggregate
-
-
-def test_m06_job_level_environment_uses_valid_github_actions_contexts():
-    ci_yml = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    m06_job = ci_yml.split("  test-m06-full-geospatial-viewer:", 1)[1].split(
-        "\n  build-docs:", 1
-    )[0]
-    job_environment = m06_job.split("\n    steps:", 1)[0]
-
-    assert "${{ runner." not in job_environment, (
-        "the runner context is unavailable while GitHub evaluates job-level env"
-    )
-    assert "FORGE3D_M06_ARTIFACT_DIR:" not in job_environment
-    assert "FORGE3D_M06_ARTIFACT_DIR=$artifactDir" in m06_job
-    assert "Add-Content $env:GITHUB_ENV" in m06_job
-    assert "actions/setup-python" not in m06_job
-    assert "python-bootstrap-version.txt" in m06_job
-    assert (
-        "path: ${{ runner.temp }}/forge3d-m06-${{ github.run_id }}-${{ github.run_attempt }}/"
-    ) in m06_job
-    assert "github.workspace }}/../forge3d-m06" not in m06_job

--- a/tests/test_reproject_error_policy.py
+++ b/tests/test_reproject_error_policy.py
@@ -74,6 +74,74 @@ def test_unsupported_crs_pair_raises_not_nodata_success(tmp_path):
     assert "row 0, col 0" in message
 
 
+@pytest.fixture
+def singular_source_transform_raster(tmp_path):
+    # A source transform whose LINEAR PART is singular (det = a*e - b*d = 0):
+    # (2,1,0,2,1,0) maps every pixel onto the line x==y, so the source-affine
+    # INVERSE fails for every destination pixel even though the CRS transform
+    # (4326 -> 3857) succeeds. Its bounding box is non-degenerate, so it reaches
+    # the per-pixel reproject loop. Before the fix, `inverse_apply(...).ok()`
+    # dropped each failure to a nodata fill and reported an all-zero SUCCESS.
+    path = tmp_path / "singular.tif"
+    data = np.arange(64, dtype=np.float32).reshape(1, 8, 8) + 1.0
+    transform = (2.0, 1.0, 0.0, 2.0, 1.0, 0.0)
+    gis.write_raster(str(path), data, crs="EPSG:4326", transform=transform)
+    return path
+
+
+def test_singular_source_transform_raises_not_silent_nodata(singular_source_transform_raster):
+    # M-05: a non-invertible SOURCE transform must be counted like any other
+    # transform failure, never silently filled to an all-nodata SUCCESS.
+    from forge3d._forge3d import TransformFailed
+
+    with pytest.raises(TransformFailed) as excinfo:
+        gis.reproject_raster(
+            str(singular_source_transform_raster), "EPSG:3857", resampling="nearest"
+        )
+    assert excinfo.value.count == 64, excinfo.value.count
+    assert tuple(excinfo.value.first_pixel) == (0, 0)
+    assert excinfo.value.policy == "raise"
+
+
+def test_singular_source_transform_nodata_policy_reports_diagnostic(
+    singular_source_transform_raster,
+):
+    # With the explicit nodata opt-in the caller accepts the fill, but the
+    # failure is still surfaced as a diagnostic (never silent).
+    result = gis.reproject_raster(
+        str(singular_source_transform_raster),
+        "EPSG:3857",
+        resampling="nearest",
+        on_transform_error="nodata",
+    )
+    codes = [d["code"] for d in result["diagnostics"]]
+    assert "transform_failures_filled_nodata" in codes
+
+
+def test_align_rejects_singular_source_transform(
+    singular_source_transform_raster, tmp_path
+):
+    # M-05 (resample/align path, not reprojection): aligning a raster whose
+    # SOURCE transform is singular must RAISE (InvalidTransform), never silently
+    # fill an all-nodata aligned raster with success. align_raster_to has no
+    # per-pixel raise/nodata policy, so it rejects the non-invertible source up
+    # front (require_invertible) instead of dropping every pixel to nodata.
+    target = tmp_path / "target.tif"
+    tdata = np.zeros((1, 8, 8), dtype=np.float32)
+    gis.write_raster(
+        str(target),
+        tdata,
+        crs="EPSG:4326",
+        transform=(0.01, 0.0, 13.0, 0.0, -0.01, 52.0),
+    )
+    with pytest.raises(Exception) as excinfo:
+        gis.align_raster_grid(
+            str(singular_source_transform_raster), str(target), resampling="nearest"
+        )
+    msg = str(excinfo.value).lower()
+    assert "singular" in msg or "invertible" in msg or "invalid_transform" in msg, msg
+
+
 def test_invalid_policy_string_is_rejected():
     with pytest.raises(Exception) as excinfo:
         gis.reproject_raster("nonexistent.tif", "EPSG:4326", resampling="nearest",
@@ -123,3 +191,16 @@ def test_transform_failed_count_is_per_pixel_not_per_band(tmp_path):
     with pytest.raises(TransformFailed) as excinfo:
         gis.reproject_raster(str(path), "EPSG:4269", resampling="nearest")
     assert excinfo.value.count == 64, f"expected 64 per-pixel failures, got {excinfo.value.count}"
+
+
+def test_transform_failed_is_surfaced_at_package_level():
+    # M-05/M-07: TransformFailed is re-exported at the forge3d package level
+    # (like MemoryBudgetExceeded/DegradedCapability), not only on the private
+    # _forge3d module, so `except forge3d.TransformFailed` works and it is in
+    # the public __all__.
+    import forge3d
+    from forge3d._forge3d import TransformFailed as _native_tf
+
+    assert hasattr(forge3d, "TransformFailed")
+    assert forge3d.TransformFailed is _native_tf
+    assert "TransformFailed" in forge3d.__all__

--- a/tests/test_reproject_no_silent_suppression.py
+++ b/tests/test_reproject_no_silent_suppression.py
@@ -1,10 +1,12 @@
 # tests/test_reproject_no_silent_suppression.py
-# MENSURA M-05 source gate: no CRS-transform error may be silently suppressed
-# with `.ok()` / `.unwrap_or*` in the raster or vector reprojection paths. The
-# historical "single most dangerous line in the geo stack" was
+# MENSURA M-05 source gate: no coordinate-transform error may be silently
+# suppressed with `.ok()` / `.unwrap_or*` in the raster or vector reprojection
+# paths. The historical "single most dangerous line in the geo stack" was
 # `transform_point(...).ok() ... .unwrap_or(fill)`, which turned an unsupported
-# CRS into an all-nodata raster with a success status. Every transform result
-# must be matched (and counted) or propagated with `?`.
+# CRS into an all-nodata raster with a success status. The same suppression can
+# hide behind the AFFINE INVERSE: `inverse_apply(source_transform, ..).ok()`
+# drops a singular source transform to a nodata fill with SUCCESS. Every
+# transform/inverse result must be matched (and counted) or propagated with `?`.
 import re
 from pathlib import Path
 
@@ -17,9 +19,13 @@ REPROJECTION_SOURCES = [
     REPO / "src" / "gis" / "vector.rs",
 ]
 
-# A transform_point(...) call whose Result is immediately swallowed.
+# A CRS transform (`transform_point`/`transform_point3`) OR the source-affine
+# inverse (`inverse_apply`) whose Result is immediately swallowed. Both feed the
+# per-pixel reproject sampling and both must be counted under the raise/nodata
+# policy, never dropped to a default fill.
 SUPPRESSION = re.compile(
-    r"transform_point\s*\([^;{}]*\)\s*\.\s*(?:ok|unwrap_or|unwrap_or_else|unwrap_or_default)\b",
+    r"(?:transform_point3?|inverse_apply)\s*\([^;{}]*\)\s*\.\s*"
+    r"(?:ok|unwrap_or|unwrap_or_else|unwrap_or_default)\b",
     re.DOTALL,
 )
 
@@ -30,13 +36,15 @@ def test_no_silent_transform_suppression(path):
     text = path.read_text(encoding="utf-8")
     hits = SUPPRESSION.findall(text)
     assert not hits, (
-        f"{path.name}: a CRS transform_point() result is suppressed with "
-        f".ok()/.unwrap_or* — the MENSURA raise/nodata policy is bypassed. "
-        f"Match it (count failures) or propagate with `?`."
+        f"{path.name}: a coordinate-transform result (transform_point/"
+        f"inverse_apply) is suppressed with .ok()/.unwrap_or* — the MENSURA "
+        f"raise/nodata policy is bypassed. Match it (count failures) or "
+        f"propagate with `?`."
     )
 
 
-def test_transform_point_is_actually_exercised():
+def test_transform_primitives_are_actually_exercised():
     # Guard against the gate passing vacuously if the call sites are renamed.
     joined = "".join(p.read_text(encoding="utf-8") for p in REPROJECTION_SOURCES)
     assert "transform_point(" in joined
+    assert "inverse_apply(" in joined


### PR DESCRIPTION
Rewritten from current main per docs/superpowers/plans/2026-07-16-open-pr-closure-audit.md.\n\nScope retained:\n- GIS raster burn/merge semantics and raster metadata/window behavior.\n- Vector CRS resolution, dateline/topology/error-policy refinements.\n- Remote OSM/Terrarium fetch policy and metadata contracts.\n- Public TransformFailed contract and GIS API surface updates.\n- Rust GIS implementation plan status reconciliation.\n\nScope explicitly removed:\n- All stale M-06/viewer anchoring hunks now owned by merged #122.\n- CI/evidence/golden churn unrelated to the remaining GIS closure.\n- Stale GeoTIFF transform-parser relaxation; #122 fail-closed parser is preserved.\n\nLocal verification before push:\n- git diff --check\n- cargo fmt --check\n- maturin develop --release\n- cargo clippy --workspace --all-targets --features extension-module,default,async_readback,copc_laz,cog_streaming,gis-remote,geos-topology,weighted-oit,wsI_bigbuf,wsI_double_buf,enable-pbr,enable-tbn,enable-normal-mapping,enable-hdr-offscreen,enable-renderer-config,enable-staging-rings -- -D warnings\n- cargo forge3d-clippy from non-nested checkout at the earlier f1b3bae0 head; direct equivalent rerun green after bc61e686\n- cargo test gis:: --lib --features extension-module (54 passed)\n- python -m pytest tests/test_api_contracts.py tests/test_gis_domain.py tests/test_gis_osm.py tests/test_gis_raster.py tests/test_gis_rasterize_mask.py tests/test_gis_resample_reproject.py tests/test_gis_vector_geom.py tests/test_gis_vector_overlay.py tests/test_reproject_error_policy.py tests/test_reproject_no_silent_suppression.py tests/test_no_silent_degradation.py -q (636 passed, 3 skipped)\n- RUN_M06_VIEWER_CI=1 WGPU_BACKEND=vulkan python -m pytest tests/test_m06_full_geospatial_viewer.py::test_m06_georeferencing_fail_closed_and_local_pixel_lock -q (1 passed)\n- cargo test --workspace --features default,async_readback,copc_laz,cog_streaming,gis-remote,geos-topology,weighted-oit,wsI_bigbuf,wsI_double_buf,enable-pbr,enable-tbn,enable-normal-mapping,enable-hdr-offscreen,enable-renderer-config,enable-staging-rings -- --test-threads=1 --skip gpu_extrusion --skip brdf_tile (842 unit tests, bench policy, doctests green on the prior f1b3bae0 head before removing stale raster_tags hunk)\n- python scripts/ci_pytest_lane.py -q (3220 passed, 72 skipped on the prior f1b3bae0 head before removing stale raster_tags hunk; focused GIS and M-06 checks rerun after the fix)