### PR TITLE
chore: bump version to 1.33.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -851,7 +851,7 @@ checksum = "aa9a19cbb55df58761df49b23516a86d432839add4af60fc256da840f66ed35b"
 
 [[package]]
 name = "forge3d"
-version = "1.33.1"
+version = "1.33.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "forge3d"
-version = "1.33.1"
+version = "1.33.2"
 edition = "2021"
 autoexamples = false
 description = "GPU-accelerated offline 3D map rendering with Rust-first GIS vector, rasterization, mask, thematic, CRS, affine, windowing, and reprojection support"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "forge3d"
-version = "1.33.1"
+version = "1.33.2"
 description = "forge3d: Rust/WebGPU offline 3D maps with Rust-first GIS vector, rasterization, mask, thematic, CRS, affine, windowing, and reprojection support"
 requires-python = ">=3.10"
 dependencies = [

--- a/python/forge3d/__init__.py
+++ b/python/forge3d/__init__.py
@@ -19,7 +19,7 @@ Utilities:
     has_gpu             - Check GPU availability
 """
 
-__version__ = "1.33.1"
+__version__ = "1.33.2"
 version = __version__
 
 import numpy as np


### PR DESCRIPTION
## Summary
- bump Cargo and Python package metadata to 1.33.2
- prepare the official patch release containing the merged terrain hue-variation capability from #133

## Local verification
- `git diff --check` — pass
- four-source version consistency script — pass (1.33.2)
- `FORGE3D_NO_BOOTSTRAP=1 ... pytest tests/test_install_smoke.py::test_version_consistency -q` — 1 passed
- `cargo metadata --no-deps --format-version 1` — pass (1.33.2)
- `cargo fmt --all -- --check` — pass
- `cargo check --features extension-module` — host kernel SIGKILL at final crate under memory pressure; CI is required for the broad Rust/wheel gate

Closes the release packaging step after #133; no shader or certificate payload changes.