### PR TITLE
Fix debug-build NVIDIA Vulkan terrain pipeline crash (validation layer x shader debug info)

### DIFF
--- a/src/core/fence_tracker.rs
+++ b/src/core/fence_tracker.rs
@@ -172,7 +172,7 @@ mod tests {
         let instance = Instance::new(wgpu::InstanceDescriptor {
             backends: Backends::all(),
             dx12_shader_compiler: Default::default(),
-            flags: wgpu::InstanceFlags::default(),
+            flags: crate::core::gpu::instance_flags(),
             gles_minor_version: wgpu::Gles3MinorVersion::Automatic,
         });
 

--- a/src/core/gpu.rs
+++ b/src/core/gpu.rs
@@ -156,6 +156,22 @@ fn parse_backend_request(raw: String) -> RenderResult<(String, wgpu::Backends, w
     Ok((raw, pair.0, pair.1))
 }
 
+/// Instance flags for every forge3d-owned wgpu instance.
+///
+/// wgpu's build-config default enables DEBUG and VALIDATION together in
+/// debug builds. DEBUG makes naga embed the complete WGSL source and line
+/// table as SPIR-V debug info, and the Vulkan SDK's validation layer
+/// (observed with VK_LAYER_KHRONOS_validation 1.4.313 on Windows/NVIDIA)
+/// crashes with an access violation while consuming the multi-thousand-line
+/// terrain module in that form — either feature alone is fine. Keep
+/// VALIDATION's real API coverage in debug builds and drop only the embedded
+/// shader sources; `WGPU_DEBUG=1` opts back in and `WGPU_VALIDATION=0` opts
+/// out, per wgpu's standard environment convention. Release builds keep
+/// wgpu's empty default.
+pub(crate) fn instance_flags() -> wgpu::InstanceFlags {
+    (wgpu::InstanceFlags::default() - wgpu::InstanceFlags::DEBUG).with_env()
+}
+
 fn backends_from_env() -> RenderResult<wgpu::Backends> {
     if let Some((_, mask, _)) = requested_backend_from_env()? {
         return Ok(mask);
@@ -203,6 +219,7 @@ pub fn try_ctx() -> RenderResult<&'static GpuContext> {
         let backends = backends_from_env()?;
         let mut instance_desc = wgpu::InstanceDescriptor {
             backends,
+            flags: instance_flags(),
             ..Default::default()
         };
         let dx12_compiler = if deterministic_mode() {
@@ -400,6 +417,7 @@ pub fn align_copy_bpr(unpadded: u32) -> u32 {
 pub fn create_device_for_test() -> Option<wgpu::Device> {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::all(),
+        flags: instance_flags(),
         ..Default::default()
     });
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {
@@ -448,6 +466,7 @@ pub fn create_device_for_test() -> Option<wgpu::Device> {
 pub fn create_device_and_queue_for_test() -> Option<(wgpu::Device, wgpu::Queue)> {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::all(),
+        flags: instance_flags(),
         ..Default::default()
     });
     let adapter = pollster::block_on(instance.request_adapter(&wgpu::RequestAdapterOptions {

--- a/src/core/staging_rings.rs
+++ b/src/core/staging_rings.rs
@@ -334,7 +334,7 @@ mod tests {
         let instance = Instance::new(wgpu::InstanceDescriptor {
             backends: Backends::all(),
             dx12_shader_compiler: Default::default(),
-            flags: wgpu::InstanceFlags::default(),
+            flags: crate::core::gpu::instance_flags(),
             gles_minor_version: wgpu::Gles3MinorVersion::Automatic,
         });
 

--- a/src/viewer/init/device_init.rs
+++ b/src/viewer/init/device_init.rs
@@ -49,6 +49,7 @@ pub async fn create_device_and_surface(
         .map_or(wgpu::Backends::all(), |(_, mask, _)| *mask);
     let instance = Instance::new(wgpu::InstanceDescriptor {
         backends: backend_mask,
+        flags: crate::core::gpu::instance_flags(),
         ..Default::default()
     });
 

--- a/tests/test_terrain_runtime.py
+++ b/tests/test_terrain_runtime.py
@@ -1,9 +1,13 @@
 from __future__ import annotations
 
+import json
+import os
+import subprocess
 import sys
 import types
 
 import _terrain_runtime as terrain_runtime
+import pytest
 from forge3d import map_scene
 
 
@@ -106,3 +110,122 @@ def test_terrain_rendering_available_uses_child_probe(monkeypatch) -> None:
         assert str(repo / "python") not in child_pythonpath
     finally:
         terrain_runtime.terrain_rendering_available.cache_clear()
+
+
+def test_nvidia_vulkan_terrain_constructor_child_smoke() -> None:
+    """The public terrain constructor must return on a qualifying Vulkan GPU.
+
+    Keep this in a fresh child process: the native GPU context is global and a
+    prior test must not select another backend before this constructor seam is
+    exercised.  The children run the DEFAULT instance-flag configuration, so
+    ambient ``WGPU_DEBUG``/``WGPU_VALIDATION`` overrides and Vulkan loader
+    layer filters are stripped from their environment — the historic
+    regression (validation layer crashing on debug-info-laden terrain SPIR-V)
+    only reproduces under specific flag combinations and must not be masked
+    or spuriously reintroduced by the invoking shell.  A non-qualifying host
+    is an honest absence for this physical adapter regression gate, not a
+    synthetic pass; ``device_probe`` never raises, so a probe child that
+    exits nonzero, times out, or prints no JSON is an operational failure,
+    not adapter absence.
+    """
+
+    env = dict(os.environ)
+    for override in (
+        "WGPU_DEBUG",
+        "WGPU_VALIDATION",
+        "WGPU_ALLOW_UNDERLYING_NONCOMPLIANT_ADAPTER",
+        "VK_INSTANCE_LAYERS",
+        "VK_LOADER_LAYERS_ENABLE",
+        "VK_LOADER_LAYERS_DISABLE",
+    ):
+        env.pop(override, None)
+    env.update(WGPU_BACKENDS="vulkan", WGPU_BACKEND="vulkan", PYTHONUNBUFFERED="1")
+    try:
+        probe = subprocess.run(
+            [
+                sys.executable,
+                "-u",
+                "-c",
+                "import json, forge3d as f3d; print(json.dumps(f3d.device_probe('vulkan')))",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(
+            "NVIDIA Vulkan adapter probe child timed out after 120s; "
+            "device_probe reports absence as a status dict, so a hang is an "
+            f"operational failure: stdout={exc.stdout!r} stderr={exc.stderr!r}",
+            pytrace=False,
+        )
+    if probe.returncode != 0:
+        exit_hex = f"0x{probe.returncode & 0xFFFFFFFF:08X}"
+        pytest.fail(
+            "NVIDIA Vulkan adapter probe child failed; device_probe never "
+            f"raises, so a nonzero exit is an operational failure: "
+            f"exit={probe.returncode} ({exit_hex}) stdout={probe.stdout!r} "
+            f"stderr={probe.stderr!r}",
+            pytrace=False,
+        )
+    try:
+        adapter = json.loads(probe.stdout.strip().splitlines()[-1])
+    except (json.JSONDecodeError, IndexError):
+        pytest.fail(
+            "NVIDIA Vulkan adapter probe child exited 0 without a JSON "
+            f"probe dict: stdout={probe.stdout!r} stderr={probe.stderr!r}",
+            pytrace=False,
+        )
+    if not isinstance(adapter, dict) or adapter.get("status") not in ("ok", "no_adapter"):
+        pytest.fail(
+            "NVIDIA Vulkan adapter probe returned no structurally valid "
+            "verdict (expected a dict with status 'ok' or 'no_adapter'): "
+            f"{adapter!r} stderr={probe.stderr!r}",
+            pytrace=False,
+        )
+    vendor = adapter.get("vendor")
+    if adapter.get("status") == "ok" and type(vendor) is not int:
+        pytest.fail(
+            "NVIDIA Vulkan adapter probe returned status 'ok' without an "
+            f"integer vendor id: {adapter!r}",
+            pytrace=False,
+        )
+    if not (
+        adapter.get("status") == "ok"
+        and str(adapter.get("backend", "")).lower() == "vulkan"
+        and str(adapter.get("device_type", "")).lower() == "discretegpu"
+        and vendor == 0x10DE
+        and not bool(adapter.get("software_fallback", True))
+    ):
+        pytest.skip(f"qualifying NVIDIA Vulkan adapter absent: {adapter!r}")
+
+    try:
+        result = subprocess.run(
+            [
+                sys.executable,
+                "-u",
+                "-c",
+                "import forge3d as f3d; "
+                "session = f3d.Session(window=False); "
+                "f3d.TerrainRenderer(session)",
+            ],
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=120,
+        )
+    except subprocess.TimeoutExpired as exc:
+        pytest.fail(
+            "NVIDIA Vulkan TerrainRenderer constructor child timed out after 120s: "
+            f"stdout={exc.stdout!r} stderr={exc.stderr!r}",
+            pytrace=False,
+        )
+    exit_hex = f"0x{result.returncode & 0xFFFFFFFF:08X}"
+    assert result.returncode == 0, (
+        "NVIDIA Vulkan TerrainRenderer constructor child failed: "
+        f"exit={result.returncode} ({exit_hex}) stdout={result.stdout!r} "
+        f"stderr={result.stderr!r}"
+    )


### PR DESCRIPTION
## Root cause

On Windows/NVIDIA hosts with the Vulkan SDK installed, **debug builds** of forge3d crashed with `STATUS_ACCESS_VIOLATION` (0xC0000005) inside `vkCreateGraphicsPipelines` while the `TerrainRenderer` constructor built the terrain pipeline. Isolation matrix on an RTX 3070 (driver-level repro, 3x runs per cell):

| wgpu `DEBUG` flag | wgpu `VALIDATION` flag | Result |
|---|---|---|
| on | on | crash |
| off | on | OK |
| on | off | OK |
| on | on, loader layers disabled (`VK_LOADER_LAYERS_DISABLE=~all~`) | OK |

wgpu's build-config default enables `InstanceFlags::DEBUG | VALIDATION` together in debug builds. `DEBUG` makes naga embed the complete ~7,000-line assembled terrain WGSL source plus line table as SPIR-V debug info, and `VK_LAYER_KHRONOS_validation` (SDK 1.4.313) faults while consuming the terrain module in that form. Either feature alone is fine. **Release builds use empty flags and were never affected** — pristine unsplit `main` passes 3/3 as a release build on the same machine, so CI release wheels and PyPI users never saw this.

## Why not a WGSL / stage-split fix

The originally staged approach (splitting `terrain_pbr_pom` into vertex/fragment stage modules, a bounded-stack pipeline worker, and a `textureDimensions` explicit-level change) was carried through hypothesis testing and **falsified**: each variant merely perturbed the module bytes (the embedded debug-info source), which flips the layer bug non-deterministically. With the real two-factor trigger held constant, the split tree still crashed and unsplit `main` still passed. None of that machinery ships here; `main`'s shadow behavior and WGSL are completely untouched.

## The fix

A single shared helper, `core::gpu::instance_flags()`, now routes **every forge3d-owned wgpu instance** (global context, viewer, in-crate test devices):

```rust
(wgpu::InstanceFlags::default() - wgpu::InstanceFlags::DEBUG).with_env()
```

- Debug builds keep `VALIDATION`'s real API coverage and drop only the embedded shader sources.
- Release builds keep wgpu's empty default — zero behavior change.
- Both bits remain overridable via wgpu's standard `WGPU_DEBUG` / `WGPU_VALIDATION` env convention, so no capability is removed.

## Regression test

`tests/test_terrain_runtime.py::test_nvidia_vulkan_terrain_constructor_child_smoke` runs `Session(window=False)` + `TerrainRenderer` in a fresh child process under the **default** flag configuration on a qualifying physical NVIDIA Vulkan adapter (child env sanitized of `WGPU_*`/Vulkan-loader overrides). Probe timeouts, nonzero exits, and structurally invalid probe verdicts fail loudly; only a structurally valid non-qualifying verdict skips. This test was red on this hardware before the fix and is green after (debug and release builds).

## Certificates

The pre-approved protected refresh of the 22 committed recipe certificates is **not needed**: this diff contains no WGSL, shader-label, golden, or certificate changes, so the committed certificates remain byte-identical to `main` and stay valid (verified: `git diff main..HEAD` touches only the five files above; local `test_determinism_hash` green).

## Validation (local, RTX 3070 / Windows 11, debug build unless noted)

- `cargo fmt --check` PASS; `cargo forge3d-clippy` PASS
- `maturin develop` PASS (also `--release`)
- `tests/test_api_contracts.py`: 403 passed
- `tests/test_terrain_runtime.py`: 7 passed (incl. the new NVIDIA child gate; also green 3/3 on release build)
- `tests/test_shader_reachability.py` + `tests/test_shader_proofs.py`: passed (1 expected feature-gated skip)
- `tests/test_shadow_techniques.py` + `tests/test_determinism_hash.py`: 486 passed / 5 pre-existing asset-gated skips across the combined battery
- `scripts/terrain_ci_probe.py --mode terrain` and `--mode terrain-aov` with `--require-nvidia-vulkan`: exit 0, `software_fallback=false`
- Rust: `cargo test --lib verify` (93 passed) and `--lib shader_sources` (all passed) under the curated CI feature set
- Independent Codex (Luna) review: 2 MAJOR + 1 NIT findings, all fixed and re-verified RESOLVED

Not run locally: the full hosted CI matrix (Rust test legs, docs, wheels) — delegated to this PR's checks.

## Scope

Explicitly excluded: everything from the abandoned `codex/d-drive-migration-runtime` lineage — no `examples/` files, no D-drive migration artifacts, no generated binaries, no certificate or golden changes. The diff is exactly five files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)