### PR TITLE
Gate ANAMNESIS workloads without losing coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+  schedule:
+    - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
       update_recipe_certificates:
@@ -12,6 +14,10 @@ on:
         required: false
         default: false
         type: boolean
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read
@@ -91,6 +97,7 @@ jobs:
     outputs:
       terrain_goldens: ${{ steps.filter.outputs.terrain_goldens }}
       f3dz: ${{ steps.filter.outputs.f3dz }}
+      anamnesis: ${{ steps.filter.outputs.anamnesis }}
 
     steps:
       - uses: actions/checkout@v4
@@ -142,6 +149,22 @@ jobs:
               - 'tests/data/codec_corpus/**'
               - 'tests/test_f3dz_codec.py'
               - 'tools/f3dz_determinism_report.py'
+            anamnesis:
+              - '.github/workflows/ci.yml'
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'build.rs'
+              - 'pyproject.toml'
+              - '.cargo/**'
+              - 'src/**'
+              - 'python/**'
+              - 'scripts/check_anamnesis_portability.py'
+              - 'scripts/terrain_ci_probe.py'
+              - 'scripts/assert_junit_zero_skips.py'
+              - 'tests/anamnesis_gpu_acceptance.py'
+              - 'tests/anamnesis_irrelevant_inputs.toml'
+              - 'tests/test_anamnesis_*.py'
+              - 'tests/goldens/determinism/**'
 
   # ============================================================================
   # Rust Tests (cargo test)
@@ -377,6 +400,50 @@ jobs:
         env:
           FORGE3D_NO_BOOTSTRAP: '1'
         run: python scripts/ci_pytest_lane.py -v --tb=short
+
+  # ============================================================================
+  # Accounted slow Python tests (one hosted representative)
+  # ============================================================================
+  test-python-slow:
+    name: Test Python Slow (ubuntu, 3.11)
+    needs: [build-wheels, prepare-lfs-fixtures]
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Download shared LFS fixture artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: lfs-fixture-bundles
+          path: lfs-fixture-bundles
+
+      - name: Restore Python TIFF fixtures
+        run: python -m zipfile -e lfs-fixture-bundles/python-tiffs.zip .
+
+      - name: Download Linux wheel artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: wheels-linux
+          path: dist/
+
+      - name: Install wheel and slow-lane dependencies
+        run: |
+          python scripts/install_compatible_wheel.py dist
+          pip install pytest numpy pillow
+
+      - name: Run accounted slow Python lane
+        env:
+          FORGE3D_NO_BOOTSTRAP: '1'
+        run: python scripts/ci_pytest_lane.py --slow-lane -v --tb=short
 
   # ============================================================================
   # TERMINUS deterministic CPU-only robustness fuzzer
@@ -1033,7 +1100,12 @@ jobs:
   # ============================================================================
   test-anamnesis-portability-seed:
     name: ANAMNESIS Physical Seed (Windows Vulkan)
-    needs: build-wheels
+    needs: [build-wheels, terrain-golden-paths]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      needs.terrain-golden-paths.outputs.anamnesis == 'true'
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 20
     env:
@@ -1107,7 +1179,12 @@ jobs:
 
   test-anamnesis-portability:
     name: ANAMNESIS Physical Consume (Windows DX12)
-    needs: [build-wheels, test-anamnesis-portability-seed]
+    needs: [build-wheels, terrain-golden-paths, test-anamnesis-portability-seed]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      needs.terrain-golden-paths.outputs.anamnesis == 'true'
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 20
     env:
@@ -1196,7 +1273,12 @@ jobs:
   # ============================================================================
   test-anamnesis-production:
     name: ANAMNESIS 600-frame Production (NVIDIA Vulkan)
-    needs: build-wheels
+    needs: [build-wheels, terrain-golden-paths]
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      needs.terrain-golden-paths.outputs.anamnesis == 'true'
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 50
     env:
@@ -1347,7 +1429,7 @@ jobs:
   # ============================================================================
   ci-success:
     name: CI Success
-    needs: [prepare-lfs-fixtures, terrain-golden-paths, test-rust, build-wheels, test-python, test-terminus-fuzz, test-python-linux-arm, test-golden-images, refresh-recipe-certificates, test-m06-full-geospatial-viewer, test-f3dz-gpu, test-anamnesis-portability-seed, test-anamnesis-portability, test-anamnesis-production, build-docs]
+    needs: [prepare-lfs-fixtures, terrain-golden-paths, test-rust, build-wheels, test-python, test-python-slow, test-terminus-fuzz, test-python-linux-arm, test-golden-images, refresh-recipe-certificates, test-m06-full-geospatial-viewer, test-f3dz-gpu, test-anamnesis-portability-seed, test-anamnesis-portability, test-anamnesis-production, build-docs]
     runs-on: ubuntu-latest
     if: always()
 
@@ -1363,20 +1445,47 @@ jobs:
           # aggregator. `absent` (no usable adapter) still reports as job
           # `success` and is surfaced by the lane line below, not swallowed.
           echo "golden lane: ${{ needs.test-golden-images.outputs.lane || 'skipped(paths)' }}"
+          anamnesis_required="${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.terrain-golden-paths.outputs.anamnesis == 'true' }}"
+          echo "ANAMNESIS physical lanes required: $anamnesis_required"
+          golden_failed=0
+          if [ "${{ needs.test-golden-images.result }}" != "success" ] && [ "${{ needs.test-golden-images.result }}" != "skipped" ]; then
+            golden_failed=1
+          fi
+          refresh_failed=0
+          if [ "${{ needs.refresh-recipe-certificates.result }}" != "success" ] && [ "${{ needs.refresh-recipe-certificates.result }}" != "skipped" ]; then
+            refresh_failed=1
+          fi
+          f3dz_failed=0
+          if [ "${{ needs.test-f3dz-gpu.result }}" != "success" ] && [ "${{ needs.test-f3dz-gpu.result }}" != "skipped" ]; then
+            f3dz_failed=1
+          fi
+          anamnesis_failed=0
+          if [ "$anamnesis_required" = "true" ]; then
+            if [ "${{ needs.test-anamnesis-portability-seed.result }}" != "success" ] || \
+               [ "${{ needs.test-anamnesis-portability.result }}" != "success" ] || \
+               [ "${{ needs.test-anamnesis-production.result }}" != "success" ]; then
+              anamnesis_failed=1
+            fi
+          else
+            if [ "${{ needs.test-anamnesis-portability-seed.result }}" != "skipped" ] || \
+               [ "${{ needs.test-anamnesis-portability.result }}" != "skipped" ] || \
+               [ "${{ needs.test-anamnesis-production.result }}" != "skipped" ]; then
+              anamnesis_failed=1
+            fi
+          fi
           if [ "${{ needs.prepare-lfs-fixtures.result }}" != "success" ] || \
              [ "${{ needs.terrain-golden-paths.result }}" != "success" ] || \
              [ "${{ needs.test-rust.result }}" != "success" ] || \
              [ "${{ needs.build-wheels.result }}" != "success" ] || \
              [ "${{ needs.test-python.result }}" != "success" ] || \
+             [ "${{ needs.test-python-slow.result }}" != "success" ] || \
              [ "${{ needs.test-terminus-fuzz.result }}" != "success" ] || \
              [ "${{ needs.test-python-linux-arm.result }}" != "success" ] || \
-             { [ "${{ needs.test-golden-images.result }}" != "success" ] && [ "${{ needs.test-golden-images.result }}" != "skipped" ]; } || \
-             { [ "${{ needs.refresh-recipe-certificates.result }}" != "success" ] && [ "${{ needs.refresh-recipe-certificates.result }}" != "skipped" ]; } || \
+             [ "$golden_failed" -ne 0 ] || \
+             [ "$refresh_failed" -ne 0 ] || \
              [ "${{ needs.test-m06-full-geospatial-viewer.result }}" != "success" ] || \
-             { [ "${{ needs.test-f3dz-gpu.result }}" != "success" ] && [ "${{ needs.test-f3dz-gpu.result }}" != "skipped" ]; } || \
-             [ "${{ needs.test-anamnesis-portability-seed.result }}" != "success" ] || \
-             [ "${{ needs.test-anamnesis-portability.result }}" != "success" ] || \
-             [ "${{ needs.test-anamnesis-production.result }}" != "success" ] || \
+             [ "$f3dz_failed" -ne 0 ] || \
+             [ "$anamnesis_failed" -ne 0 ] || \
              [ "${{ needs.build-docs.result }}" != "success" ]; then
             echo "❌ CI failed"
             exit 1

--- a/.github/workflows/determinism-matrix.yml
+++ b/.github/workflows/determinism-matrix.yml
@@ -126,6 +126,10 @@ on:
       - 'tests/goldens/determinism/**'
       - '.github/workflows/determinism-matrix.yml'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   SCENE: terra_determinata_v1
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,6 +17,10 @@ on:
           - 'true'
           - 'false'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 permissions:
   contents: read
 

--- a/scripts/ci_pytest_lane.py
+++ b/scripts/ci_pytest_lane.py
@@ -1,12 +1,12 @@
 #!/usr/bin/env python
 # scripts/ci_pytest_lane.py
-# CENSOR Task 13: the default CI Python test lane. Runs the WHOLE tests/ tree
-# except the files enumerated in tests/UNRUN.toml (each with a documented,
-# owner-attributed, non-expired reason). This is the single honest source of
-# "what Python CI runs by default" -- tests/test_no_silent_degradation.py
-# imports unrun_files() from here so the UNRUN accounting gate stays truthful.
+# CENSOR Task 13: the default CI Python lane selects all accounted test files
+# except tests/UNRUN.toml entries with `not slow`; `--slow-lane` selects those
+# same accounted files with `slow`. This is the single honest source of "what
+# Python CI runs" -- tests/test_no_silent_degradation.py imports unrun_files()
+# from here so the UNRUN accounting gate stays truthful.
 # RELEVANT FILES: tests/UNRUN.toml, tests/_toml_compat.py, .github/workflows/ci.yml
-"""Run pytest over tests/ minus the UNRUN allowlist, forwarding extra argv."""
+"""Run an explicitly accounted pytest lane, forwarding extra argv."""
 from __future__ import annotations
 
 import subprocess
@@ -18,6 +18,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 TESTS = ROOT / "tests"
 UNRUN_TOML = TESTS / "UNRUN.toml"
+SLOW_LANE_SELECTOR = "--slow-lane"
 
 # tests/_toml_compat.py is the shared loader (stdlib tomllib on >=3.11, tiny
 # hand-rolled fallback on 3.10 where CI still runs).
@@ -47,14 +48,21 @@ def default_lane_files() -> list[str]:
     return [f for f in _all_test_files() if f not in unrun]
 
 
-def build_pytest_args(passthrough: list[str]) -> list[str]:
-    """Compose the pytest argv: the explicit run-list + passthrough.
+def build_pytest_args(passthrough: list[str], *, slow: bool = False) -> list[str]:
+    """Compose the pytest argv: explicit files, marker selection, passthrough.
 
     We pass the file list explicitly rather than `tests/ --ignore=<file>`
     to make the lane's accounting directly inspectable and to prevent UNRUN
     files that fail at collection time from ever being imported.
+
+    ``--slow-lane`` is private to this wrapper.  It selects the same accounted
+    files with the ``slow`` marker and is removed before pytest sees argv.
     """
-    return [*default_lane_files(), *passthrough]
+    forwarded = list(passthrough)
+    if SLOW_LANE_SELECTOR in forwarded:
+        slow = True
+        forwarded.remove(SLOW_LANE_SELECTOR)
+    return [*default_lane_files(), "-m", "slow" if slow else "not slow", *forwarded]
 
 
 def _github_escape(message: str) -> str:

--- a/tests/test_anamnesis_incremental.py
+++ b/tests/test_anamnesis_incremental.py
@@ -26,6 +26,7 @@ def _recipe(text: str) -> dict:
     }
 
 
+@pytest.mark.slow
 def test_600_frame_incremental_matches_cold_and_recomputes_exact_set(tmp_path):
     warm_store = tmp_path / "warm"
     cold_store = tmp_path / "cold-modified"
@@ -95,6 +96,7 @@ def test_structured_scheduler_executes_only_changed_passes(tmp_path):
         label: f"test-executor:{label}".encode("utf-8") for label in executors
     }
     options = {
+        "frames": [250],
         "verify_reads": False,
         "pass_executors": executors,
         "pass_executor_fingerprints": fingerprints,

--- a/tests/test_assert_junit_zero_skips.py
+++ b/tests/test_assert_junit_zero_skips.py
@@ -263,7 +263,7 @@ def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
     root = Path(__file__).resolve().parents[1]
     exact_ref = "ref: ${{ github.event.pull_request.head.sha || github.sha }}"
     expected_counts = {
-        "ci.yml": 16,
+        "ci.yml": 17,
         "determinism-matrix.yml": 6,
     }
 

--- a/tests/test_ci_lfs_fanout.py
+++ b/tests/test_ci_lfs_fanout.py
@@ -25,7 +25,7 @@ def test_ci_downloads_verified_lfs_media_once_and_shares_one_artifact() -> None:
     assert "875b243474b151175f76037acd60c2149ac2e46fba9ba2bbce0c9a6998015dd3" in workflow
     assert "d09d229fa265749720a6b4bd40c440799f43286bf2d401d732ea77f89d0bd478" in workflow
     assert "is still an LFS pointer" in workflow
-    assert workflow.count("name: lfs-fixture-bundles") == 3
+    assert workflow.count("name: lfs-fixture-bundles") == 4
     assert workflow.count("uses: actions/upload-artifact@v4") >= 1
     assert "retention-days: 1" in workflow
 
@@ -50,7 +50,10 @@ def test_ci_lfs_manifest_contains_only_lane_fixtures() -> None:
 def test_python_and_m06_restore_only_their_fixture_bundles() -> None:
     workflow = _workflow()
     python_job = workflow.split("  test-python:", 1)[1].split(
-        "  test-terminus-fuzz:", 1
+        "\n  # ============================================================================\n  # Accounted slow Python tests (one hosted representative)", 1
+    )[0]
+    slow_job = workflow.split("  test-python-slow:", 1)[1].split(
+        "\n  # ============================================================================\n  # TERMINUS", 1
     )[0]
     golden_job = workflow.split("  test-golden-images:", 1)[1].split(
         "  refresh-recipe-certificates:", 1
@@ -59,9 +62,12 @@ def test_python_and_m06_restore_only_their_fixture_bundles() -> None:
         "  build-docs:", 1
     )[0]
 
-    assert "needs: [build-wheels, prepare-lfs-fixtures]" in python_job
-    assert "python-tiffs.zip" in python_job
-    assert "forge3d.pdb" not in python_job
+    for job in (python_job, slow_job):
+        assert "needs: [build-wheels, prepare-lfs-fixtures]" in job
+        assert job.count(".zip") == 1
+        assert "python-tiffs.zip" in job
+        assert "m06-dem.zip" not in job
+        assert "forge3d.pdb" not in job
     assert "lfs-fixture-bundles" not in golden_job
     assert "needs: [build-wheels, prepare-lfs-fixtures]" in m06_job
     assert "m06-dem.zip" in m06_job

--- a/tests/test_no_silent_degradation.py
+++ b/tests/test_no_silent_degradation.py
@@ -361,6 +361,85 @@ def test_e_unrun_accounting_is_exhaustive_and_honest():
     )
 
 
+def test_e_slow_lane_is_marker_selected_and_accounted():
+    default_args = ci_pytest_lane.build_pytest_args([])
+    slow_args = ci_pytest_lane.build_pytest_args(
+        [ci_pytest_lane.SLOW_LANE_SELECTOR]
+    )
+    assert default_args[default_args.index("-m") + 1] == "not slow"
+    assert slow_args[slow_args.index("-m") + 1] == "slow"
+    assert ci_pytest_lane.SLOW_LANE_SELECTOR not in slow_args
+
+    ci_yml = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    slow_job = ci_yml.split("  test-python-slow:", 1)[1].split(
+        "\n  # ============================================================================\n  # TERMINUS", 1
+    )[0]
+    assert "python scripts/ci_pytest_lane.py --slow-lane" in slow_job
+    aggregate = ci_yml.split("  ci-success:", 1)[1]
+    assert "test-python-slow" in aggregate.split("\n    runs-on:", 1)[0]
+
+
+def test_e_anamnesis_physical_jobs_are_path_gated_honestly():
+    ci_yml = (ROOT / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    paths_job = ci_yml.split("  terrain-golden-paths:", 1)[1].split(
+        "\n  # ============================================================================\n  # Rust Tests", 1
+    )[0]
+    assert "anamnesis: ${{ steps.filter.outputs.anamnesis }}" in paths_job
+    for path in (
+        "'src/**'",
+        "'python/**'",
+        "'scripts/check_anamnesis_portability.py'",
+        "'scripts/terrain_ci_probe.py'",
+        "'scripts/assert_junit_zero_skips.py'",
+        "'tests/anamnesis_gpu_acceptance.py'",
+        "'tests/goldens/determinism/**'",
+    ):
+        assert path in paths_job
+
+    required = (
+        "github.event_name == 'workflow_dispatch'",
+        "github.event_name == 'schedule'",
+        "github.event_name == 'push' && github.ref == 'refs/heads/main'",
+        "needs.terrain-golden-paths.outputs.anamnesis == 'true'",
+    )
+    for job_name in (
+        "test-anamnesis-portability-seed",
+        "test-anamnesis-portability",
+        "test-anamnesis-production",
+    ):
+        job = ci_yml.split(f"  {job_name}:", 1)[1].split(
+            "\n    runs-on:", 1
+        )[0]
+        for fragment in required:
+            assert fragment in job
+    production = ci_yml.split("  test-anamnesis-production:", 1)[1].split(
+        "\n  # ============================================================================\n  # Documentation Build", 1
+    )[0]
+    assert "test_real_gpu_600_frame_acceptance" in production
+    aggregate = ci_yml.split("  ci-success:", 1)[1]
+    assert "anamnesis_required" in aggregate
+    required_branch, skip_tail = aggregate.split(
+        'if [ "$anamnesis_required" = "true" ]; then', 1
+    )[1].split("\n          else\n", 1)
+    skip_branch = skip_tail.split("\n          fi\n          if ", 1)[0]
+    for job_name in (
+        "test-anamnesis-portability-seed",
+        "test-anamnesis-portability",
+        "test-anamnesis-production",
+    ):
+        result_prefix = f"needs.{job_name}.result "
+        success_check = result_prefix + '}}" != "success"'
+        skipped_check = result_prefix + '}}" != "skipped"'
+        assert success_check in required_branch
+        assert success_check not in skip_branch
+        assert skipped_check in skip_branch
+        assert skipped_check not in required_branch
+
+
 # ---------------------------------------------------------------------------
 # (f) visual-golden lane honesty
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- run the structured scheduler contract at `frames=[250]`
- exclude `slow` from the default Python lane and add an accountable hosted slow lane
- keep the CPU 600-frame and 10,000-mutation gates in that slow lane
- cancel superseded PR workflow runs
- path-gate physical ANAMNESIS jobs while retaining the full 600-frame gate for relevant changes, `main`, nightly, and manual runs
- keep the optional 60-frame PR smoke out until live timing shows it is needed

## Why

ANAMNESIS coverage was concentrated in the default and physical lanes, causing avoidable PR cost. The previous layout also let superseded runs continue. This separates fast and slow accountability while keeping required physical coverage fail-closed.

## Validation

- canonical Python lane: 3725 passed, 71 skipped, 6 deselected
- focused CI/accounting contracts: 12 passed
- CPU 600-frame + 10,000-mutation gates: 2 passed
- workflow YAML parsed and all `needs` references resolved
- `git diff --check` passed
- commit hook `cargo clippy` passed
- fresh Sol review: `ship`
- pre-push Standards and Spec reviews: pass

## Residual risk

The first live scheduled and path-filtered GitHub Actions runs remain operational validation; the workflow fails closed if required physical runners do not succeed.