### PR TITLE
HDR terrain mood: EXR decode + IBL.from_hdr + colors mood-grade

### DIFF
--- a/docs/italy-forest-pt-hdr-mood-diagnosis-2026-07-13.md
+++ b/docs/italy-forest-pt-hdr-mood-diagnosis-2026-07-13.md
@@ -1,0 +1,274 @@
+# Why the HDR barely changes the Italy-forest PT poster's colour mood
+
+**Date:** 2026-07-13
+**Scope:** Root-cause diagnosis + ranked remediation plan (read-only investigation; no code changed)
+**Subject:** `examples/forest_cover_copernicus/italy_forest_pt_3d.py` (PT poster) and its imported
+composer `examples/forest_cover_copernicus/italy_forest_cover_3d.py`
+**Evidence:** cached per-HDR light fields in `examples/out/italy_forest_pt/pt_light_field_*.npz`
+(snow_field_1k, venice_sunset_4k, brown_photostudio_02_4k); tracer source under
+`src/path_tracing/`. Two measurement harnesses (per-stage attenuation budget + cosine-weighted
+irradiance/mood extractor) reproduce every number below.
+
+> **Independent audit (2026-07-13):** verified against the working tree by an independent audit and a
+> `float64` re-derivation. The root cause and the Option 1 recommendation stand; two headline
+> magnitudes were corrected — a `float32`-accumulator artifact and a domain mislabel ("plate-wide"
+> conflated the full light field with the map subject). Over the **Italy map subject** the colour
+> shift is **~2.3%** (~0.6% over the full light field) and the anchor counterfactual is
+> **−0.023 → −0.071**; both corrections strengthen the same causal direction. See *Provenance &
+> precision notes* in the appendix.
+
+---
+
+## TL;DR
+
+The HDR **does** change the poster's *luminance* mood (brightness, relief contrast, shadow depth
+— that is why venice reads `medianL` 181 vs snow 175) — but it **cannot** change the *colour*
+mood, and the small colour signal it would deliver points the **wrong way**: venice's physical
+light is **blue**, not warm. Three stacked mechanisms neutralise colour, only one of which is the
+tint-anchor originally suspected — and the anchor turns out to be *helping*, not hurting. To make
+the "sunset read warm" you cannot let more of the physical cast through (that makes venice bluer);
+you need an **artistic mood-grade derived from the HDR's warm horizon band**, added as one
+compose-time knob.
+
+---
+
+## (a) Quantified root-cause diagnosis
+
+### The phenomenon, stated precisely
+
+The overlay is a **fixed, light-free palette**
+([`_forest_rgba`](../examples/forest_cover_copernicus/italy_forest_cover_3d.py) — colour is a
+function of forest cover only, plus a deterministic light-free moss grain, so it takes **no lighting
+input**). The HDR reaches the finished plate through exactly **two** channels out of
+[`_shade_on_overlay_grid`](../examples/forest_cover_copernicus/italy_forest_pt_3d.py): the
+achromatic `shade` (→ brightness/contrast) and the chromatic `tint`. Everything else in the
+compose path (`_apply_final_map_brightness`, page vignette, contact-shadow glows) is
+**HDR-independent**.
+
+- **Luminance mood transfers fine.** Replaying `shade` → `scale` over the **Italy map subject**
+  (overlay alpha): mean-brightness snow **0.857** → venice **0.890** (+3.9%) → brown **0.912**
+  (+6.5%); mid-dark area fraction (`shade < 0.5`) snow **30.0%** vs brown **13.2%** (>2×). This
+  matches the observed `medianL`/relief-contrast spread. Nothing is broken here.
+- **Colour mood does not.** Over the **Italy map subject** the HDR shifts colour by only **~2.3%**
+  (~0.6% over the full light field); the only larger movement (~9%) is confined to dark shadows —
+  and for venice it is toward **blue**.
+
+### The three stacked neutralisers (colour), with the attenuation budget
+
+Measured venice-vs-snow warm ratio (R/B; `<1` = bluer than the neutral snow control) at each
+pipeline stage, over the **full light field** unless noted:
+
+| Stage | venice R/B | snow R/B | venice ÷ snow | what happens |
+|---|---|---|---|---|
+| **Env up-irradiance** (physical diffuse fill) | 0.528 | 1.016 | **0.52×** | ← **root: geometry** |
+| Raw light field (all hits) | 0.882 | 1.022 | 0.86× | sun dilutes the blue |
+| Raw light field (shadow) | 0.463 | 1.001 | 0.46× | shadows = pure blue fill |
+| Raw shadow *tint* | 0.444 | 0.991 | 0.45× | |
+| After anchor + **clamp** (shadow) | 0.788 | 0.973 | 0.81× | clamp caps the residual |
+| Final `tint_mix` (shadow) | 0.899 | 0.988 | 0.91× | ×0.45 strength halves it |
+| **Final `tint_mix` (full light field)** | 0.995 | 1.001 | **0.994×** | **−0.61%** |
+| **Final `tint_mix` (Italy map subject)** | 0.981 | 1.004 | **0.977×** | **−2.27% — the map figure** |
+
+**Layer A — geometry + physics (the root cause).** The render surface is an *up-facing* canopy
+shot from *nadir*, and the IBL fill is `albedo · env(cosine-sampled upper hemisphere)`
+([`hybrid_terrain_traversal.wgsl` line 481](../src/shaders/hybrid_terrain_traversal.wgsl),
+orientation `vv = acos(d.y)/π` so row 0 = zenith). So a Lambertian canopy integrates the **sky**.
+For `venice_sunset`, the cosine-weighted up-facing irradiance is **R/B 0.528 (strongly blue)** —
+the vivid sunset orange lives in a narrow horizon band (central 10 of the 64 env rows; R/B 1.905) /
+a few high-radiance texels (saturation × peak-radiance weighted, R/B 14.6) that an up-facing surface
+barely samples. **The light field is blue
+at birth** (lf_all 0.882, shadow 0.463), *before any overlay logic runs.* This was adversarially
+upheld three ways, including against the tracer's own cached output (shadow R/B 0.463 matches
+row0=up, not the flipped 0.963).
+
+**Layer B — the fixed warm-white sun (is the sun dominating? YES).** The only warm term is the
+directional sun `light_color = [I, 0.97·I, 0.92·I]`
+([`render_terrain.rs` line 395](../src/path_tracing/hybrid_compute/render_terrain.rs)), with
+`ambient_color = [0,0,0]` (line 457) and **no `sun_color` parameter on the Python seam**
+([`path_tracing.py` line 877](../python/forge3d/path_tracing.py)). Solving venice's lit-pixel
+chromaticity as a sun/env mix, the fixed sun supplies **~70–80% of the lit-surface chromaticity**
+(an independent least-squares fit lands at **75.9%**; this is a chromaticity estimate, not a raw
+irradiance fraction — the cached RGB is Reinhard-tonemapped,
+[`hybrid_terrain_traversal.wgsl` line 512](../src/shaders/hybrid_terrain_traversal.wgsl)). It
+is *identical for all three HDRs*, so it can never carry sunset-specific colour — it just drags the
+lit majority toward neutral (env 0.528 → lit 0.892).
+
+**Layer C — the colour-fidelity guardrails (which steps neutralise, quantified).** This is where
+the "it's the anchor" hypothesis was close but the mechanism is subtler than "the anchor removes
+the cast":
+
+- The **anchor** (`tint /= median_lit_tint`,
+  [`italy_forest_pt_3d.py` line 303](../examples/forest_cover_copernicus/italy_forest_pt_3d.py))
+  divides out the global cast, pinning the lit majority to `tint≈1` — this is what holds the
+  map-subject colour shift down to **~2.3%** (~0.6% over the full light field). Adversarial
+  counterfactual (anchor disabled): the venice−snow transfer moves **−0.023 → −0.071** over the map
+  subject (**−0.0061 → −0.0639** over the full field; shadow **−0.0894 → −0.0984**), i.e. **removing
+  the anchor makes venice *much bluer*** because its global cast is blue (anchor R/B 0.889). **The
+  anchor is materially *warming* venice, not suppressing warmth.**
+- The **CLAMP `(0.88, 1.12)`**, not the anchor, is the operative governor of what little survives:
+  raw shadow tint **0.444 → 0.787** by the clamp; with vs without the anchor the clamped shadow
+  differs by only **0.0008** R/B (0.7870 vs 0.7862), dropping below 0.0005 only after the
+  0.45-strength mix. Then `LIGHT_TINT_STRENGTH=0.45` halves the residual again (→ 0.899).
+
+**Net:** colour is held to ~2.3% over the map subject (~0.6% over the full light field) *by design*
+(anchor pins lit areas → clamp caps shadows → 0.45 strength halves them), and the ~9% that leaks
+into shadows is venice's true
+**blue**. There is no warmth for any downstream step to reveal — the signal was blue before the
+overlay ever touched it. (*Ordering:* Layer A is the wrong-sign **source**, Layer B the fixed-sun
+**dilution**, Layer C the compose-time **bottleneck** — for "why venice isn't warm" A is primary;
+for "why *any* HDR chroma barely reaches the plate" C is the binding constraint.)
+
+### Two verified corrections to the original framing
+
+1. **The anchor is not the villain.** Deleting/relaxing it (the literal "let the full cast
+   through") makes venice **cooler**, the opposite of the goal.
+2. **`PALETTE_CHROMA_RESTORE = 1.38` is inert in this PT path.** `COMPOSE_POSTER=False` →
+   `_compose_snapshot` takes the branch at
+   [`italy_forest_cover_3d.py` lines 1919–1935](../examples/forest_cover_copernicus/italy_forest_cover_3d.py),
+   which never calls `_restore_palette_chroma_from_source`. That restore lives on the *separate*
+   composer `_render` flow (`_combine_render_passes` at line 2045 → `_compose_clean_palette_with_relief`
+   at 1596–1644), which the PT poster never enters — it is not in `_compose_snapshot`'s poster branch.
+   So it is neither a lever nor a
+   regression risk here; the live "not-too-pale" guards in the PT path are the warm palette itself,
+   `FINAL_MAP_BRIGHTNESS=0.96`, and `HIGHLIGHT_SCALE_CAP=1.06`.
+
+---
+
+## (b) Ranked remediation plan
+
+The key realisation: "mood" splits into two incompatible notions the original brief conflates.
+**"Full physical cast"** (as described) = honest but **blue** for venice. **"Warm sunset look"**
+(what is actually wanted) = an artistic grade toward the env's *dominant warm* chromaticity. The
+plan delivers one `MOOD_STRENGTH ∈ [0,1]` knob (default 0 = byte-identical) with a
+`MOOD_MODE ∈ {grade, cast}` selector so both notions are available; **default `grade`**.
+
+| # | Option | Function / knob | Delivers warm venice? | Dark risk | Pale risk | Effort | Compose-time? |
+|---|---|---|---|---|---|---|---|
+| **1 ✅** | **Env mood-grade (artistic warm)** | `_modulate_overlay` + new `_env_mood_tint(hdr)`; `MOOD_STRENGTH` | **Yes** | low | med* | low | **Yes** |
+| 2 | Un-anchor blend (honest cast) | `_shade_on_overlay_grid` anchor `**(1−k)` + clamp co-scale | No (→ true blue) | med | low | low | Yes |
+| 3 | Upstream trace (sun_color / SUN:ENV ratio) | `render_terrain.rs` + Python seam | No (wrong sign) | med | med | high | **No** |
+| 4 | Naive: widen clamp + raise strength | `LIGHT_TINT_*` constants | No (amplifies blue) | low | low | low | Yes |
+
+`*` pale risk is `med` only for the naive spec; the recommended luminance-preserving + capped
+variant drops it to low.
+
+### ★ RECOMMENDED DEFAULT — Option 1: env mood-grade
+
+In [`_modulate_overlay`](../examples/forest_cover_copernicus/italy_forest_pt_3d.py), multiply the
+plate by `mood_mult = 1 + MOOD_STRENGTH·(mood_tint − 1)`, where `mood_tint` is a new
+`_env_mood_tint(hdr)` reusing `_load_hdr_env`. It is the **only** option that can warm venice,
+because it decouples from the physically-blue fill. Non-negotiable design conditions:
+
+- **Horizon-band extractor, NOT saturation-weighted.** The horizon band (central 10 of the 64 env
+  rows) auto-adapts correctly (venice R/B **1.905**, snow 1.031, brown 1.258); saturation × peak-
+  radiance weighting is pathological (venice 14.6 extreme, **brown 0.847 points cool — wrong way**).
+- **Luminance-preserving** multiply (re-add the luminance delta, as
+  `_restore_palette_chroma_from_source` does at
+  [`italy_forest_cover_3d.py` lines 1244–1248](../examples/forest_cover_copernicus/italy_forest_cover_3d.py))
+  → protects both "not too dark" and "not too pale."
+- **Cap** the warm boost (analogue of `HIGHLIGHT_SCALE_CAP`) so bright cream-sand highlights don't
+  clip toward white (the pale-flake failure).
+- **Grade the legend swatches too** (`_draw_moss_legend`), else the legend↔map read drifts.
+- Default is `0` (off, byte-identical to current); `~0.25–0.35` is the **recommended preset** when
+  mood is wanted. Sweeps under `--reuse-shade` in seconds (a full HDR decode then downsample to 64
+  rows — cheap vs a re-trace; no GPU).
+
+### Option 2 — un-anchor blend (ship as the honest companion mode)
+
+`tint /= anchor**(1 − MOOD_STRENGTH)` with clamp width co-scaled. This is the literal "full cast,"
+and it is worth having, but be clear it delivers venice's **true blue** mood (cooler/darker),
+addresses only Layer C, and is really 2–3 coupled params (the un-anchored blue blows past the
+`1.12` clamp asymmetrically). Guard `k==0` with an explicit branch for byte-identity.
+
+### Option 3 — upstream trace (reject as default)
+
+Wrong sign (lowering sun→env pushes venice toward its blue fill; a warm `sun_color` is then
+stripped by the very anchor that neutralises lit pixels), can't iterate at compose-time (re-trace
+at the 512 MiB ceiling), needs a Rust+PyO3 change patched at **two** sites (`render_terrain.rs:395`
+*and* the ReSTIR dir-light at `:497`), and has a stale-cache footgun (the `.npz` key is HDR-stem
+only, [`italy_forest_pt_3d.py` line 419](../examples/forest_cover_copernicus/italy_forest_pt_3d.py)
+— a sun_color change would silently reuse a stale field). Its only honest niche is subtle warmth
+for already-neutral HDRs.
+
+### Option 4 — naive clamp/strength (reject)
+
+Amplifies the *true* residual, which is blue → venice gets **cooler**; only bites shadows anyway.
+Explicitly the wrong lever.
+
+---
+
+## (c) Verification recipe
+
+**Iterate at compose-time** on the cached fields:
+
+```bash
+# venice vs snow, grade mode, same palette, cached light fields (no GPU)
+.venv/Scripts/python examples/forest_cover_copernicus/italy_forest_pt_3d.py --reuse-shade \
+  --hdr D:/ghsl-population/venice_sunset_4k.hdr --palette swatch \
+  --snapshot examples/out/italy_forest_pt/ab_venice_moodX.png
+.venv/Scripts/python examples/forest_cover_copernicus/italy_forest_pt_3d.py --reuse-shade \
+  --hdr C:/Users/milos/forge3d/assets/hdri/snow_field_1k.hdr --palette swatch \
+  --snapshot examples/out/italy_forest_pt/ab_snow_moodX.png
+```
+
+**Metric** (measure on the masked map subject of the finished PNGs), three gauges:
+
+1. **Mood lands (the target):** shadow-region **R − B** (0–255). Baseline today: venice **56**,
+   snow **57** (venice is −1, i.e. *cooler*). Success: at `MOOD_STRENGTH≈0.3`,
+   **venice_shadow(R−B) − snow_shadow(R−B) ≥ +8**, and monotonically increasing with the knob.
+   (Also check overall R−B, not just shadow, since grade is global.)
+2. **"Not too dark" holds:** mean plate luminance within **±3%** of the `MOOD_STRENGTH=0` render.
+3. **"Not too pale" holds:** fraction of subject pixels with any channel ≥ 250 **does not
+   increase** vs baseline (guards the cream-highlight clip).
+
+*Mask definitions.* The map **subject** = the overlay alpha mask (`alpha > 0`) propagated to poster
+coordinates — NOT a luminance threshold, which would sweep in the title, legend and contact shadows.
+The **shadow** region = subject pixels whose carried `shade ≤ 0.25`; carry the actual `shade` field
+through the same resize as the plate — do **not** approximate it with a darkest-luminance quartile,
+which confounds dark-green forest cover with lighting shadow. Measure R−B under the identical mask
+across variants.
+
+A cheap **predictive** check without rendering (drives Option 1 tuning): on the cached field, the
+finished warm shift ≈ `MOOD_STRENGTH · (mood_tint_R − mood_tint_B)` with `mood_tint` = the
+luminance-normalised horizon-band env colour — venice horizon R/B 1.905 vs snow 1.031 means venice
+gains warmth while snow stays ~neutral by construction. Confirm the *sign* is positive for venice
+before committing a full render.
+
+---
+
+## Appendix — how the numbers were produced
+
+Three pure-numpy harnesses (no forge3d import, no GPU) replicate `_load_hdr_env`,
+`_shade_on_overlay_grid` and `_modulate_overlay` verbatim and read the cached `.npz` light fields:
+
+- **per-stage attenuation budget** — env chromaticity → raw light field (all / lit / shadow) →
+  tint anchor → clamp → `tint_mix`, with venice-vs-snow ratios at each stage (full light field).
+- **cosine-weighted irradiance + mood extractor** — proper up-facing diffuse irradiance colour
+  (confirms venice fill is physically blue) and the saturation-weighted / horizon-band "mood
+  colour" (confirms a warm grade source exists for Option 1).
+- **subject-domain harness** — applies the production bicubic resize to overlay resolution and masks
+  by the overlay alpha, so the Italy map-subject figures are reported separately from the full
+  rectangular light field. All summary means use a `float64` accumulator.
+
+The diagnosis was adversarially red-teamed (7 independent verification/stress agents): the
+"anchor is the sole cause" claim was **refuted** (removing the anchor makes venice bluer); the
+"venice fill is physically blue" claim was **upheld** on three independent lines; and the
+"colour barely changes" money-metric was judged **valid for chroma but incomplete for mood**
+(it omits the achromatic `shade` channel, through which brightness/relief mood *does* transfer).
+
+**Provenance & precision notes.** The cached `.npz` files store only `rgb` and `hit` (no HDR path
+or hash); the HDR each field was traced against is inferred from the filename stem
+(`venice_sunset_4k` → `D:/ghsl-population/venice_sunset_4k.hdr`, distinct from the unused
+`assets/hdri/venice_sunrise_4k.hdr`, whose up-irradiance is R/B **0.598**, not 0.528).
+
+Two audit passes corrected the quantitative claims; the mechanism, causal ordering and the Option 1
+recommendation were unchanged in both. **(1) Accumulator:** an earlier draft used numpy's default
+`float32` accumulator over millions of pixels; all summary means are now `float64` (this moved the
+full-field colour shift 0.17% → 0.61% and the full-field anchor counterfactual −0.0017 → −0.0082 up
+to −0.0061 → −0.0639). **(2) Domain:** "plate-wide" originally meant the **full rectangular light
+field**, 78% of which is transparent no-data; the honest map figure is the **Italy map subject**
+(overlay alpha, after the production bicubic resize). Three domains are now kept distinct — full
+light field, Italy subject, and finished poster. Headline subject values: colour shift **−2.27%**,
+anchor counterfactual **−0.023 → −0.071**, luminance scale **0.857 / 0.890 / 0.912**
+(snow / venice / brown). All figures were independently re-derived and confirmed against the working
+tree.

--- a/docs/superpowers/specs/2026-07-13-general-hdr-terrain-mood-design.md
+++ b/docs/superpowers/specs/2026-07-13-general-hdr-terrain-mood-design.md
@@ -78,7 +78,7 @@ band = environment[start:stop, :, :3]
 
 `apply_luminance_preserving_tint` accepts RGB or RGBA arrays. It blends the supplied tint with identity using `strength`, multiplies RGB, then restores the original Rec.709 luminance by adding the per-pixel luminance delta. Alpha is copied unchanged. A strength of zero returns values identical to the input. Callers grade a completed composition when map and legend colours must remain matched.
 
-Both functions validate shapes, finite inputs, `0 <= strength <= 1`, `0 < horizon_fraction <= 1`, and `max_gain >= 1`. They preserve floating input dtype; integer input is calculated in float and rounded/clipped back to the original integer range.
+Both functions validate shapes, finite inputs, `0 <= strength <= 1`, `0 < horizon_fraction <= 1`, and `max_gain >= 1`. They preserve floating input dtype. The integer round-trip applies only to `apply_luminance_preserving_tint` (computed in float, rounded/clipped back to the original integer range); `environment_mood_tint` returns a float64 tint for integer environments because a colour multiplier has no meaningful integer representation. For floating images `apply_luminance_preserving_tint` clamps the graded RGB to the input dtype's finite range before casting, so extreme-but-finite inputs saturate instead of overflowing to `inf`/`nan`; in-range values are unaffected.
 
 Mood-ordering tests use small synthetic linear-RGB environment arrays with controlled cool, warm, and brown horizon rows. They do not depend on git-ignored HDR files, local caches, or machine-specific paths.
 

--- a/python/forge3d/colors.py
+++ b/python/forge3d/colors.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from typing import List, Tuple
 
+import numpy as np
+
 
 def hex_to_rgb(hex_color: str) -> Tuple[int, int, int]:
     """Convert hex color to RGB tuple (0-255 range).
@@ -54,11 +56,170 @@ def hex_to_rgba(hex_color: str, alpha: float = 1.0) -> List[float]:
 
 def rgb_to_normalized(rgb: Tuple[int, int, int]) -> List[float]:
     """Convert RGB (0-255) to normalized (0.0-1.0) values.
-    
+
     Args:
         rgb: Tuple of (R, G, B) values in 0-255 range
-        
+
     Returns:
         List of [R, G, B] values in 0.0-1.0 range
     """
     return [rgb[0] / 255.0, rgb[1] / 255.0, rgb[2] / 255.0]
+
+
+# Rec.709 luminance weights (sum to exactly 1.0 in float64), shared by the
+# opt-in environment mood-grade utilities below.
+_REC709_WEIGHTS = np.array([0.2126, 0.7152, 0.0722], dtype=np.float64)
+
+
+def environment_mood_tint(
+    environment: "np.ndarray",
+    *,
+    horizon_fraction: float = 10 / 64,
+    max_gain: float = 1.25,
+) -> "np.ndarray":
+    """Derive an artistic mood tint from an HDR environment's horizon band.
+
+    This is an OPT-IN, renderer-independent utility. It never touches the
+    environment the path tracer samples and never triggers a re-trace. It
+    exists because physically correct environment lighting does not necessarily
+    express the artistic mood of an HDR: a sunset's warm colour is concentrated
+    near the horizon, while an up-facing surface integrates the (often blue)
+    sky. The returned tint is the horizon band's chromaticity, normalized to
+    unit luminance, for use as a colour multiplier by
+    :func:`apply_luminance_preserving_tint`.
+
+    Args:
+        environment: Linear-RGB environment array, shape ``(H, W, >=3)``.
+        horizon_fraction: Fraction of ``H`` (rows) forming the central horizon
+            band. Must be in ``(0, 1]``.
+        max_gain: Per-channel clamp on the returned multiplier, applied
+            symmetrically as ``[1 / max_gain, max_gain]``. Must be ``>= 1``.
+
+    Returns:
+        A length-3 multiplier in the environment's floating dtype (float16/32/
+        64); integer or other environments yield a float64 tint. If the band's
+        Rec.709 luminance is ``<= 1e-12`` (a near-black band), returns the
+        identity ``[1, 1, 1]``.
+
+    The band is fixed as::
+
+        band_height = max(1, min(H, round(horizon_fraction * H)))  # ties-to-even
+        start = (H - band_height) // 2
+        stop = start + band_height  # exclusive
+
+    The band mean uses a float64 accumulator. This deliberately does NOT use
+    saturation or peak-radiance weighting, which gives the wrong sign for valid
+    brown environments.
+    """
+    if not np.isfinite(horizon_fraction) or not (0.0 < float(horizon_fraction) <= 1.0):
+        raise ValueError(f"horizon_fraction must be in (0, 1], got {horizon_fraction!r}")
+    if not np.isfinite(max_gain) or not (float(max_gain) >= 1.0):
+        raise ValueError(f"max_gain must be >= 1, got {max_gain!r}")
+
+    env = np.asarray(environment)
+    if env.ndim != 3 or env.shape[2] < 3:
+        raise ValueError(f"environment must be (H, W, >=3), got shape {env.shape}")
+    if env.shape[0] == 0 or env.shape[1] == 0:
+        # Empty spatial axes have no horizon band; the mean would be NaN.
+        raise ValueError(f"environment must have non-empty H and W, got shape {env.shape}")
+    if not np.isfinite(env).all():
+        raise ValueError("environment contains non-finite samples")
+
+    # The tint preserves a floating input dtype (float16/32/64); integer or
+    # other environments yield a float64 tint (a multiplier has no meaningful
+    # integer round-trip). The band mean itself always accumulates in float64.
+    out_dtype = env.dtype if np.issubdtype(env.dtype, np.floating) else np.float64
+
+    height = int(env.shape[0])
+    band_height = max(1, min(height, round(horizon_fraction * height)))
+    start = (height - band_height) // 2
+    stop = start + band_height
+    band = np.asarray(env[start:stop, :, :3], dtype=np.float64)
+    mean_rgb = band.mean(axis=(0, 1))
+
+    lum = float(np.dot(mean_rgb, _REC709_WEIGHTS))
+    if lum <= 1e-12:
+        return np.ones(3, dtype=out_dtype)
+    tint = np.clip(mean_rgb / lum, 1.0 / float(max_gain), float(max_gain))
+    return tint.astype(out_dtype)
+
+
+def apply_luminance_preserving_tint(
+    image: "np.ndarray",
+    tint: "np.ndarray",
+    *,
+    strength: float = 0.0,
+) -> "np.ndarray":
+    """Apply a luminance-preserving colour tint to a completed RGB(A) image.
+
+    This is a POST-render artistic operation. Callers grade a finished
+    composition (so map and legend colours stay matched) rather than changing
+    physical lighting. The tint is blended with identity by ``strength``,
+    multiplied into RGB, then the original Rec.709 luminance is restored by
+    adding the per-pixel luminance delta. Alpha is copied unchanged. A
+    ``strength`` of zero returns values identical to the input.
+
+    Args:
+        image: RGB ``(H, W, 3)`` or RGBA ``(H, W, 4)`` array. Floating dtype is
+            preserved, with graded RGB clamped to the dtype's finite range (so
+            extreme inputs saturate instead of overflowing to ``inf``);
+            integer dtype is computed in float and rounded/clipped back to its
+            original integer range.
+        tint: Length-3 colour multiplier (e.g. from
+            :func:`environment_mood_tint`).
+        strength: Blend amount in ``[0, 1]``.
+
+    Returns:
+        The graded image, same shape and dtype as ``image``.
+    """
+    if not np.isfinite(strength) or not (0.0 <= float(strength) <= 1.0):
+        raise ValueError(f"strength must be in [0, 1], got {strength!r}")
+
+    img = np.asarray(image)
+    if img.ndim != 3 or img.shape[2] not in (3, 4):
+        raise ValueError(f"image must be (H, W, 3) or (H, W, 4), got shape {img.shape}")
+    if not np.isfinite(img).all():
+        raise ValueError("image contains non-finite samples")
+
+    tint_arr = np.asarray(tint, dtype=np.float64)
+    if tint_arr.shape != (3,):
+        raise ValueError(f"tint must have exactly three components, got shape {tint_arr.shape}")
+    if not np.isfinite(tint_arr).all():
+        raise ValueError("tint contains non-finite values")
+
+    if float(strength) == 0.0:
+        return img.copy()
+
+    in_dtype = img.dtype
+    rgb = img[..., :3].astype(np.float64)
+    mix = 1.0 + float(strength) * (tint_arr - 1.0)
+    # The tint+restore pipeline is homogeneous in `rgb`, so inputs near the
+    # float64 maximum are computed on a power-of-two downscale (exact in
+    # binary floating point — identical bits for every in-range input) to keep
+    # the intermediates finite, then scaled back.
+    peak = float(np.abs(rgb).max()) if rgb.size else 0.0
+    scale = 2.0 ** (int(np.ceil(np.log2(peak))) - 500) if peak > 2.0**500 else 1.0
+    work = rgb / scale
+    lum0 = work @ _REC709_WEIGHTS
+    tinted = work * mix
+    lum1 = tinted @ _REC709_WEIGHTS
+    tinted = tinted + (lum0 - lum1)[..., None]
+    if scale != 1.0:
+        # Saturate in the scaled domain (exact power-of-two bounds) so the
+        # scale-back multiply cannot overflow to inf (or warn).
+        limit = np.finfo(np.float64).max / scale
+        tinted = np.clip(tinted, -limit, limit) * scale
+
+    out = img.astype(np.float64)
+    out[..., :3] = tinted
+    # Alpha (if present) is already carried through `out` unchanged.
+
+    if np.issubdtype(in_dtype, np.integer):
+        info = np.iinfo(in_dtype)
+        return np.clip(np.rint(out), info.min, info.max).astype(in_dtype)
+    # Floating range policy: graded RGB is clamped to the input dtype's finite
+    # range so a narrower cast (or a scaled-back near-max float64 value)
+    # cannot produce inf. In-range values pass through bit-identically.
+    finfo = np.finfo(in_dtype)
+    out[..., :3] = np.clip(out[..., :3], float(finfo.min), float(finfo.max))
+    return out.astype(in_dtype)

--- a/src/formats/exr.rs
+++ b/src/formats/exr.rs
@@ -1,0 +1,277 @@
+//! OpenEXR environment decoder.
+//!
+//! Decodes an EXR image into the same linear-RGB [`HdrImage`] representation
+//! the Radiance loader produces, so `IBL.from_hdr` can accept `.exr` files.
+//! Gated behind the `images` feature (enabled by default); the feature-off
+//! build returns an explicit feature-required error rather than failing
+//! silently.
+
+use super::hdr::HdrImage;
+use crate::core::error::{RenderError, RenderResult};
+use std::path::Path;
+
+/// Load an OpenEXR environment map into the same linear-RGB [`HdrImage`]
+/// representation the Radiance loader produces.
+///
+/// Reads the first flat layer and maps channels by their EXACT OpenEXR channel
+/// names `R`, `G`, and `B`, independent of their storage order; any other
+/// channel (e.g. `A`, `Z`, depth AOVs) is ignored. All three colour channels
+/// are required. Sample data is converted per OpenEXR pixel type
+/// (`F16 -> to_f32()`, `F32` copied, `U32 -> as f32`) and interleaved in
+/// row-major RGB order.
+#[cfg(feature = "images")]
+pub fn load_exr<P: AsRef<Path>>(path: P) -> RenderResult<HdrImage> {
+    use exr::prelude::{read_first_flat_layer_from_file, FlatSamples};
+
+    let path = path.as_ref();
+    let image = read_first_flat_layer_from_file(path).map_err(|e| {
+        RenderError::io(format!(
+            "Failed to read EXR file '{}': {}",
+            path.display(),
+            e
+        ))
+    })?;
+
+    let width = image.layer_data.size.width();
+    let height = image.layer_data.size.height();
+    if width == 0 || height == 0 {
+        return Err(RenderError::upload(
+            "EXR image dimensions cannot be zero".to_string(),
+        ));
+    }
+    let pixel_count = width
+        .checked_mul(height)
+        .ok_or_else(|| RenderError::upload("EXR image dimensions overflow".to_string()))?;
+
+    // FlatSamples is exhaustive over F16/F32/U32; all three are supported.
+    let to_f32 = |samples: &FlatSamples| -> Vec<f32> {
+        match samples {
+            FlatSamples::F16(s) => s.iter().map(|x| x.to_f32()).collect(),
+            FlatSamples::F32(s) => s.clone(),
+            FlatSamples::U32(s) => s.iter().map(|x| *x as f32).collect(),
+        }
+    };
+
+    let mut r: Option<Vec<f32>> = None;
+    let mut g: Option<Vec<f32>> = None;
+    let mut b: Option<Vec<f32>> = None;
+    for channel in &image.layer_data.channel_data.list {
+        match channel.name.to_string().as_str() {
+            "R" => r = Some(to_f32(&channel.sample_data)),
+            "G" => g = Some(to_f32(&channel.sample_data)),
+            "B" => b = Some(to_f32(&channel.sample_data)),
+            _ => {}
+        }
+    }
+
+    let (r, g, b) = match (r, g, b) {
+        (Some(r), Some(g), Some(b)) => (r, g, b),
+        _ => {
+            return Err(RenderError::upload(format!(
+                "EXR file '{}' is missing one of the required R, G, B channels",
+                path.display()
+            )))
+        }
+    };
+    if r.len() != pixel_count || g.len() != pixel_count || b.len() != pixel_count {
+        return Err(RenderError::upload(format!(
+            "EXR channel sample counts do not match {}x{} dimensions",
+            width, height
+        )));
+    }
+
+    let mut data = Vec::with_capacity(pixel_count * 3);
+    for i in 0..pixel_count {
+        data.push(r[i]);
+        data.push(g[i]);
+        data.push(b[i]);
+    }
+
+    Ok(HdrImage {
+        width: width as u32,
+        height: height as u32,
+        data,
+    })
+}
+
+/// EXR decoding requires the `images` feature (enabled by the default feature
+/// set). This stub keeps builds compiled without `images` working and returns
+/// an explicit feature-required error instead of silently failing.
+#[cfg(not(feature = "images"))]
+pub fn load_exr<P: AsRef<Path>>(path: P) -> RenderResult<HdrImage> {
+    let _ = path.as_ref();
+    Err(RenderError::upload(
+        "EXR environment decoding requires the 'images' feature, which was \
+         disabled in this build"
+            .to_string(),
+    ))
+}
+
+/// EXR decoder tests: minimal deterministic fixtures with shuffled channel
+/// storage order and ignored extra channels, across F16/F32/U32 sample types.
+#[cfg(all(test, feature = "images"))]
+mod exr_tests {
+    use super::*;
+    use exr::prelude::*;
+    use half::f16;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn tmp_exr(name: &str) -> std::path::PathBuf {
+        let mut p = std::env::temp_dir();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before unix epoch")
+            .as_nanos();
+        p.push(format!(
+            "forge3d_exr_{name}_{}_{}.exr",
+            std::process::id(),
+            nonce
+        ));
+        p
+    }
+
+    /// Write an EXR from (name, samples) channels in arbitrary INSERTION order.
+    /// `AnyChannels::sort` normalizes on-disk order alphabetically, so a decoder
+    /// that keyed off storage order would mislabel the channels — this exercises
+    /// the loader's name-based, order-independent mapping.
+    fn write_exr_channels(
+        path: &Path,
+        width: usize,
+        height: usize,
+        channels: Vec<(&str, FlatSamples)>,
+    ) {
+        let mut list = SmallVec::<[AnyChannel<FlatSamples>; 4]>::new();
+        for (name, samples) in channels {
+            list.push(AnyChannel {
+                name: Text::new_or_none(name).expect("valid channel name"),
+                sample_data: samples,
+                quantize_linearly: false,
+                sampling: Vec2(1, 1),
+            });
+        }
+        let channels = AnyChannels::sort(list);
+        let image = Image::from_channels((width, height), channels);
+        image.write().to_file(path).expect("write exr fixture");
+    }
+
+    #[test]
+    fn f32_shuffled_order_ignores_extra_channels() {
+        let r = [0.1f32, 0.2, 0.3, 0.4];
+        let g = [0.5f32, 0.6, 0.7, 0.8];
+        let b = [0.9f32, 1.0, 1.1, 1.2];
+        let path = tmp_exr("f32_shuffled");
+        // Insertion order B, Z, R, A, G; on-disk sorted A,B,G,R,Z — R,G,B are
+        // neither first nor contiguous.
+        write_exr_channels(
+            &path,
+            2,
+            2,
+            vec![
+                ("B", FlatSamples::F32(b.to_vec())),
+                ("Z", FlatSamples::F32(vec![9.0, 9.0, 9.0, 9.0])),
+                ("R", FlatSamples::F32(r.to_vec())),
+                ("A", FlatSamples::F32(vec![1.0, 1.0, 1.0, 1.0])),
+                ("G", FlatSamples::F32(g.to_vec())),
+            ],
+        );
+        let img = load_exr(&path).expect("decode f32 exr");
+        std::fs::remove_file(&path).ok();
+        assert_eq!((img.width, img.height), (2, 2));
+        let mut expected = Vec::new();
+        for i in 0..4 {
+            expected.push(r[i]);
+            expected.push(g[i]);
+            expected.push(b[i]);
+        }
+        assert_eq!(img.data, expected);
+    }
+
+    #[test]
+    fn f16_samples_shuffled_order() {
+        let r = [0.25f32, 0.5, 0.75, 1.0];
+        let g = [0.125f32, 0.25, 0.375, 0.5];
+        let b = [1.5f32, 2.0, 2.5, 3.0];
+        let half = |xs: &[f32]| FlatSamples::F16(xs.iter().map(|&x| f16::from_f32(x)).collect());
+        let path = tmp_exr("f16");
+        write_exr_channels(
+            &path,
+            2,
+            2,
+            vec![("G", half(&g)), ("B", half(&b)), ("R", half(&r))],
+        );
+        let img = load_exr(&path).expect("decode f16 exr");
+        std::fs::remove_file(&path).ok();
+        assert_eq!((img.width, img.height), (2, 2));
+        // These values are exactly half-representable, so the conversion is
+        // lossless: compare against the same F16->f32 round-trip.
+        for i in 0..4 {
+            assert_eq!(img.data[i * 3], f16::from_f32(r[i]).to_f32());
+            assert_eq!(img.data[i * 3 + 1], f16::from_f32(g[i]).to_f32());
+            assert_eq!(img.data[i * 3 + 2], f16::from_f32(b[i]).to_f32());
+        }
+    }
+
+    #[test]
+    fn u32_samples_shuffled_order() {
+        let r = [0u32, 1, 2, 3];
+        let g = [10u32, 20, 30, 40];
+        let b = [100u32, 200, 300, 400];
+        let path = tmp_exr("u32");
+        write_exr_channels(
+            &path,
+            2,
+            2,
+            vec![
+                ("B", FlatSamples::U32(b.to_vec())),
+                ("R", FlatSamples::U32(r.to_vec())),
+                ("G", FlatSamples::U32(g.to_vec())),
+            ],
+        );
+        let img = load_exr(&path).expect("decode u32 exr");
+        std::fs::remove_file(&path).ok();
+        assert_eq!((img.width, img.height), (2, 2));
+        for i in 0..4 {
+            assert_eq!(img.data[i * 3], r[i] as f32);
+            assert_eq!(img.data[i * 3 + 1], g[i] as f32);
+            assert_eq!(img.data[i * 3 + 2], b[i] as f32);
+        }
+    }
+
+    #[test]
+    fn missing_channel_is_an_error() {
+        let path = tmp_exr("missing_b");
+        write_exr_channels(
+            &path,
+            2,
+            2,
+            vec![
+                ("R", FlatSamples::F32(vec![0.1, 0.2, 0.3, 0.4])),
+                ("G", FlatSamples::F32(vec![0.5, 0.6, 0.7, 0.8])),
+            ],
+        );
+        let err = load_exr(&path).unwrap_err();
+        std::fs::remove_file(&path).ok();
+        assert!(
+            format!("{err}").contains("missing"),
+            "expected missing-channel error, got: {err}"
+        );
+    }
+}
+
+/// Feature-off contract: without `images`, `load_exr` returns an explicit
+/// feature-required error. The normal CI matrix always enables `images`, so
+/// this branch is only reachable under `cargo test --no-default-features`.
+#[cfg(all(test, not(feature = "images")))]
+mod exr_feature_off_tests {
+    use super::*;
+
+    #[test]
+    fn load_exr_requires_images_feature() {
+        let err = load_exr("nonexistent.exr").unwrap_err();
+        let msg = format!("{err}");
+        assert!(
+            msg.contains("images"),
+            "expected feature-required error, got: {msg}"
+        );
+    }
+}

--- a/src/formats/hdr.rs
+++ b/src/formats/hdr.rs
@@ -340,4 +340,43 @@ mod tests {
 
         assert_eq!(rgba, expected);
     }
+
+    #[test]
+    fn load_hdr_uncompressed_round_trip_dims_and_values() {
+        use std::io::Write;
+        use std::time::{SystemTime, UNIX_EPOCH};
+
+        let mut path = std::env::temp_dir();
+        let nonce = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("clock before unix epoch")
+            .as_nanos();
+        path.push(format!(
+            "forge3d_hdr_radiance_{}_{}.hdr",
+            std::process::id(),
+            nonce
+        ));
+        {
+            let mut f = File::create(&path).expect("create radiance fixture");
+            // 4x2, width < 8 avoids the new-style RLE path (first byte 128 != 2
+            // also forces the uncompressed scanline branch).
+            f.write_all(b"#?RADIANCE\nFORMAT=32-bit_rle_rgbe\n\n-Y 2 +X 4\n")
+                .unwrap();
+            let px = [128u8, 64, 32, 129]; // e=129 -> 2^(129-128-8) = 2^-7
+            for _ in 0..(4 * 2) {
+                f.write_all(&px).unwrap();
+            }
+        }
+        let img = load_hdr(&path).expect("decode radiance fixture");
+        std::fs::remove_file(&path).ok();
+
+        assert_eq!((img.width, img.height), (4, 2));
+        assert_eq!(img.data.len(), 4 * 2 * 3);
+        let exp = 2.0f32.powi(129 - 128 - 8);
+        for i in 0..(4 * 2) {
+            assert!((img.data[i * 3] - 128.0 * exp).abs() < 1e-6);
+            assert!((img.data[i * 3 + 1] - 64.0 * exp).abs() < 1e-6);
+            assert!((img.data[i * 3 + 2] - 32.0 * exp).abs() < 1e-6);
+        }
+    }
 }

--- a/src/formats/mod.rs
+++ b/src/formats/mod.rs
@@ -2,9 +2,12 @@
 //!
 //! Supports loading various image formats for texture and HDR usage.
 
-// L6: HDR (Radiance) format loader
+// L6: Radiance HDR (.hdr/.rgbe) format loader.
 pub mod hdr;
 pub use hdr::{load_hdr, HdrImage};
 
-// L6: Optional EXR format loader (feature-gated)
-// EXR support is planned but not yet implemented
+// OpenEXR (.exr) environment decoder. `load_exr` is compiled in every build:
+// with the default `images` feature it decodes EXR, and without it returns an
+// explicit feature-required error.
+pub mod exr;
+pub use exr::load_exr;

--- a/src/lighting/ibl_wrapper.rs
+++ b/src/lighting/ibl_wrapper.rs
@@ -88,8 +88,27 @@ impl IBL {
             }
         };
 
-        // Load HDR image
-        let hdr_image = crate::formats::hdr::load_hdr(path).map_err(|e| {
+        // Load the environment map, dispatching by file extension so the
+        // documented .hdr/.rgbe/.exr contract holds. The loader returns a
+        // RenderError; wrap it MANUALLY with PyIOError (not `?` through the
+        // generic From<RenderError>, which would surface I/O failures as
+        // PyRuntimeError — the wrong type for a file-load error).
+        let ext = Path::new(path)
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| e.to_ascii_lowercase())
+            .unwrap_or_default();
+        let hdr_image = match ext.as_str() {
+            "hdr" | "rgbe" => crate::formats::load_hdr(path),
+            "exr" => crate::formats::load_exr(path),
+            other => {
+                return Err(pyo3::exceptions::PyIOError::new_err(format!(
+                    "Unsupported environment map format '.{}' for '{}': expected .hdr, .rgbe, or .exr",
+                    other, path
+                )));
+            }
+        }
+        .map_err(|e| {
             pyo3::exceptions::PyIOError::new_err(format!(
                 "Failed to load HDR file '{}': {}",
                 path, e

--- a/tests/test_colors_mood.py
+++ b/tests/test_colors_mood.py
@@ -1,0 +1,245 @@
+# tests/test_colors_mood.py
+# Slice 2 of the 2026-07-13 HDR terrain mood design: opt-in, renderer-
+# independent environment mood-grade utilities in forge3d.colors.
+#
+# All fixtures are small SYNTHETIC linear-RGB arrays — no HDR files, caches, or
+# machine-specific paths. These lock the exact horizon rows, identity
+# fallbacks, cool/warm/brown ordering, strength-zero identity, luminance
+# preservation before output clipping, unchanged alpha, bounded gains, and the
+# integer-dtype round-trip (rounding, clipping, return dtype).
+
+import numpy as np
+import pytest
+
+from forge3d.colors import apply_luminance_preserving_tint, environment_mood_tint
+
+# Rec.709 weights (sum to exactly 1.0) shared with the implementation.
+W = np.array([0.2126, 0.7152, 0.0722], dtype=np.float64)
+
+
+# ---------------------------------------------------------------------------
+# environment_mood_tint
+# ---------------------------------------------------------------------------
+def test_horizon_band_uses_only_central_rows():
+    # H=64 -> band_height=round(10/64*64)=10, start=(64-10)//2=27, stop=37.
+    H, Wd = 64, 8
+    env = np.zeros((H, Wd, 3), dtype=np.float64)
+    env[:, :, 2] = 10.0  # strong blue fill would dominate a full-image mean
+    band = slice(27, 37)
+    env[band, :, :] = 0.0
+    env[band, :, 0] = 2.0  # pure red horizon band
+
+    tint = environment_mood_tint(env)
+    assert tint[0] > tint[2], "tint must reflect the warm band, not the blue fill"
+
+    mean = env[band, :, :3].astype(np.float64).mean(axis=(0, 1))
+    lum = float(mean @ W)
+    expected = np.clip(mean / lum, 1.0 / 1.25, 1.25)
+    assert np.allclose(tint, expected)
+
+
+def test_band_boundaries_are_exact():
+    # Poisoning the rows immediately adjacent to [27, 37) must not leak in.
+    H, Wd = 64, 4
+    env = np.zeros((H, Wd, 3), dtype=np.float64)
+    env[27:37, :, :] = 1.0  # neutral grey band -> identity tint
+    env[26, :, 0] = 1000.0  # just above the band
+    env[37, :, 2] = 1000.0  # just below the band (stop is exclusive)
+
+    tint = environment_mood_tint(env)
+    assert np.allclose(tint, [1.0, 1.0, 1.0], atol=1e-9)
+
+
+def test_near_black_band_returns_identity():
+    env = np.zeros((64, 4, 3), dtype=np.float64)
+    env[27:37, :, :] = 1e-15  # band luminance below the 1e-12 floor
+    tint = environment_mood_tint(env)
+    assert np.array_equal(tint, np.array([1.0, 1.0, 1.0]))
+
+
+def test_cool_warm_brown_ordering():
+    def band_tint(rgb):
+        env = np.zeros((64, 4, 3), dtype=np.float64)
+        env[27:37, :, :] = rgb
+        # max_gain high enough that the clamp does not saturate the ordering.
+        return environment_mood_tint(env, max_gain=4.0)
+
+    warm = band_tint([1.0, 0.5, 0.2])   # R >> B
+    brown = band_tint([0.5, 0.35, 0.25])  # mildly warm
+    cool = band_tint([0.2, 0.5, 1.0])   # B >> R
+
+    warm_rb = warm[0] - warm[2]
+    brown_rb = brown[0] - brown[2]
+    cool_rb = cool[0] - cool[2]
+    assert warm_rb > brown_rb > cool_rb
+    assert warm[0] > warm[2], "warm horizon must read warm"
+    assert cool[0] < cool[2], "cool horizon must read cool"
+
+
+def test_tint_gains_are_bounded():
+    env = np.zeros((64, 4, 3), dtype=np.float64)
+    env[27:37, :, 0] = 5.0  # extreme warm would blow past the gain cap
+    tint = environment_mood_tint(env, max_gain=1.25)
+    assert np.all(tint <= 1.25 + 1e-12)
+    assert np.all(tint >= 1.0 / 1.25 - 1e-12)
+
+
+def test_environment_mood_tint_validation():
+    env = np.zeros((8, 8, 3), dtype=np.float64)
+    with pytest.raises(ValueError):
+        environment_mood_tint(env, horizon_fraction=0.0)
+    with pytest.raises(ValueError):
+        environment_mood_tint(env, horizon_fraction=1.5)
+    with pytest.raises(ValueError):
+        environment_mood_tint(env, max_gain=0.5)
+    with pytest.raises(ValueError):
+        environment_mood_tint(np.zeros((8, 8), dtype=np.float64))  # not 3D
+    with pytest.raises(ValueError):
+        environment_mood_tint(np.zeros((8, 8, 2), dtype=np.float64))  # <3 channels
+    with pytest.raises(ValueError):
+        environment_mood_tint(np.full((8, 8, 3), np.nan, dtype=np.float64))
+    # Empty spatial axes have no band; must be rejected, not return NaNs.
+    with pytest.raises(ValueError):
+        environment_mood_tint(np.zeros((0, 8, 3), dtype=np.float64))
+    with pytest.raises(ValueError):
+        environment_mood_tint(np.zeros((8, 0, 3), dtype=np.float64))
+
+
+def test_environment_mood_tint_preserves_floating_dtype():
+    def make(dtype):
+        env = np.zeros((64, 4, 3), dtype=dtype)
+        env[27:37, :, 0] = 1.0  # warm band
+        return environment_mood_tint(env)
+
+    for dtype in (np.float16, np.float32, np.float64):
+        tint = make(dtype)
+        assert tint.dtype == dtype, f"{dtype} not preserved (got {tint.dtype})"
+        assert tint[0] > tint[2]
+    # Integer environments have no floating dtype to preserve -> float64 tint.
+    env_i = np.zeros((64, 4, 3), dtype=np.uint8)
+    env_i[27:37, :, 0] = 200
+    tint_i = environment_mood_tint(env_i)
+    assert tint_i.dtype == np.float64
+    assert tint_i[0] > tint_i[2]
+
+
+def test_environment_mood_tint_accepts_rgba_and_ignores_alpha():
+    env = np.zeros((64, 4, 4), dtype=np.float64)
+    env[27:37, :, 0] = 1.0
+    env[:, :, 3] = 999.0  # alpha must be ignored (slice is [..., :3])
+    tint = environment_mood_tint(env)
+    assert tint.shape == (3,)
+    assert tint[0] > tint[2]
+
+
+# ---------------------------------------------------------------------------
+# apply_luminance_preserving_tint
+# ---------------------------------------------------------------------------
+def test_strength_zero_is_identity_copy():
+    img = (np.arange(5 * 7 * 4, dtype=np.float32).reshape(5, 7, 4) / 100.0)
+    out = apply_luminance_preserving_tint(img, [1.5, 0.8, 0.9], strength=0.0)
+    assert out.dtype == img.dtype
+    assert np.array_equal(out, img)
+    assert out is not img  # a copy, not the same buffer
+
+
+def test_luminance_preserved_before_output_clipping():
+    rng = np.random.default_rng(1)
+    img = rng.random((6, 6, 3)).astype(np.float64) * 2.0  # HDR-ish, may exceed 1
+    tint = np.array([1.4, 0.9, 0.7])
+    out = apply_luminance_preserving_tint(img, tint, strength=0.6)
+    lum_in = img @ W
+    lum_out = out @ W
+    assert np.allclose(lum_in, lum_out, atol=1e-9), "luminance must be preserved"
+    assert not np.allclose(out, img), "the tint must actually change chroma"
+
+
+def test_alpha_is_copied_unchanged():
+    img = np.zeros((3, 3, 4), dtype=np.float64)
+    img[..., :3] = 0.5
+    img[..., 3] = np.linspace(0.0, 1.0, 9).reshape(3, 3)
+    out = apply_luminance_preserving_tint(img, [1.3, 0.8, 0.9], strength=0.5)
+    assert np.array_equal(out[..., 3], img[..., 3])
+
+
+def test_integer_dtype_round_trip():
+    img = np.array([[[100, 150, 200], [10, 20, 30]]], dtype=np.uint8)
+    tint = np.array([1.3, 1.0, 0.7])
+    out = apply_luminance_preserving_tint(img, tint, strength=0.5)
+
+    assert out.dtype == np.uint8
+    assert out.min() >= 0 and out.max() <= 255
+
+    rgb = img[..., :3].astype(np.float64)
+    mix = 1.0 + 0.5 * (tint - 1.0)
+    lum0 = rgb @ W
+    tinted = rgb * mix
+    lum1 = tinted @ W
+    tinted = tinted + (lum0 - lum1)[..., None]
+    expected = np.clip(np.rint(tinted), 0, 255).astype(np.uint8)
+    assert np.array_equal(out, expected)
+
+
+def test_integer_clipping_saturates_not_wraps():
+    # A bright pixel pushed past 255 by a warm tint must SATURATE to 255, not
+    # wrap around (uint8(303) would wrap to 47). uint8 output is trivially in
+    # 0-255 even on wraparound, so assert the exact saturated pixel instead.
+    img = np.full((1, 1, 3), 250, dtype=np.uint8)
+    out = apply_luminance_preserving_tint(img, [1.25, 1.0, 0.8], strength=1.0)
+    assert out.dtype == np.uint8
+    # R is ~303 before clipping: it must saturate to 255, not wrap to 47.
+    assert out[0, 0, 0] == 255
+    assert out[0, 0, 0] != 47
+    assert np.array_equal(out[0, 0], np.array([255, 240, 190], dtype=np.uint8))
+
+
+def test_extreme_floating_values_stay_finite():
+    # Every channel at the dtype's finite maximum with a >1 tint used to
+    # overflow: float16/float32 on the narrowing cast, float64 in the float64
+    # intermediates (inf - inf -> nan). Finite input must yield finite output,
+    # saturated to the input dtype's finite range.
+    tint = np.array([1.25, 0.8, 0.8])
+    for dtype in (np.float16, np.float32, np.float64):
+        finfo = np.finfo(dtype)
+        img = np.full((2, 2, 3), finfo.max, dtype=dtype)
+        out = apply_luminance_preserving_tint(img, tint, strength=1.0)
+        assert out.dtype == dtype
+        assert np.isfinite(out).all(), f"{dtype} produced non-finite output: {out[0, 0]}"
+        assert np.all(np.abs(out) <= finfo.max)
+        # The saturating channel clamps to the dtype maximum, not below it.
+        assert out[0, 0, 0] == finfo.max
+
+
+def test_extreme_value_path_is_bit_identical_for_normal_inputs():
+    # The overflow guards (power-of-two downscale + finite-range clamp) must
+    # be inert for ordinary HDR-range inputs: same bits as the plain formula.
+    rng = np.random.default_rng(7)
+    img = (rng.random((5, 5, 3)) * 4.0).astype(np.float32)
+    tint = np.array([1.4, 0.9, 0.7])
+    out = apply_luminance_preserving_tint(img, tint, strength=0.6)
+
+    rgb = img.astype(np.float64)
+    mix = 1.0 + 0.6 * (tint - 1.0)
+    lum0 = rgb @ W
+    tinted = rgb * mix
+    lum1 = tinted @ W
+    expected = (tinted + (lum0 - lum1)[..., None]).astype(np.float32)
+    assert np.array_equal(out, expected)
+
+
+def test_apply_tint_validation():
+    img = np.zeros((4, 4, 3), dtype=np.float64)
+    with pytest.raises(ValueError):
+        apply_luminance_preserving_tint(img, [1.0, 1.0], strength=0.5)  # tint len 2
+    with pytest.raises(ValueError):
+        apply_luminance_preserving_tint(img, [1.0, 1.0, 1.0], strength=1.5)  # strength>1
+    with pytest.raises(ValueError):
+        apply_luminance_preserving_tint(img, [1.0, 1.0, 1.0], strength=-0.1)
+    with pytest.raises(ValueError):
+        apply_luminance_preserving_tint(np.zeros((4, 4, 2)), [1, 1, 1], strength=0.5)
+    with pytest.raises(ValueError):
+        apply_luminance_preserving_tint(np.zeros((4, 4)), [1, 1, 1], strength=0.5)
+    with pytest.raises(ValueError):
+        apply_luminance_preserving_tint(
+            np.full((4, 4, 3), np.nan), [1, 1, 1], strength=0.5
+        )

--- a/tests/test_ibl_from_hdr_formats.py
+++ b/tests/test_ibl_from_hdr_formats.py
@@ -1,0 +1,152 @@
+# tests/test_ibl_from_hdr_formats.py
+# Slice 3 of the 2026-07-13 HDR terrain mood design: IBL.from_hdr must honour
+# its documented .hdr / .rgbe / .exr contract by dispatching the loader on the
+# file extension, and reject unsupported extensions with an I/O error.
+#
+# IBL.from_hdr decodes and stores the environment image WITHOUT touching the
+# GPU (prefiltering is lazy), so these run without a rendering device. Value
+# correctness of the EXR decode is locked by the Rust tests in
+# src/formats/hdr.rs; here we lock the Python-visible extension dispatch.
+#
+# No EXR writer library ships in the test env and forge3d exposes no plain
+# R/G/B EXR writer, so we author a minimal uncompressed OpenEXR (FLOAT samples,
+# channels named exactly R/G/B) in pure Python.
+
+import struct
+
+import numpy as np
+import pytest
+
+import forge3d as f3d
+
+pytestmark = pytest.mark.skipif(
+    not hasattr(f3d, "IBL"), reason="native IBL not available"
+)
+
+
+def _write_radiance(path, width=8, height=4):
+    with open(path, "wb") as fh:
+        fh.write(b"#?RADIANCE\nFORMAT=32-bit_rle_rgbe\n\n")
+        fh.write(f"-Y {height} +X {width}\n".encode())
+        # First byte 128 (!= 2) forces the uncompressed scanline branch.
+        fh.write(bytes([128, 128, 128, 128]) * (width * height))
+
+
+def _write_minimal_exr(path, width, height, channels):
+    """Write an uncompressed single-part scanline OpenEXR with FLOAT samples.
+
+    ``channels`` maps channel name -> flat row-major float sequence of length
+    ``width * height``. Channels are stored alphabetically, as OpenEXR requires.
+    """
+    names = sorted(channels.keys())
+    nch = len(names)
+
+    def attr(name, type_, payload):
+        return (
+            name.encode() + b"\x00"
+            + type_.encode() + b"\x00"
+            + struct.pack("<i", len(payload))
+            + payload
+        )
+
+    chlist = b""
+    for nm in names:
+        chlist += nm.encode() + b"\x00"
+        chlist += struct.pack("<i", 2)   # pixel type: FLOAT
+        chlist += struct.pack("<B", 0)   # pLinear
+        chlist += b"\x00\x00\x00"        # reserved
+        chlist += struct.pack("<i", 1)   # xSampling
+        chlist += struct.pack("<i", 1)   # ySampling
+    chlist += b"\x00"                    # end of channel list
+
+    header = b""
+    header += attr("channels", "chlist", chlist)
+    header += attr("compression", "compression", struct.pack("<B", 0))  # none
+    header += attr("dataWindow", "box2i", struct.pack("<iiii", 0, 0, width - 1, height - 1))
+    header += attr("displayWindow", "box2i", struct.pack("<iiii", 0, 0, width - 1, height - 1))
+    header += attr("lineOrder", "lineOrder", struct.pack("<B", 0))  # increasing Y
+    header += attr("pixelAspectRatio", "float", struct.pack("<f", 1.0))
+    header += attr("screenWindowCenter", "v2f", struct.pack("<ff", 0.0, 0.0))
+    header += attr("screenWindowWidth", "float", struct.pack("<f", 1.0))
+    header += b"\x00"                    # end of header
+
+    magic = struct.pack("<i", 20000630)
+    version = struct.pack("<i", 2)       # version 2, no flags (scanline)
+
+    pix_size = nch * width * 4           # FLOAT = 4 bytes/sample
+    block_size = 8 + pix_size            # y(4) + dataSize(4) + pixels
+    offset_table_start = len(magic) + len(version) + len(header)
+    scanlines_start = offset_table_start + height * 8
+
+    offset_table = b"".join(
+        struct.pack("<Q", scanlines_start + y * block_size) for y in range(height)
+    )
+
+    blocks = b""
+    for y in range(height):
+        blocks += struct.pack("<i", y)
+        blocks += struct.pack("<i", pix_size)
+        for nm in names:
+            row = channels[nm][y * width:(y + 1) * width]
+            blocks += struct.pack("<%df" % width, *row)
+
+    with open(path, "wb") as fh:
+        fh.write(magic + version + header + offset_table + blocks)
+
+
+def test_hdr_extension_accepted(tmp_path):
+    p = tmp_path / "env.hdr"
+    _write_radiance(p)
+    ibl = f3d.IBL.from_hdr(str(p))
+    assert ibl.dimensions == (8, 4)
+
+
+def test_rgbe_extension_accepted(tmp_path):
+    p = tmp_path / "env.rgbe"
+    _write_radiance(p)
+    ibl = f3d.IBL.from_hdr(str(p))
+    assert ibl.dimensions == (8, 4)
+
+
+def test_exr_extension_accepted(tmp_path):
+    p = tmp_path / "env.exr"
+    w, h = 2, 2
+    n = w * h
+    _write_minimal_exr(
+        p, w, h,
+        {
+            "R": [0.1, 0.2, 0.3, 0.4][:n],
+            "G": [0.5, 0.6, 0.7, 0.8][:n],
+            "B": [0.9, 1.0, 1.1, 1.2][:n],
+        },
+    )
+    ibl = f3d.IBL.from_hdr(str(p))
+    assert ibl.dimensions == (2, 2)
+
+
+def test_exr_uppercase_extension_accepted(tmp_path):
+    # Dispatch is case-insensitive.
+    p = tmp_path / "ENV.EXR"
+    _write_minimal_exr(p, 1, 1, {"R": [0.5], "G": [0.25], "B": [0.75]})
+    ibl = f3d.IBL.from_hdr(str(p))
+    assert ibl.dimensions == (1, 1)
+
+
+def test_unsupported_extension_raises_ioerror(tmp_path):
+    # The unsupported-format branch fires before the file is even opened.
+    for name in ("env.png", "env.tif", "env.jpg", "env"):
+        with pytest.raises(IOError):
+            f3d.IBL.from_hdr(str(tmp_path / name))
+
+
+def test_missing_exr_channel_raises_ioerror(tmp_path):
+    # A decode failure (missing B channel) surfaces as IOError, not RuntimeError.
+    p = tmp_path / "no_blue.exr"
+    _write_minimal_exr(p, 2, 2, {"R": [0.1, 0.2, 0.3, 0.4], "G": [0.5, 0.6, 0.7, 0.8]})
+    with pytest.raises(IOError):
+        f3d.IBL.from_hdr(str(p))
+
+
+def test_nonexistent_exr_raises_ioerror(tmp_path):
+    with pytest.raises(IOError):
+        f3d.IBL.from_hdr(str(tmp_path / "does_not_exist.exr"))


### PR DESCRIPTION
## What
HDR terrain mood controls: an OpenEXR decoder (`load_exr`, compiled in every build — decodes with the `images` feature, returns an explicit feature-required error without it), `IBL.from_hdr` format dispatch, and an opt-in `colors` mood-grade path.

## Task provenance
Implements **HDR terrain mood design** — `docs/superpowers/specs/2026-07-13-general-hdr-terrain-mood-design.md` (a superpowers design spec, not a moonshot codename).

## Depends on
none — branches off `codex/censor-closure`.

## Notes / risks
- Does **not** touch the `MANIFEST.in *.ttf` hunk (that is #2).
- EXR decode and `IBL.from_hdr` are GPU-free, so the tests run without an adapter.

## Verification
- `maturin develop` ✓
- `pytest test_colors_mood.py + test_ibl_from_hdr_formats.py` → **23 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
