### PR TITLE
fix(terrain): add mesh:zup camera mode for Z-up terrain orbits

### DIFF
--- a/python/forge3d/terrain_params.py
+++ b/python/forge3d/terrain_params.py
@@ -1894,7 +1894,12 @@ class TerrainRenderParams:
     # P6.1: Color space correctness toggles (defaults to False for P5 compatibility)
     colormap_srgb: bool = False  # Use Rgba8UnormSrgb for colormap texture (correct sampling)
     output_srgb_eotf: bool = False  # Use exact linear_to_srgb() instead of pow-gamma
-    # P7: Camera projection mode ("screen" = fullscreen triangle, "mesh" = perspective grid)
+    # P7: Camera projection mode ("screen" = fullscreen triangle, "mesh" = perspective grid).
+    # "mesh:zup" selects the Z-up orbit camera: mesh terrain lives in the world
+    # XY plane with heights along +Z, so the legacy Y-up orbit renders oblique
+    # views rolled (its up vector is a grid axis). With zup, cam_theta_deg is
+    # the polar angle from +Z (0 = top-down, 90 = horizon) and cam_phi_deg the
+    # azimuth within the terrain plane; plain "mesh" keeps legacy output.
     camera_mode: str = "screen"
     # P7: Debug mode for projection probes (0=normal, 40=view-depth, 41=NDC depth, 42=view-pos XYZ)
     debug_mode: int = 0
@@ -2130,7 +2135,7 @@ def make_terrain_params_config(
     cam_phi_deg: float = 135.0,
     cam_theta_deg: float = 45.0,
     fov_y_deg: float = 55.0,
-    camera_mode: str = "screen",  # "screen" (fullscreen triangle) or "mesh" (perspective grid)
+    camera_mode: str = "screen",  # "screen", "mesh", or "mesh:zup" (Z-up orbit, see TerrainParams)
     debug_mode: int = 0,  # 0=normal, 40=view-depth probe, 41=NDC depth, 42=view-pos XYZ
     clip: Optional[Tuple[float, float]] = None,
     height_curve_mode: str = "linear",

--- a/src/terrain/renderer.rs
+++ b/src/terrain/renderer.rs
@@ -56,9 +56,9 @@ pub use self::core::{TerrainRenderer, TerrainScene, ViewerTerrainData};
 use self::atmosphere::create_atmosphere_init_resources;
 use self::bind_groups::create_base_bind_group_layouts;
 use self::core::{
-    clipmap_camera_config, is_clipmap_camera_mode, is_mesh_camera_mode, ts_begin, ts_end,
-    IblUniforms, NoopShadow, OverlayBinding, PipelineCache, MATERIAL_LAYER_CAPACITY,
-    TERRAIN_DEFAULT_CASCADE_SPLITS,
+    clipmap_camera_config, is_clipmap_camera_mode, is_mesh_camera_mode, is_zup_camera_mode,
+    ts_begin, ts_end, IblUniforms, NoopShadow, OverlayBinding, PipelineCache,
+    MATERIAL_LAYER_CAPACITY, TERRAIN_DEFAULT_CASCADE_SPLITS,
 };
 use self::geometry::TerrainGeometryProvider;
 use self::height_ao::create_heightfield_init_resources;

--- a/src/terrain/renderer/aov.rs
+++ b/src/terrain/renderer/aov.rs
@@ -488,7 +488,7 @@ impl TerrainScene {
         let height_inputs =
             self.upload_height_inputs(heightmap, water_mask, params.terrain_data_revision)?;
         self.prepare_geometry(params)?;
-        let probe_world_span = if params.camera_mode.to_lowercase() == "mesh" {
+        let probe_world_span = if is_mesh_camera_mode(&params.camera_mode) {
             params.terrain_span.max(1e-3)
         } else {
             1.0

--- a/src/terrain/renderer/core.rs
+++ b/src/terrain/renderer/core.rs
@@ -254,6 +254,22 @@ pub(super) fn is_clipmap_camera_mode(camera_mode: &str) -> bool {
     terrain_camera_mode_tag(camera_mode).eq_ignore_ascii_case("clipmap")
 }
 
+/// True when the camera mode carries the `zup` option (e.g. `"mesh:zup"`).
+///
+/// Mesh-mode terrain lives in the world XY plane with heights along +Z, but
+/// the legacy orbit camera is parameterized around +Y with `up = Vec3::Y` —
+/// a grid axis — so oblique views render rolled and north-south inverted.
+/// `zup` opts into a Z-up orbit (theta = polar angle from +Z, 0 looks straight
+/// down; phi = azimuth in the terrain plane) with `up = Vec3::Z`, matching the
+/// interactive viewer's terrain semantics. Kept as an opt-in suffix so
+/// existing `"mesh"` callers keep byte-identical output.
+pub(super) fn is_zup_camera_mode(camera_mode: &str) -> bool {
+    camera_mode
+        .split(':')
+        .skip(1)
+        .any(|part| part.trim().eq_ignore_ascii_case("zup"))
+}
+
 pub(super) fn clipmap_camera_config(
     camera_mode: &str,
 ) -> Option<crate::terrain::clipmap::ClipmapConfig> {
@@ -472,5 +488,23 @@ impl Drop for TerrainScene {
         if self.reflection_probe_grid_uniform_alloc_bytes > 0 {
             tracker.free_buffer_allocation(self.reflection_probe_grid_uniform_alloc_bytes, false);
         }
+    }
+}
+
+#[cfg(test)]
+mod camera_mode_tests {
+    use super::{is_clipmap_camera_mode, is_mesh_camera_mode, is_zup_camera_mode};
+
+    #[test]
+    fn zup_suffix_is_detected_and_tag_helpers_still_match() {
+        assert!(is_zup_camera_mode("mesh:zup"));
+        assert!(is_zup_camera_mode("mesh:ZUP"));
+        assert!(is_mesh_camera_mode("mesh:zup"));
+        assert!(!is_zup_camera_mode("mesh"));
+        assert!(!is_zup_camera_mode("screen"));
+        assert!(!is_zup_camera_mode("zup"));
+        assert!(is_clipmap_camera_mode("clipmap:4:64"));
+        assert!(!is_zup_camera_mode("clipmap:4:64"));
+        assert!(is_zup_camera_mode("clipmap:4:64:zup"));
     }
 }

--- a/src/terrain/renderer/offline.rs
+++ b/src/terrain/renderer/offline.rs
@@ -460,7 +460,7 @@ impl TerrainScene {
         let height_inputs =
             self.upload_height_inputs(heightmap, water_mask, offline_params.terrain_data_revision)?;
         self.prepare_geometry(&offline_params)?;
-        let probe_world_span = if offline_params.camera_mode.to_lowercase() == "mesh" {
+        let probe_world_span = if is_mesh_camera_mode(&offline_params.camera_mode) {
             offline_params.terrain_span.max(1e-3)
         } else {
             1.0

--- a/src/terrain/renderer/upload.rs
+++ b/src/terrain/renderer/upload.rs
@@ -336,13 +336,36 @@ impl TerrainScene {
         let phi_rad = params.cam_phi_deg.to_radians();
         let theta_rad = params.cam_theta_deg.to_radians();
 
-        let eye_x = params.cam_target[0] + params.cam_radius * theta_rad.sin() * phi_rad.cos();
-        let eye_y = params.cam_target[1] + params.cam_radius * theta_rad.cos();
-        let eye_z = params.cam_target[2] + params.cam_radius * theta_rad.sin() * phi_rad.sin();
+        let (eye_offset, up) = if is_zup_camera_mode(&params.camera_mode) {
+            // Z-up orbit for terrain that lives in the XY plane with heights
+            // along +Z (mesh mode): theta stays "0 looks straight down", phi
+            // is the azimuth within the terrain plane. Near-vertical views
+            // fall back to +Y for `up` because look_at is degenerate when the
+            // view direction is parallel to the up vector.
+            let offset = glam::Vec3::new(
+                params.cam_radius * theta_rad.sin() * phi_rad.cos(),
+                params.cam_radius * theta_rad.sin() * phi_rad.sin(),
+                params.cam_radius * theta_rad.cos(),
+            );
+            let up = if theta_rad.sin().abs() < 1e-4 {
+                glam::Vec3::Y
+            } else {
+                glam::Vec3::Z
+            };
+            (offset, up)
+        } else {
+            (
+                glam::Vec3::new(
+                    params.cam_radius * theta_rad.sin() * phi_rad.cos(),
+                    params.cam_radius * theta_rad.cos(),
+                    params.cam_radius * theta_rad.sin() * phi_rad.sin(),
+                ),
+                glam::Vec3::Y,
+            )
+        };
 
-        let eye = glam::Vec3::new(eye_x, eye_y, eye_z);
         let target = glam::Vec3::from_array(params.cam_target);
-        let up = glam::Vec3::Y;
+        let eye = target + eye_offset;
         let view = glam::Mat4::look_at_rh(eye, target, up);
         let aspect = params.size_px.0 as f32 / params.size_px.1 as f32;
         let proj = glam::Mat4::perspective_rh(

--- a/src/terrain/renderer/virtual_texture.rs
+++ b/src/terrain/renderer/virtual_texture.rs
@@ -1352,7 +1352,7 @@ impl TerrainMaterialVTRuntime {
         &self,
         params: &crate::terrain::render_params::TerrainRenderParams,
     ) -> ([f32; 2], [f32; 2]) {
-        if params.camera_mode.eq_ignore_ascii_case("mesh") {
+        if super::core::is_mesh_camera_mode(&params.camera_mode) {
             let aspect = params.size_px.0 as f32 / params.size_px.1.max(1) as f32;
             let center = [
                 (params.cam_target[0] / params.terrain_span.max(1e-3)) + 0.5,


### PR DESCRIPTION
## Problem

Mesh-mode terrain lives in the world XY plane with heights along +Z (`terrain_pbr_pom.wgsl` `mesh_world_pos`), but `build_camera_matrices` orbits the eye around +Y with a hard-coded `up = Vec3::Y` — a grid axis. Oblique mesh renders therefore come out rolled with north-south inverted: the camera treats the terrain as a wall. The error nearly cancels at diagonal (phi≈45) cameras, which is how it survived visual review; forge3d-studio's final-render downloads surfaced it as "the downloaded image is upside down".

## Fix

- New opt-in camera mode string **`mesh:zup`** (colon-option, same pattern as `clipmap:N:M`): Z-up orbit with `up = Vec3::Z` (+Y fallback at the top-down pole where look_at degenerates). `cam_theta_deg` keeps its documented "0 looks straight down" meaning; `cam_phi_deg` becomes a true azimuth within the terrain plane.
- Plain `mesh` is untouched and stays byte-identical for existing callers.
- Hardened the three camera-mode checks that compared the raw string against `"mesh"` (aov/offline probe span, virtual-texture visible rect) to `is_mesh_camera_mode` so option suffixes cannot silently change probe scaling.
- Documented the mode in `terrain_params.py`; unit test for the suffix parser.

## Verification

Rebuilt the wheel and A/B-compared the offline pipeline against the interactive viewer on an asymmetric two-cone DEM at azimuths 0°/45°/135°: marker-vector angles agree within 2.5°. Consumers mapping north-up rasters use `np.flipud(dem)` + azimuth negation (the reflection flips orbit handedness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)