### PR TITLE
MENSURA: Earth-scale f64 world coords (anchor, tiles3d, scene)

### DIFF
--- a/src/animation/mod.rs
+++ b/src/animation/mod.rs
@@ -10,6 +10,16 @@ pub mod render_queue;
 #[cfg(feature = "extension-module")]
 use pyo3::{prelude::*, types::PyAny};
 
+fn cubic_hermite_f64(p0: f64, p1: f64, p2: f64, p3: f64, t: f32) -> f64 {
+    let t = f64::from(t);
+    let t2 = t * t;
+    let t3 = t2 * t;
+    0.5 * ((2.0 * p1)
+        + (-p0 + p2) * t
+        + (2.0 * p0 - 5.0 * p1 + 4.0 * p2 - p3) * t2
+        + (-p0 + 3.0 * p1 - 3.0 * p2 + p3) * t3)
+}
+
 /// A single camera keyframe with position and timing.
 #[derive(Debug, Clone, Copy)]
 #[cfg_attr(
@@ -24,11 +34,11 @@ pub struct CameraKeyframe {
     /// Polar angle in degrees measured down from the vertical axis.
     pub theta_deg: f32,
     /// Distance from target/center.
-    pub radius: f32,
+    pub radius: f64,
     /// Field of view in degrees.
     pub fov_deg: f32,
     /// Optional explicit terrain target in world space.
-    pub target: Option<[f32; 3]>,
+    pub target: Option<[f64; 3]>,
 }
 
 impl CameraKeyframe {
@@ -36,9 +46,9 @@ impl CameraKeyframe {
         time: f32,
         phi_deg: f32,
         theta_deg: f32,
-        radius: f32,
+        radius: f64,
         fov_deg: f32,
-        target: Option<[f32; 3]>,
+        target: Option<[f64; 3]>,
     ) -> Self {
         Self {
             time,
@@ -68,9 +78,9 @@ impl CameraKeyframe {
             time as f32,
             phi as f32,
             theta as f32,
-            radius as f32,
+            radius,
             fov as f32,
-            target.map(|value| [value.0 as f32, value.1 as f32, value.2 as f32]),
+            target.map(|value| [value.0, value.1, value.2]),
         )
     }
 
@@ -91,7 +101,7 @@ impl CameraKeyframe {
 
     #[getter]
     fn radius(&self) -> f64 {
-        self.radius as f64
+        self.radius
     }
 
     #[getter]
@@ -101,8 +111,7 @@ impl CameraKeyframe {
 
     #[getter]
     fn target(&self) -> Option<(f64, f64, f64)> {
-        self.target
-            .map(|value| (value[0] as f64, value[1] as f64, value[2] as f64))
+        self.target.map(|value| (value[0], value[1], value[2]))
     }
 
     fn __repr__(&self) -> String {
@@ -135,9 +144,9 @@ impl CameraKeyframe {
 pub struct CameraState {
     pub phi_deg: f32,
     pub theta_deg: f32,
-    pub radius: f32,
+    pub radius: f64,
     pub fov_deg: f32,
-    pub target: Option<[f32; 3]>,
+    pub target: Option<[f64; 3]>,
 }
 
 #[cfg(feature = "extension-module")]
@@ -155,7 +164,7 @@ impl CameraState {
 
     #[getter]
     fn radius(&self) -> f64 {
-        self.radius as f64
+        self.radius
     }
 
     #[getter]
@@ -165,8 +174,7 @@ impl CameraState {
 
     #[getter]
     fn target(&self) -> Option<(f64, f64, f64)> {
-        self.target
-            .map(|value| (value[0] as f64, value[1] as f64, value[2] as f64))
+        self.target.map(|value| (value[0], value[1], value[2]))
     }
 
     fn __repr__(&self) -> String {
@@ -258,16 +266,16 @@ impl CameraAnimation {
         k2: CameraKeyframe,
         k3: CameraKeyframe,
         t: f32,
-    ) -> Option<[f32; 3]> {
+    ) -> Option<[f64; 3]> {
         let p1 = k1.target?;
         let p2 = k2.target?;
         let p0 = k0.target.unwrap_or(p1);
         let p3 = k3.target.unwrap_or(p2);
 
         Some([
-            interpolation::cubic_hermite(p0[0], p1[0], p2[0], p3[0], t),
-            interpolation::cubic_hermite(p0[1], p1[1], p2[1], p3[1], t),
-            interpolation::cubic_hermite(p0[2], p1[2], p2[2], p3[2], t),
+            cubic_hermite_f64(p0[0], p1[0], p2[0], p3[0], t),
+            cubic_hermite_f64(p0[1], p1[1], p2[1], p3[1], t),
+            cubic_hermite_f64(p0[2], p1[2], p2[2], p3[2], t),
         ])
     }
 
@@ -294,7 +302,7 @@ impl CameraAnimation {
                 k3.theta_deg,
                 t,
             ),
-            radius: interpolation::cubic_hermite(k0.radius, k1.radius, k2.radius, k3.radius, t),
+            radius: cubic_hermite_f64(k0.radius, k1.radius, k2.radius, k3.radius, t),
             fov_deg: interpolation::cubic_hermite(
                 k0.fov_deg, k1.fov_deg, k2.fov_deg, k3.fov_deg, t,
             ),
@@ -353,6 +361,28 @@ impl CameraAnimation {
     }
 }
 
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn earth_scale_targets_keep_submillimetre_offsets() {
+        let mut animation = CameraAnimation::new();
+        animation.add_keyframe(CameraKeyframe::new(
+            0.0,
+            0.0,
+            45.0,
+            1_000.000_25,
+            45.0,
+            Some([6_378_137.000_25, 0.0, 0.0]),
+        ));
+        let state = animation.evaluate(0.0).unwrap();
+        assert_eq!(state.radius, 1_000.000_25);
+        let recovered = state.target.unwrap()[0] - 6_378_137.0;
+        assert!((recovered - 0.000_25).abs() < 1e-9, "{recovered}");
+    }
+}
+
 #[cfg(feature = "extension-module")]
 #[pymethods]
 impl CameraAnimation {
@@ -376,9 +406,9 @@ impl CameraAnimation {
             time as f32,
             phi as f32,
             theta as f32,
-            radius as f32,
+            radius,
             fov as f32,
-            target.map(|value| [value.0 as f32, value.1 as f32, value.2 as f32]),
+            target.map(|value| [value.0, value.1, value.2]),
         ));
     }
 

--- a/src/camera/anchor.rs
+++ b/src/camera/anchor.rs
@@ -1,0 +1,152 @@
+// src/camera/anchor.rs
+// MENSURA: camera-relative anchoring — the f64→f32 cliff, moved on purpose.
+//
+// World coordinates stay f64 until the last possible instant. `Anchor` holds
+// an f64 world origin, rebased whenever the camera moves more than
+// `anchor_epsilon` (default 1 km) away from it; the view matrix is built from
+// anchor-relative positions and per-object model matrices carry the
+// anchor-relative object origin. Narrowing happens in exactly ONE place —
+// `Anchor::narrow`, used only by `to_render_*` — and that single `as f32`
+// site is grep-gated by tests/test_world_coord_f32_gate.py.
+// RELEVANT FILES: src/geo/units.rs, src/scene/py_api/base.rs, src/camera/mod.rs
+
+use glam::{DVec3, Mat4, Vec3};
+
+use crate::geo::units::{Coord, CrsTag, EpochTag};
+
+/// An f64 world-space origin that render-space f32 values are measured from.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Anchor {
+    origin: DVec3,
+    anchor_epsilon: f64,
+}
+
+impl Default for Anchor {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Anchor {
+    /// Default rebase threshold: 1 km. At that offset an f32 relative
+    /// coordinate still resolves ~0.06 mm.
+    pub const DEFAULT_EPSILON_M: f64 = 1_000.0;
+
+    pub fn new() -> Self {
+        Self {
+            origin: DVec3::ZERO,
+            anchor_epsilon: Self::DEFAULT_EPSILON_M,
+        }
+    }
+
+    pub fn with_epsilon(anchor_epsilon: f64) -> Self {
+        Self {
+            origin: DVec3::ZERO,
+            anchor_epsilon,
+        }
+    }
+
+    pub fn origin(&self) -> DVec3 {
+        self.origin
+    }
+
+    pub fn anchor_epsilon(&self) -> f64 {
+        self.anchor_epsilon
+    }
+
+    /// Rebase the anchor onto the camera eye when it has drifted more than
+    /// `anchor_epsilon` from the current origin. Returns true on rebase (the
+    /// caller must then refresh every model offset derived from this anchor).
+    pub fn rebase_if_needed(&mut self, eye: DVec3) -> bool {
+        if (eye - self.origin).length() > self.anchor_epsilon {
+            self.origin = eye;
+            true
+        } else {
+            false
+        }
+    }
+
+    /// The ONLY sanctioned f64→f32 narrowing of a world coordinate in the
+    /// codebase (single textual `as f32`, enforced at source level).
+    #[inline]
+    fn narrow(value: f64) -> f32 {
+        value as f32
+    }
+
+    /// Narrow an anchor-relative world position to render-space f32.
+    pub fn to_render_vec3(&self, p: DVec3) -> Vec3 {
+        let rel = p - self.origin;
+        Vec3::new(
+            Self::narrow(rel.x),
+            Self::narrow(rel.y),
+            Self::narrow(rel.z),
+        )
+    }
+
+    /// Typed entry point: the single named function where a `Coord` leaves
+    /// the f64 world and becomes a render-space `Vec3`.
+    pub fn to_render_f32<C: CrsTag, E: EpochTag>(&self, p: Coord<C, E>) -> Vec3 {
+        self.to_render_vec3(p.raw())
+    }
+
+    /// Right-handed look-at view matrix built from anchor-relative eye and
+    /// target. The subtraction happens in f64; only the small relative
+    /// vectors are narrowed.
+    pub fn view_look_at(&self, eye: DVec3, target: DVec3, up: Vec3) -> Mat4 {
+        Mat4::look_at_rh(self.to_render_vec3(eye), self.to_render_vec3(target), up)
+    }
+
+    /// Anchor-relative translation an object's model matrix must carry for
+    /// geometry authored relative to `object_origin`.
+    pub fn model_offset(&self, object_origin: DVec3) -> Vec3 {
+        self.to_render_vec3(object_origin)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::geo::units::{Coord, Ecef, Itrf2014};
+
+    #[test]
+    fn anchor_defaults_to_world_origin_and_identity_behaviour() {
+        let anchor = Anchor::new();
+        let eye = DVec3::new(3.0, 2.0, 3.0);
+        let view = anchor.view_look_at(eye, DVec3::ZERO, Vec3::Y);
+        let legacy = Mat4::look_at_rh(Vec3::new(3.0, 2.0, 3.0), Vec3::ZERO, Vec3::Y);
+        assert!(
+            (view
+                .to_cols_array()
+                .iter()
+                .zip(legacy.to_cols_array().iter())
+                .map(|(a, b)| (a - b).abs())
+                .fold(0.0f32, f32::max))
+                < 1e-7
+        );
+    }
+
+    #[test]
+    fn rebase_triggers_only_beyond_epsilon() {
+        let mut anchor = Anchor::new();
+        assert!(!anchor.rebase_if_needed(DVec3::new(999.0, 0.0, 0.0)));
+        assert_eq!(anchor.origin(), DVec3::ZERO);
+        assert!(anchor.rebase_if_needed(DVec3::new(1_500.0, 0.0, 0.0)));
+        assert_eq!(anchor.origin(), DVec3::new(1_500.0, 0.0, 0.0));
+    }
+
+    #[test]
+    fn anchored_narrowing_preserves_submillimetre_offsets_at_earth_radius() {
+        // The whole point: 6.38e6 + 0.25 mm survives narrowing when measured
+        // relative to a nearby anchor, and is destroyed without one.
+        let base = DVec3::new(6_378_137.0, 0.0, 0.0);
+        let mut anchor = Anchor::new();
+        anchor.rebase_if_needed(base);
+        let p = Coord::<Ecef, Itrf2014>::ecef(6_378_137.000_25, 0.0, 0.0);
+        let rel = anchor.to_render_f32(p);
+        assert!((rel.x - 0.000_25).abs() < 1e-6, "rel.x = {}", rel.x);
+        // Unanchored narrowing of the same coordinate loses the offset
+        // entirely (~0.5 m quantization at this magnitude).
+        let unanchored = Anchor::new().to_render_f32(p);
+        assert_eq!(unanchored.x, 6_378_137.0f32);
+    }
+}

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -3,8 +3,11 @@
 //! Provides right-handed, Y-up, -Z forward camera math (standard GL-style look-at).
 //! Supports both "wgpu" (0..1 Z) and "gl" (-1..1 Z) clip spaces.
 
+pub mod anchor;
 pub mod dof;
 pub mod validation;
+
+pub use anchor::Anchor;
 
 use glam::{Mat4, Vec3, Vec4Swizzles};
 use numpy::PyArray2;

--- a/src/scene/core/constructor.rs
+++ b/src/scene/core/constructor.rs
@@ -183,6 +183,7 @@ impl Scene {
             height_view: Some(hview),
             height_sampler: Some(hsamp),
             scene,
+            camera_anchor: crate::camera::Anchor::new(),
             last_uniforms: uniforms,
             ssao,
             ssao_enabled: false,

--- a/src/scene/mod.rs
+++ b/src/scene/mod.rs
@@ -76,6 +76,9 @@ pub struct Scene {
     height_sampler: Option<wgpu::Sampler>,
 
     scene: SceneGlobals,
+    // MENSURA: f64 camera anchor; world camera coordinates are narrowed to
+    // f32 only relative to this origin (see src/camera/anchor.rs).
+    camera_anchor: crate::camera::Anchor,
     last_uniforms: crate::terrain::TerrainUniforms,
     ssao: SsaoResources,
     ssao_enabled: bool,

--- a/src/scene/py_api/base.rs
+++ b/src/scene/py_api/base.rs
@@ -17,20 +17,31 @@ impl Scene {
     #[pyo3(text_signature = "($self, eye, target, up, fovy_deg, znear, zfar)")]
     pub fn set_camera_look_at(
         &mut self,
-        eye: (f32, f32, f32),
-        target: (f32, f32, f32),
-        up: (f32, f32, f32),
+        eye: (f64, f64, f64),
+        target: (f64, f64, f64),
+        up: (f64, f64, f64),
         fovy_deg: f32,
         znear: f32,
         zfar: f32,
     ) -> PyResult<()> {
         use crate::camera;
         let aspect = self.width as f32 / self.height as f32;
-        let eye_v = glam::Vec3::new(eye.0, eye.1, eye.2);
-        let target_v = glam::Vec3::new(target.0, target.1, target.2);
-        let up_v = glam::Vec3::new(up.0, up.1, up.2);
+        // MENSURA: world positions cross the PyO3 boundary in f64 and are
+        // narrowed only relative to the camera anchor. The scene's geometry
+        // is authored relative to the world origin, so the anchor offset of
+        // that origin is folded into the view transform; with the anchor at
+        // the origin (all coordinates < 1 km) this is bit-identical to the
+        // legacy path. Projection stays f32.
+        let eye_d = glam::DVec3::new(eye.0, eye.1, eye.2);
+        let target_d = glam::DVec3::new(target.0, target.1, target.2);
+        let up_v = glam::DVec3::new(up.0, up.1, up.2).as_vec3();
+        self.camera_anchor.rebase_if_needed(eye_d);
+        let eye_v = self.camera_anchor.to_render_vec3(eye_d);
+        let target_v = self.camera_anchor.to_render_vec3(target_d);
         camera::validate_camera_params(eye_v, target_v, up_v, fovy_deg, znear, zfar)?;
-        self.scene.view = glam::Mat4::look_at_rh(eye_v, target_v, up_v);
+        let world_origin_offset = self.camera_anchor.model_offset(glam::DVec3::ZERO);
+        self.scene.view = glam::Mat4::look_at_rh(eye_v, target_v, up_v)
+            * glam::Mat4::from_translation(world_origin_offset);
         self.scene.proj = camera::perspective_wgpu(fovy_deg.to_radians(), aspect, znear, zfar);
         let uniforms = self
             .scene

--- a/src/tiles3d/bounds.rs
+++ b/src/tiles3d/bounds.rs
@@ -1,7 +1,13 @@
 //! Bounding volume types for 3D Tiles
+//!
+//! World-space math here is f64 end to end (MENSURA): geodetic regions go
+//! through the full-precision geocentric conversion and are never truncated
+//! to f32 — ECEF magnitudes are ~6.38e6 m, where an f32 mantissa costs ≈0.5 m.
 
-use glam::{Mat4, Vec3};
+use glam::{DVec3, Mat4, Vec3};
 use serde::{Deserialize, Serialize};
+
+use crate::geo::units::{Ellipsoidal, Height};
 
 /// Bounding volume for a 3D Tile
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -40,36 +46,46 @@ pub struct BoundingRegion {
 }
 
 impl BoundingVolume {
-    /// Get the center point of the bounding volume
-    pub fn center(&self) -> Vec3 {
+    /// Get the center point of the bounding volume, in f64 world space.
+    pub fn center(&self) -> DVec3 {
         match self {
-            Self::Box(b) => Vec3::new(b.data[0], b.data[1], b.data[2]),
-            Self::Sphere(s) => Vec3::new(s.sphere[0], s.sphere[1], s.sphere[2]),
+            Self::Box(b) => DVec3::new(b.data[0] as f64, b.data[1] as f64, b.data[2] as f64),
+            Self::Sphere(s) => {
+                DVec3::new(s.sphere[0] as f64, s.sphere[1] as f64, s.sphere[2] as f64)
+            }
             Self::Region(r) => {
                 let lon = (r.region[0] + r.region[2]) / 2.0;
                 let lat = (r.region[1] + r.region[3]) / 2.0;
-                let height = (r.region[4] + r.region[5]) / 2.0;
+                // 3D Tiles region heights are ellipsoidal metres per spec §8.
+                let height = Height::<Ellipsoidal>::new((r.region[4] + r.region[5]) / 2.0);
                 wgs84_to_ecef(lon, lat, height)
             }
         }
     }
 
-    /// Get approximate radius for SSE calculation
-    pub fn radius(&self) -> f32 {
+    /// Get approximate radius for SSE calculation, in metres (f64).
+    pub fn radius(&self) -> f64 {
         match self {
             Self::Box(b) => {
-                let x_len = Vec3::new(b.data[3], b.data[4], b.data[5]).length();
-                let y_len = Vec3::new(b.data[6], b.data[7], b.data[8]).length();
-                let z_len = Vec3::new(b.data[9], b.data[10], b.data[11]).length();
+                let x_len = Vec3::new(b.data[3], b.data[4], b.data[5]).length() as f64;
+                let y_len = Vec3::new(b.data[6], b.data[7], b.data[8]).length() as f64;
+                let z_len = Vec3::new(b.data[9], b.data[10], b.data[11]).length() as f64;
                 (x_len * x_len + y_len * y_len + z_len * z_len).sqrt()
             }
-            Self::Sphere(s) => s.sphere[3],
+            Self::Sphere(s) => s.sphere[3] as f64,
             Self::Region(r) => {
+                // region[] is [west, south, east, north] in RADIANS. The
+                // east-west arc shrinks with cos(latitude); use the region's
+                // central latitude and the half-diagonal of the box.
+                const R: f64 = 6_378_137.0;
                 let d_lon = (r.region[2] - r.region[0]).abs();
                 let d_lat = (r.region[3] - r.region[1]).abs();
                 let d_h = (r.region[5] - r.region[4]).abs();
-                let approx_meters = (d_lon.max(d_lat) * 6378137.0) as f32;
-                (approx_meters * approx_meters + (d_h as f32) * (d_h as f32)).sqrt() / 2.0
+                let lat_c = (r.region[1] + r.region[3]) / 2.0;
+                let half_ew = d_lon / 2.0 * R * lat_c.cos();
+                let half_ns = d_lat / 2.0 * R;
+                let half_h = d_h / 2.0;
+                (half_ew * half_ew + half_ns * half_ns + half_h * half_h).sqrt()
             }
         }
     }
@@ -102,11 +118,12 @@ impl BoundingVolume {
         }
     }
 
-    /// Check if this volume intersects a frustum (simplified AABB check)
+    /// Check if this volume intersects a frustum (simplified AABB check).
+    /// Clip-space math runs in f64 so ECEF-magnitude centers keep precision.
     pub fn intersects_frustum(&self, view_proj: &Mat4) -> bool {
         let center = self.center();
         let radius = self.radius();
-        let clip = *view_proj * center.extend(1.0);
+        let clip = view_proj.as_dmat4() * center.extend(1.0);
         if clip.w <= 0.0 {
             return radius > clip.z.abs();
         }
@@ -119,19 +136,18 @@ impl BoundingVolume {
     }
 }
 
-/// Convert WGS84 geodetic coordinates to ECEF
-fn wgs84_to_ecef(lon_rad: f64, lat_rad: f64, height: f64) -> Vec3 {
-    const A: f64 = 6378137.0;
-    const E2: f64 = 0.00669437999014;
-    let sin_lat = lat_rad.sin();
-    let cos_lat = lat_rad.cos();
-    let sin_lon = lon_rad.sin();
-    let cos_lon = lon_rad.cos();
-    let n = A / (1.0 - E2 * sin_lat * sin_lat).sqrt();
-    let x = (n + height) * cos_lat * cos_lon;
-    let y = (n + height) * cos_lat * sin_lon;
-    let z = (n * (1.0 - E2) + height) * sin_lat;
-    Vec3::new(x as f32, y as f32, z as f32)
+/// Convert WGS84 geodetic coordinates (radians) to ECEF, full f64.
+///
+/// The height parameter is TYPED: only an ellipsoidal height is accepted.
+/// Orthometric DEM heights must first go through
+/// `crate::geo::geoid::orthometric_to_ellipsoidal`.
+pub fn wgs84_to_ecef(lon_rad: f64, lat_rad: f64, height: Height<Ellipsoidal>) -> DVec3 {
+    crate::geo::projections::geocentric::wgs84_geodetic_to_ecef(
+        lon_rad.to_degrees(),
+        lat_rad.to_degrees(),
+        height.metres(),
+    )
+    .expect("finite geodetic inputs")
 }
 
 impl Default for BoundingVolume {

--- a/src/tiles3d/sse.rs
+++ b/src/tiles3d/sse.rs
@@ -57,15 +57,15 @@ pub fn compute_sse(
     params: &SseParams,
 ) -> f32 {
     let center = bounding_volume.center();
-    let distance = (center - camera_position).length();
+    let distance = (center - camera_position.as_dvec3()).length();
 
     if distance < 0.001 {
         return f32::MAX; // Camera inside tile, always refine
     }
 
-    // SSE = (geometric_error / distance) * sse_factor
-    // This gives us pixels of error on screen
-    (geometric_error / distance) * params.sse_factor()
+    // SSE = (geometric_error / distance) * sse_factor. The result is a pixel
+    // count, not a world coordinate; narrowing it to f32 is fine.
+    ((geometric_error as f64 / distance) * params.sse_factor() as f64) as f32
 }
 
 /// Compute SSE using view-projection matrix (for frustum-based computation)
@@ -76,14 +76,14 @@ pub fn compute_sse_with_matrix(
     params: &SseParams,
 ) -> f32 {
     let center = bounding_volume.center();
-    let clip = *view_proj * center.extend(1.0);
+    let clip = view_proj.as_dmat4() * center.extend(1.0);
 
     if clip.w <= 0.0 {
         return f32::MAX; // Behind camera
     }
 
     let distance = clip.w;
-    (geometric_error / distance) * params.sse_factor()
+    ((geometric_error as f64 / distance) * params.sse_factor() as f64) as f32
 }
 
 /// Determine if a tile should be refined based on SSE threshold
@@ -98,11 +98,12 @@ pub fn should_refine(
     sse > threshold
 }
 
-/// Compute distance from camera to bounding volume surface (not center)
-pub fn distance_to_surface(bounding_volume: &BoundingVolume, camera_position: Vec3) -> f32 {
+/// Compute distance from camera to bounding volume surface (not center),
+/// in metres (f64 — the values involved are ECEF-magnitude).
+pub fn distance_to_surface(bounding_volume: &BoundingVolume, camera_position: Vec3) -> f64 {
     let center = bounding_volume.center();
     let radius = bounding_volume.radius();
-    let center_dist = (center - camera_position).length();
+    let center_dist = (center - camera_position.as_dvec3()).length();
     (center_dist - radius).max(0.001)
 }
 
@@ -114,7 +115,7 @@ pub fn compute_sse_surface(
     params: &SseParams,
 ) -> f32 {
     let distance = distance_to_surface(bounding_volume, camera_position);
-    (geometric_error / distance) * params.sse_factor()
+    ((geometric_error as f64 / distance) * params.sse_factor() as f64) as f32
 }
 
 #[cfg(test)]

--- a/tests/test_world_coord_f32_gate.py
+++ b/tests/test_world_coord_f32_gate.py
@@ -1,0 +1,126 @@
+# tests/test_world_coord_f32_gate.py
+# MENSURA win 5 (CI-gated): the f64 -> f32 cliff exists in exactly ONE place.
+#
+# Source-level gate in the style of tests/test_allocation_gate.py: across the
+# world-coordinate surface of the tree, exactly one `as f32` cast applied to a
+# world coordinate exists — inside `Anchor::narrow`, the helper used only by
+# `Anchor::to_render_*` (src/camera/anchor.rs). Everything else must carry
+# world coordinates in f64 until they pass through the anchor.
+# RELEVANT FILES: src/camera/anchor.rs, src/geo/units.rs, src/tiles3d/bounds.rs
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Scan every Rust source file. Candidate lines are selected by world-space
+# vocabulary; harmless render scalars are ignored rather than hidden by a
+# directory allowlist.
+GATED = ["src"]
+WORLD_HINT = re.compile(
+    r"\b(world|object_origin|ecef|longitude|latitude|lon|lat|target|eye|world_coord)\w*\b",
+    re.IGNORECASE,
+)
+
+# The single sanctioned world-coordinate narrowing site.
+SANCTIONED = ("src/camera/anchor.rs", "value as f32")
+
+# Casts in gated files that are demonstrably NOT world coordinates. Each entry
+# is (path, exact code substring, justification). Keep this list minimal —
+# every addition must name a non-coordinate operand.
+ALLOWLIST = [
+    ("src/core/water_surface/constructor.rs", "x as f32 * step", "grid index"),
+    ("src/core/water_surface/constructor.rs", "y as f32 * step", "grid index"),
+    ("src/path_tracing/restir/types.rs", "self.m as f32", "reservoir sample count"),
+    ("src/path_tracing/restir/types.rs", "other.m as f32", "reservoir sample count"),
+    ("src/shadows/cascade_math.rs", "shadow_map_size as f32", "texture resolution"),
+    ("src/terrain/renderer/resources/resize.rs", "width as f32 * resolution_scale", "pixel width"),
+    ("src/terrain/renderer/resources/resize.rs", "height as f32 * resolution_scale", "pixel height"),
+    ("src/viewer/terrain/overlay/stack/composite.rs", "target_width as f32", "pixel width"),
+    ("src/viewer/terrain/overlay/stack/composite.rs", "target_height as f32", "pixel height"),
+    (
+        "src/scene/py_api/base.rs",
+        "self.width as f32 / self.height as f32",
+        "u32 viewport pixel dimensions (aspect ratio), not world coordinates",
+    ),
+    (
+        "src/gis/terrarium.rs",
+        "pixel[0] as f32 * 256.0 + pixel[1] as f32 + pixel[2] as f32 / 256.0",
+        "u8 Terrarium tile decode: 24-bit quantized source data, every "
+        "representable value is exact in f32 (no f64 world value is narrowed)",
+    ),
+    (
+        "src/gis/terrarium.rs",
+        "values[row * tile_width + col] as f32",
+        "mosaic copy of the same 24-bit quantized Terrarium values back into "
+        "the f32 DEM band; exact by construction",
+    ),
+]
+
+
+def _strip_comments(text: str) -> str:
+    # Line comments and doc comments; block comments are not used for code in
+    # the gated files.
+    return "\n".join(line.split("//")[0] for line in text.splitlines())
+
+
+def _gated_files():
+    files = []
+    for entry in GATED:
+        path = ROOT / entry
+        if path.is_dir():
+            files.extend(sorted(path.rglob("*.rs")))
+        elif path.exists():
+            files.append(path)
+        else:
+            raise AssertionError(f"gated path missing: {entry}")
+    return files
+
+
+def _cast_sites():
+    sites = []
+    for path in _gated_files():
+        rel = path.relative_to(ROOT).as_posix()
+        text = _strip_comments(path.read_text(encoding="utf-8"))
+        for i, line in enumerate(text.splitlines(), 1):
+            for _ in re.finditer(r"\bas f32\b", line):
+                stripped = line.strip()
+                if WORLD_HINT.search(stripped) or (rel, "value as f32") == SANCTIONED:
+                    sites.append((rel, i, stripped))
+    return sites
+
+
+def test_exactly_one_world_coordinate_f32_cast():
+    sites = _cast_sites()
+
+    def allowed(site):
+        rel, _i, line = site
+        return any(rel == p and frag in line for p, frag in
+                   [(a[0], a[1]) for a in ALLOWLIST])
+
+    world_casts = [s for s in sites if not allowed(s)]
+    assert len(world_casts) == 1, (
+        "expected exactly ONE world-coordinate `as f32` cast "
+        f"(Anchor::narrow); found {len(world_casts)}: {world_casts}"
+    )
+    rel, _line_no, line = world_casts[0]
+    assert rel == SANCTIONED[0] and SANCTIONED[1] in line, (
+        f"the single sanctioned cast moved: {world_casts[0]}"
+    )
+
+
+def test_allowlist_entries_still_exist_verbatim():
+    # A stale allowlist entry would silently widen the gate.
+    for rel, frag, _why in ALLOWLIST:
+        text = _strip_comments((ROOT / rel).read_text(encoding="utf-8"))
+        assert frag in text, f"stale allowlist entry: {rel}: {frag}"
+
+
+def test_legacy_truncation_sites_are_gone():
+    # The original f32 cliffs named by the MENSURA audit must stay dead.
+    bounds = (ROOT / "src/tiles3d/bounds.rs").read_text(encoding="utf-8")
+    assert "Vec3::new(x as f32, y as f32, z as f32)" not in bounds
+    base = (ROOT / "src/scene/py_api/base.rs").read_text(encoding="utf-8")
+    assert "eye: (f32, f32, f32)" not in base, (
+        "set_camera_look_at must accept f64 world coordinates"
+    )


### PR DESCRIPTION
## What
Earth-scale f64 world coordinates: camera-relative anchoring (`src/camera/anchor.rs`, the sanctioned single `as f32` in the render hot path), f64 animation, and f64 3D-Tiles bounds / SSE + scene plumbing.

## Task provenance
Implements **MENSURA #13, item 6 — "Camera-relative anchoring (the f32 cliff, moved)"** (`docs/prompts/fable5-moonshots/13-mensura.md:66`). NOTE: this is **not** an FGV/M06 viewer task — `anchor.rs`'s own header says MENSURA; the `codex/m06-fgv` viewer is a separate later branch that builds on this substrate.

## Depends on
**#110** (branch `pr/01-mensura-geodesy`) — `anchor.rs` uses `crate::geo::units::{Coord, CrsTag, EpochTag, Ecef, Itrf2014}`. Base = `pr/01-mensura-geodesy`; retarget to `codex/censor-closure` after #110 merges.

## Notes / risks
- `test_world_coord_f32_gate.py` asserts exactly one sanctioned world-coord `as f32`, in `anchor.rs`.

## Verification
- `maturin develop` ✓
- `cargo test camera:: --lib` → **3 passed**; `cargo test tiles3d:: --lib` → **7 passed**
- `pytest test_world_coord_f32_gate.py` → **3 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
