### PR TITLE
CENSOR: cross-platform CI + certificate hardening

### DIFF
--- a/src/core/shader_registry.rs
+++ b/src/core/shader_registry.rs
@@ -132,10 +132,18 @@ pub fn create_labeled_shader_module(
     label: &str,
     source: &str,
 ) -> wgpu::ShaderModule {
-    let final_label = register_shader_source(label, source);
+    // Normalize line endings BEFORE hashing and compiling: `include_str!`
+    // embeds whatever the checkout produced, so a CRLF (Windows autocrlf)
+    // build and an LF (CI) build of the byte-identical repository otherwise
+    // hash the "same" shader differently, and committed certificates only
+    // verify on the platform that generated them (found by the first
+    // cross-platform run of the certificate WGSL gate). The normalized text
+    // is also what naga compiles, keeping hash == compiled bytes.
+    let normalized = source.replace("\r\n", "\n");
+    let final_label = register_shader_source(label, &normalized);
     device.create_shader_module(wgpu::ShaderModuleDescriptor {
         label: Some(&final_label),
-        source: wgpu::ShaderSource::Wgsl(source.to_string().into()),
+        source: wgpu::ShaderSource::Wgsl(normalized.into()),
     })
 }
 

--- a/src/terrain/pipeline/bind_groups.rs
+++ b/src/terrain/pipeline/bind_groups.rs
@@ -91,6 +91,18 @@ pub fn make_bg_lut(
     view: &TextureView,
     samp: &Sampler,
 ) -> BindGroup {
+    if pipeline.descriptor_indexing {
+        // With descriptor indexing the LUT layout is a binding ARRAY
+        // (count = max_palette_textures). Binding a single view against it is
+        // under-binding: wgpu-hal's Metal backend panics slicing the exposed
+        // array ("range end index N out of range for slice of length 1",
+        // found by the first Metal-lane CI run after capability negotiation
+        // started granting TEXTURE_BINDING_ARRAY). Replicate the single LUT
+        // across every slot — the single-LUT shader path only samples index 0.
+        let views: Vec<&TextureView> =
+            std::iter::repeat_n(view, pipeline.max_palette_textures.max(1) as usize).collect();
+        return make_bg_lut_array(pipeline, device, &views, samp);
+    }
     device.create_bind_group(&BindGroupDescriptor {
         label: Some("vf.Terrain.bg.lut"),
         layout: &pipeline.bgl_lut,

--- a/tests/test_mapscene_examples.py
+++ b/tests/test_mapscene_examples.py
@@ -6,6 +6,21 @@ import pytest
 
 import forge3d.map_scene as map_scene
 
+from _terrain_runtime import (
+    terrain_rendering_available as _terrain_rendering_available,
+)
+
+_requires_gpu = pytest.mark.skipif(
+    not _terrain_rendering_available(),
+    reason=(
+        "MapScene native terrain render requires a terrain-safe hardware "
+        "adapter; hosted runners (GPU-less, WARP, or guarded paravirtual "
+        "Metal) either block with a native-render diagnostic or raise by "
+        "design (SUTURA), so these render-asserting tests skip honestly"
+    ),
+)
+
+
 
 EXAMPLES = {
     "terrain_raster": Path("examples/mapscene_terrain_raster.py"),
@@ -47,13 +62,14 @@ def test_canonical_mapscene_examples_exist_and_do_not_use_raw_ipc():
         assert "send_ipc" not in text
 
 
+@_requires_gpu
 def test_terrain_raster_example_validates_renders_and_bundles(tmp_path, monkeypatch):
     module = _load_example(EXAMPLES["terrain_raster"])
 
     payload = module.run_example(tmp_path)
 
     assert payload["validation_status"] == "ok"
-    assert payload["render_status"] == "ok"
+    assert payload["render_status"] == "ok", payload.get("diagnostics") or payload
     assert payload["render_backend"] == "gpu_terrain"
     assert payload["bundle_status"] == "ok"
     assert Path(payload["png_path"]).exists()
@@ -70,13 +86,14 @@ def test_terrain_raster_example_validates_renders_and_bundles(tmp_path, monkeypa
     assert blocked_scene.last_render_path is None
 
 
+@_requires_gpu
 def test_vector_labels_example_compiles_label_plan_and_bundles(tmp_path):
     module = _load_example(EXAMPLES["vector_labels"])
 
     payload = module.run_example(tmp_path)
 
     assert payload["validation_status"] == "warning"
-    assert payload["render_status"] == "warning"
+    assert payload["render_status"] == "warning", payload.get("diagnostics") or payload
     _supported_render_backend(payload)
     assert payload["bundle_status"] == "warning"
     assert payload["accepted_label_ids"] == ["city", "park"]
@@ -85,25 +102,27 @@ def test_vector_labels_example_compiles_label_plan_and_bundles(tmp_path):
     assert Path(payload["bundle_path"]).exists()
 
 
+@_requires_gpu
 def test_fuji_labels_demo_uses_public_mapscene_gpu_label_path(tmp_path):
     module = _load_example(EXAMPLES["fuji_labels"])
 
     payload = module.run_example(tmp_path)
 
     assert payload["validation_status"] == "ok"
-    assert payload["render_status"] == "ok"
+    assert payload["render_status"] == "ok", payload.get("diagnostics") or payload
     assert payload["render_backend"] == "gpu_terrain"
     assert payload["accepted_label_ids"]
     assert Path(payload["png_path"]).exists()
 
 
+@_requires_gpu
 def test_offline_quality_example_uses_native_accumulation_and_aovs(tmp_path):
     module = _load_example(EXAMPLES["offline_quality"])
 
     payload = module.run_example(tmp_path)
 
     assert payload["validation_status"] == "ok"
-    assert payload["render_status"] == "ok"
+    assert payload["render_status"] == "ok", payload.get("diagnostics") or payload
     assert payload["render_backend"] == "gpu_terrain"
     assert payload["bundle_status"] == "ok"
     assert payload["samples_used"] == 4
@@ -117,13 +136,14 @@ def test_offline_quality_example_uses_native_accumulation_and_aovs(tmp_path):
     assert Path(payload["bundle_path"]).exists()
 
 
+@_requires_gpu
 def test_buildings_labels_example_renders_native_gpu_buildings(tmp_path):
     module = _load_example(EXAMPLES["buildings_labels"])
 
     payload = module.run_example(tmp_path)
 
     assert payload["validation_status"] == "ok"
-    assert payload["render_status"] == "ok"
+    assert payload["render_status"] == "ok", payload.get("diagnostics") or payload
     assert payload["render_backend"] == "gpu_terrain"
     assert payload["bundle_status"] == "ok"
     assert "pro_gated_path" not in payload["diagnostic_codes"]
@@ -141,13 +161,14 @@ def test_buildings_labels_example_renders_native_gpu_buildings(tmp_path):
     assert Path(payload["bundle_path"]).exists()
 
 
+@_requires_gpu
 def test_bundled_datasets_showcase_covers_specs_001_to_004(tmp_path):
     module = _load_example(EXAMPLES["bundled_datasets_showcase"])
 
     payload = module.run_example(tmp_path)
 
     assert payload["validation_status"] == "warning"
-    assert payload["render_status"] == "warning"
+    assert payload["render_status"] == "warning", payload.get("diagnostics") or payload
     assert payload["bundle_status"] == "warning"
     assert payload["dataset_names"] == ["mini_dem", "sample_boundaries"]
     assert payload["accepted_label_ids"] == [
@@ -163,6 +184,7 @@ def test_bundled_datasets_showcase_covers_specs_001_to_004(tmp_path):
     assert Path(payload["bundle_path"]).exists()
 
 
+@_requires_gpu
 def test_p1_assets_bundle_showcase_covers_spec_005(tmp_path):
     module = _load_example(EXAMPLES["p1_assets_bundle_showcase"])
 

--- a/tests/test_mapscene_quickstart.py
+++ b/tests/test_mapscene_quickstart.py
@@ -9,6 +9,21 @@ import pytest
 
 from _terrain_runtime import terrain_rendering_available
 
+from _terrain_runtime import (
+    terrain_rendering_available as _terrain_rendering_available,
+)
+
+_requires_gpu = pytest.mark.skipif(
+    not _terrain_rendering_available(),
+    reason=(
+        "MapScene native terrain render requires a terrain-safe hardware "
+        "adapter; hosted runners (GPU-less, WARP, or guarded paravirtual "
+        "Metal) either block with a native-render diagnostic or raise by "
+        "design (SUTURA), so these render-asserting tests skip honestly"
+    ),
+)
+
+
 
 QUICKSTART = Path("docs/guides/offline_3d_map_rendering.md")
 START_QUICKSTART = Path("docs/start/quickstart.md")
@@ -42,6 +57,7 @@ def test_mapscene_quickstart_points_to_canonical_examples():
     assert "raw IPC" not in text
 
 
+@_requires_gpu
 def test_quickstart_vector_labels_scenario_is_executable(tmp_path):
     module = _load_example(VECTOR_EXAMPLE)
 
@@ -191,13 +207,14 @@ def test_quickstart_models_accept_path_objects_in_serialized_recipes(tmp_path):
     json.dumps(payload)
 
 
+@_requires_gpu
 def test_quickstart_building_scenario_renders_native_gpu_buildings(tmp_path):
     module = _load_example(BUILDING_EXAMPLE)
 
     payload = module.run_example(tmp_path)
 
     assert payload["validation_status"] == "ok"
-    assert payload["render_status"] == "ok"
+    assert payload["render_status"] == "ok", payload.get("diagnostics") or payload
     assert payload["render_backend"] == "gpu_terrain"
     assert payload["bundle_status"] == "ok"
     assert payload["building_backend"] == "terrain_scatter_instanced_mesh"

--- a/tests/test_no_silent_degradation.py
+++ b/tests/test_no_silent_degradation.py
@@ -107,8 +107,27 @@ def _cargo_features() -> set[str]:
     return names
 
 
+def _cargo_feature_table() -> dict[str, list[str]]:
+    """Parse Cargo.toml's [features] table with a regex.
+
+    Deliberately NOT load_toml: on Python 3.10 the tiny _toml_compat fallback
+    parser only understands the UNRUN/allowlist schema and returns a dict with
+    no "features" key, which made this gate error (not fail honestly) on every
+    3.10 CI leg — unseen until the exhaustive lane first ran there.
+    """
+    text = (ROOT / "Cargo.toml").read_text(encoding="utf-8")
+    section = re.search(r"\[features\](.*?)(?:\n\[)", text, re.DOTALL)
+    assert section, "could not locate [features] in Cargo.toml"
+    table: dict[str, list[str]] = {}
+    for m in re.finditer(
+        r"^([A-Za-z0-9_\-]+)\s*=\s*\[([^\]]*)\]", section.group(1), re.MULTILINE
+    ):
+        table[m.group(1)] = re.findall(r'"([^"]+)"', m.group(2))
+    return table
+
+
 def _feature_closure(features: set[str]) -> set[str]:
-    table = load_toml(ROOT / "Cargo.toml")["features"]
+    table = _cargo_feature_table()
     closure = set(features)
     pending = list(features)
     while pending:

--- a/tests/test_render_certificate_contract.py
+++ b/tests/test_render_certificate_contract.py
@@ -116,6 +116,11 @@ def test_public_render_entrypoints_expose_certificate_keyword() -> None:
 
 
 def test_brdf_tile_emits_a_live_certified_pass() -> None:
+    import pytest
+
+    if not f3d.has_gpu():
+        pytest.skip("BRDF tile render requires a GPU adapter")
+
     from forge3d.diagnostics import render_certificate
 
     rgba = f3d.render_brdf_tile("lambert", 0.4, 32, 32, certificate=True)
@@ -123,7 +128,10 @@ def test_brdf_tile_emits_a_live_certified_pass() -> None:
 
     assert rgba.shape == (32, 32, 4)
     assert [entry["label"] for entry in certificate["passes"]] == ["brdf.tile"]
-    assert certificate["passes"][0]["gpu_ms"] > 0.0
+    if "timestamp_query" in certificate["capabilities"]["granted"]:
+        assert certificate["passes"][0]["gpu_ms"] > 0.0
+    else:
+        assert certificate["passes"][0]["gpu_ms"] == 0.0
     assert set(certificate["engine"]["wgsl_module_hashes"]) == {"brdf_tile.shader"}
 
 

--- a/tests/test_terrain_material_maps.py
+++ b/tests/test_terrain_material_maps.py
@@ -15,6 +15,21 @@ from forge3d.terrain_params import (
     make_terrain_params_config,
 )
 
+from _terrain_runtime import (
+    terrain_rendering_available as _terrain_rendering_available,
+)
+
+_requires_gpu = pytest.mark.skipif(
+    not _terrain_rendering_available(),
+    reason=(
+        "MapScene native terrain render requires a terrain-safe hardware "
+        "adapter; hosted runners (GPU-less, WARP, or guarded paravirtual "
+        "Metal) either block with a native-render diagnostic or raise by "
+        "design (SUTURA), so these render-asserting tests skip honestly"
+    ),
+)
+
+
 
 GPU_AVAILABLE = terrain_rendering_available()
 
@@ -94,6 +109,7 @@ def test_native_render_params_decode_material_map_paths(tmp_path: Path) -> None:
     }
 
 
+@_requires_gpu
 def test_mapscene_terrain_metadata_wires_material_maps_to_native_params(tmp_path: Path) -> None:
     normal_path = tmp_path / "normal.png"
     roughness_path = tmp_path / "roughness.png"

--- a/tests/test_terrain_runtime.py
+++ b/tests/test_terrain_runtime.py
@@ -35,6 +35,15 @@ def test_terrain_rendering_available_short_circuits_on_hosted_macos_ci(monkeypat
 
 def test_terrain_rendering_available_uses_child_probe(monkeypatch) -> None:
     terrain_runtime.terrain_rendering_available.cache_clear()
+    # This unit test exercises the child-probe plumbing itself; the hosted-CI
+    # blanket guards would short-circuit before subprocess.run on GitHub
+    # runners, so disable them explicitly for the mock scenario.
+    monkeypatch.setattr(
+        terrain_runtime, "_running_on_unsupported_hosted_macos_ci", lambda: False
+    )
+    monkeypatch.setattr(
+        terrain_runtime, "_running_on_unsupported_hosted_windows_ci", lambda: False
+    )
     monkeypatch.setattr(terrain_runtime.f3d, "has_gpu", lambda: True)
     monkeypatch.setattr(terrain_runtime.f3d, "device_probe", lambda _: {"status": "ok"})
     monkeypatch.setattr(terrain_runtime, "_adapter_is_terrain_safe", lambda _: True)

--- a/tests/test_trust_boundary_diagnostics.py
+++ b/tests/test_trust_boundary_diagnostics.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import glob
 import os
 import subprocess
 import sys
@@ -180,10 +181,16 @@ def _run_engine_info_subprocess(extra_env: dict) -> subprocess.CompletedProcess:
     env.pop("WGPU_BACKENDS", None)
     env.pop("WGPU_BACKEND", None)
     env.pop("FORGE3D_DETERMINISTIC", None)
+    # Prepend the source tree ONLY when it actually contains the built native
+    # module (local `maturin develop` layout). On a clean CI checkout the
+    # source tree has no _forge3d.* — prepending it would shadow the installed
+    # wheel and turn every child into an ImportError instead of exercising the
+    # real adapter-acquisition path (found by the first exhaustive-lane CI run).
     repo_python = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "python"))
-    env["PYTHONPATH"] = os.pathsep.join(
-        [repo_python, env["PYTHONPATH"]] if env.get("PYTHONPATH") else [repo_python]
-    )
+    if glob.glob(os.path.join(repo_python, "forge3d", "_forge3d*")):
+        env["PYTHONPATH"] = os.pathsep.join(
+            [repo_python, env["PYTHONPATH"]] if env.get("PYTHONPATH") else [repo_python]
+        )
     env.update(extra_env)
     code = (
         "from forge3d import _forge3d\n"


### PR DESCRIPTION
## What
CENSOR cross-platform CI + certificate hardening: CRLF→LF normalization of WGSL before certificate hashing (`shader_registry`), the Metal binding-array LUT fix (`terrain/pipeline/bind_groups`), and a GPU-skip sweep so render-asserting MapScene tests skip honestly on GPU-less / WARP / paravirtual runners.

## Task provenance
Implements **CENSOR** — `docs/prompts/fable5-moonshots/14-censor-remediation.md` (moonshot #14).

## Depends on
none — branches off `codex/censor-closure`.

## Notes / risks
- `tests/test_mapscene_examples.py` and `tests/test_mapscene_quickstart.py` carry **only** the CENSOR GPU-skip hunks (`_requires_gpu` marker + `@_requires_gpu` decorators + diagnostic assert messages); the example-existence guards belong to #7.

## Verification
- `maturin develop` ✓
- `cargo forge3d-clippy` (pre-commit hook) ✓
- `pytest test_render_certificate_contract.py + test_no_silent_degradation.py` → **19 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
