### PR TITLE
Split hosted core CI from selected determinism and physical acceptance

### DIFF
--- a/.claude/rules/build-and-ci.md
+++ b/.claude/rules/build-and-ci.md
@@ -20,10 +20,11 @@ paths: ["Cargo.toml", "pyproject.toml", ".cargo/**", ".github/workflows/**", "py
   `FORGE3D_CERT_SIGNING_KEY` and verify committed certificates against the
   pinned production public key. Fork PRs are explicitly untrusted and do not
   claim production-signing validation.
-- `determinism-matrix` is an experimental, non-required diagnostic until the
+- `determinism-matrix` is a reusable, path-selected diagnostic until the
   documented fixed-function filtering and downstream compiler differences in
   `src/shaders/includes/determinism.wgsl` are eliminated. Its per-backend
   render jobs and zero-byte diff must stay loud; cross-adapter hash divergence
   is permitted as diagnostic evidence and must never be presented as a green
   determinism guarantee or used to replace the committed hash casually. The
-  protected release gate remains the `CI Success` aggregate.
+  stable hosted pull-request gate is `PR Core Success`; physical and selected
+  determinism evidence is reported separately by `Full Acceptance Summary`.

--- a/.github/workflows/build-wheel.yml
+++ b/.github/workflows/build-wheel.yml
@@ -1,0 +1,65 @@
+name: Build one wheel
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Exact commit SHA to build.
+        required: true
+        type: string
+      runner:
+        description: GitHub runner image.
+        required: true
+        type: string
+      target:
+        description: Rust target triple.
+        required: true
+        type: string
+      maturin_args:
+        description: Arguments passed to maturin.
+        required: true
+        type: string
+      manylinux:
+        description: maturin manylinux mode.
+        required: true
+        type: string
+      artifact:
+        description: Artifact name for the wheel.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build ${{ inputs.artifact }}
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Prove exact-head checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD: ${{ inputs.ref }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+
+      - name: Build wheel
+        uses: PyO3/maturin-action@v1
+        env:
+          # ring's aarch64 assembly expects this macro under the manylinux cross compiler.
+          CFLAGS_aarch64_unknown_linux_gnu: ${{ inputs.target == 'aarch64-unknown-linux-gnu' && '-D__ARM_ARCH=8' || '' }}
+        with:
+          target: ${{ inputs.target }}
+          args: ${{ inputs.maturin_args }}
+          manylinux: ${{ inputs.manylinux }}
+
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ inputs.artifact }}
+          path: dist/*.whl
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/certificate-refresh.yml
+++ b/.github/workflows/certificate-refresh.yml
@@ -1,0 +1,93 @@
+name: Refresh recipe certificates
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm:
+        description: Confirm this reviewed exact ref should produce new signed certificates.
+        required: true
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+concurrency:
+  group: certificate-refresh-production
+  cancel-in-progress: false
+
+jobs:
+  build-wheel-windows:
+    name: Build exact-ref Windows wheel
+    # Signing authority is never exposed to candidate-controlled branch code.
+    if: inputs.confirm && github.ref == 'refs/heads/main' && github.ref_protected
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      ref: ${{ github.sha }}
+      runner: windows-latest
+      target: x86_64-pc-windows-msvc
+      maturin_args: --release --out dist
+      manylinux: 'auto'
+      artifact: certificate-refresh-wheel-windows
+
+  refresh:
+    name: Render and sign on NVIDIA Vulkan
+    needs: build-wheel-windows
+    if: inputs.confirm && github.ref == 'refs/heads/main' && github.ref_protected
+    runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
+    environment: production-signing
+    timeout-minutes: 30
+    env:
+      WGPU_BACKEND: vulkan
+      FORGE3D_ALLOW_HOSTED_WINDOWS_TERRAIN: '1'
+      FORGE3D_CERT_SIGNING_KEY: ${{ secrets.FORGE3D_CERT_SIGNING_KEY }}
+      FORGE3D_REQUIRE_PRODUCTION_SIGNING: '1'
+      FORGE3D_NO_BOOTSTRAP: '1'
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - name: Prove exact-head checkout
+        shell: pwsh
+        run: |
+          $actual = (git rev-parse HEAD).Trim()
+          if ($actual -ne '${{ github.sha }}') {
+            throw "certificate refresh checkout mismatch: expected=${{ github.sha }} actual=$actual"
+          }
+          $actual | Set-Content "$env:RUNNER_TEMP/certificate-refresh-head.txt"
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: certificate-refresh-wheel-windows
+          path: dist/
+
+      - name: Install exact-ref wheel and test dependencies
+        shell: pwsh
+        run: |
+          python scripts/install_compatible_wheel.py dist
+          python -m pip install pytest numpy pyproj pillow
+
+      - name: Require production signing and physical NVIDIA Vulkan
+        shell: pwsh
+        run: |
+          if (-not $env:FORGE3D_CERT_SIGNING_KEY) { throw 'missing production signing key' }
+          python scripts/terrain_ci_probe.py --mode terrain --require-nvidia-vulkan --json "$env:RUNNER_TEMP/certificate-refresh-adapter.json"
+
+      - name: Render and sign the recipe catalog
+        env:
+          FORGE3D_RUN_TERRAIN_GOLDENS: '1'
+          FORGE3D_UPDATE_RECIPE_CERTIFICATES: '1'
+        run: python -m pytest tests/test_recipe_goldens.py::test_recipe_goldens_render_and_match -v --tb=short
+
+      - name: Upload signed certificates and provenance
+        uses: actions/upload-artifact@v4
+        with:
+          name: refreshed-recipe-certificates
+          path: |
+            tests/golden/certificates/*.json
+            ${{ runner.temp }}/certificate-refresh-head.txt
+            ${{ runner.temp }}/certificate-refresh-adapter.json
+          if-no-files-found: error
+          retention-days: 90

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,30 +5,66 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main, develop]
+    # labeled/unlabeled make the run-physical opt-in take effect immediately;
+    # PR concurrency cancels the obsolete run when the label changes.
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
   schedule:
     - cron: '0 3 * * *'
   workflow_dispatch:
     inputs:
-      update_recipe_certificates:
-        description: Refresh signed recipe certificates after a reviewed WGSL change.
-        required: false
-        default: false
-        type: boolean
+      scope:
+        description: Select the expensive acceptance scope; core is hosted CI only.
+        required: true
+        default: core
+        type: choice
+        options:
+          - core
+          - full
+          - determinism
+          - m06
+          - f3dz
+          - anamnesis
 
 permissions:
   contents: read
   pull-requests: read
 
 concurrency:
-  # Keep reviewed certificate refreshes isolated from ordinary CI cancellation.
-  group: ${{ github.workflow }}-${{ github.event_name == 'workflow_dispatch' && inputs.update_recipe_certificates && format('certificate-refresh-{0}', github.run_id) || github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'workflow_dispatch' && format('manual-{0}', github.ref_name) || format('run-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && !inputs.update_recipe_certificates) }}
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.event_name == 'workflow_dispatch' && format('manual-{0}', github.ref_name) || format('run-{0}', github.run_id) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
 
 env:
   CARGO_TERM_COLOR: always
   RUST_BACKTRACE: 1
 
 jobs:
+  # Cheap repository-native workflow contracts run before any Rust matrix,
+  # wheel build, LFS download, or physical-runner allocation.
+  preflight:
+    name: CI Preflight
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Validate workflow and cost-control contracts
+        env:
+          FORGE3D_NO_BOOTSTRAP: '1'
+        run: |
+          python -m pip install pytest pyyaml
+          python -m pytest \
+            tests/test_assert_junit_zero_skips.py \
+            tests/test_ci_cost_controls.py \
+            tests/test_ci_lfs_fanout.py \
+            tests/test_determinism_matrix.py \
+            -q
+
   # ============================================================================
   # Shared Git LFS fixtures
   #
@@ -39,6 +75,7 @@ jobs:
   # ============================================================================
   prepare-lfs-fixtures:
     name: Prepare LFS Fixtures
+    needs: preflight
     runs-on: ubuntu-latest
 
     steps:
@@ -94,12 +131,17 @@ jobs:
   # ============================================================================
   terrain-golden-paths:
     name: Visual Golden Paths
+    needs: preflight
     runs-on: ubuntu-latest
     outputs:
       terrain_goldens: ${{ steps.filter.outputs.terrain_goldens }}
       m06: ${{ steps.filter.outputs.m06 }}
       f3dz: ${{ steps.filter.outputs.f3dz }}
       anamnesis: ${{ steps.filter.outputs.anamnesis }}
+      determinism_render: ${{ steps.filter.outputs.determinism_render }}
+      determinism_f3dz: ${{ steps.filter.outputs.determinism_f3dz }}
+      determinism_anamnesis: ${{ steps.filter.outputs.determinism_anamnesis }}
+      tessella: ${{ steps.filter.outputs.tessella }}
 
     steps:
       - uses: actions/checkout@v4
@@ -134,6 +176,8 @@ jobs:
               - 'tests/golden/hybrid_terrain/**'
               - 'docs/gallery/**'
             m06:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/build-wheel.yml'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'build.rs'
@@ -158,6 +202,8 @@ jobs:
               - 'assets/fonts/**'
               - 'assets/geoid/egm96_n120.bin'
             f3dz:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/build-wheel.yml'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'build.rs'
@@ -195,6 +241,8 @@ jobs:
               - 'tests/_toml_compat.py'
               - 'tests/test_f3dz_codec.py'
             anamnesis:
+              - '.github/workflows/ci.yml'
+              - '.github/workflows/build-wheel.yml'
               - 'Cargo.toml'
               - 'Cargo.lock'
               - 'build.rs'
@@ -269,12 +317,69 @@ jobs:
               - 'tests/anamnesis_irrelevant_inputs.toml'
               - 'tests/test_anamnesis_*.py'
               - 'tests/goldens/determinism/**'
+            determinism_render:
+              - '.github/workflows/determinism-matrix.yml'
+              - 'src/shaders/includes/determinism.wgsl'
+              - 'src/shaders/includes/shadow_moments.wgsl'
+              - 'src/shaders/includes/tonemap_common.wgsl'
+              - 'src/shaders/shadows.wgsl'
+              - 'src/shaders/lighting_ibl.wgsl'
+              - 'src/shaders/terrain_pbr_pom.wgsl'
+              - 'src/core/gpu.rs'
+              - 'src/core/dd.rs'
+              - 'src/core/dd/**'
+              - 'src/shaders/includes/dd.wgsl'
+              - 'src/shaders/dd_harness.wgsl'
+              - 'src/shaders/dd_jitter.wgsl'
+              - 'python/forge3d/precision.py'
+              - 'python/forge3d/precision.pyi'
+              - 'python/forge3d/determinism.py'
+              - 'scripts/run_dupla_proof.py'
+              - 'scripts/check_determinism_hashes.py'
+              - 'tests/test_dd_arithmetic.py'
+              - 'tests/test_dd_jitter.py'
+              - 'tests/test_determinism_hash.py'
+              - 'tests/test_determinism_matrix.py'
+              - 'tests/goldens/determinism/**'
+            determinism_f3dz:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'pyproject.toml'
+              - 'src/codec/f3dz/**'
+              - 'src/py_functions/codec.rs'
+              - 'python/forge3d/codec.py'
+              - 'tools/f3dz_determinism_report.py'
+              - 'tests/test_f3dz_codec.py'
+              - 'tests/data/codec_corpus/**'
+              - '.github/workflows/determinism-matrix.yml'
+            determinism_anamnesis:
+              - 'Cargo.toml'
+              - 'Cargo.lock'
+              - 'pyproject.toml'
+              - 'src/core/anamnesis/**'
+              - 'python/forge3d/anamnesis.py'
+              - 'python/forge3d/determinism.py'
+              - 'scripts/check_anamnesis_portability.py'
+              - 'tests/test_anamnesis_*.py'
+              - 'tests/goldens/determinism/**'
+              - '.github/workflows/determinism-matrix.yml'
+            # No TESSELLA physical job exists on main. This explicit output is
+            # a contract guard: any future lane must consume this scope (or a
+            # deliberate manual scope) and may not run on every PR.
+            tessella:
+              - 'src/terrain/renderer/virtual_texture.rs'
+              - 'src/core/feedback_buffer.rs'
+              - 'src/core/screen_space_effects/hzb.rs'
+              - 'src/shaders/hzb_build.wgsl'
+              - 'tests/test_terrain_vt_pbr_families.py'
+              - 'tests/test_tv20_virtual_texturing.py'
 
   # ============================================================================
   # Rust Tests (cargo test)
   # ============================================================================
   test-rust:
     name: Test Rust (${{ matrix.os }})
+    needs: preflight
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -341,13 +446,13 @@ jobs:
   # Interactive Viewer E2E (macOS only; optional)
   #
   # INFORMATIONAL ONLY: this job is `continue-on-error: true` on its test step
-  # and is deliberately NOT in `ci-success` needs. Its result never gates the
+  # and is deliberately NOT in `PR Core Success` needs. Its result never gates the
   # build. The interactive lane's test files are accounted for by the
   # `interactive_viewer` marker in the UNRUN/(e)-gate bookkeeping, not here.
   # ============================================================================
   test-interactive-viewer-macos:
     name: Interactive Viewer (macOS)
-    needs: build-wheels
+    needs: build-wheel-macos
     runs-on: macos-latest
     timeout-minutes: 15
 
@@ -373,7 +478,7 @@ jobs:
       - name: Install wheel and pytest
         run: |
           python scripts/install_compatible_wheel.py dist
-          pip install pytest numpy
+          pip install pytest pyyaml numpy
 
       - name: Run interactive viewer tests
         env:
@@ -384,132 +489,155 @@ jobs:
         continue-on-error: true
 
   # ============================================================================
-  # Python Wheel Build (maturin)
+  # Exact-head platform wheels. Each named job is independently consumable, so
+  # a Linux consumer never waits for Windows, macOS, or aarch64.
   # ============================================================================
-  build-wheels:
-    name: Build Wheel (${{ matrix.platform.os }})
-    runs-on: ${{ matrix.platform.runner }}
-    strategy:
-      fail-fast: false
-      matrix:
-        platform:
-          - os: windows
-            runner: windows-latest
-            target: x86_64-pc-windows-msvc
-            maturin_args: --release --out dist
-            manylinux: auto
-          - os: linux
-            runner: ubuntu-latest
-            target: x86_64-unknown-linux-gnu
-            maturin_args: --release --out dist -i python3.10
-            manylinux: off
-          - os: macos
-            runner: macos-latest
-            target: universal2-apple-darwin
-            maturin_args: --release --out dist
-            manylinux: auto
-          - os: linux-arm
-            runner: ubuntu-latest
-            target: aarch64-unknown-linux-gnu
-            maturin_args: --release --out dist -i python3.10
-            manylinux: auto
+  build-wheel-windows:
+    name: Build Wheel (Windows)
+    needs: preflight
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: windows-latest
+      target: x86_64-pc-windows-msvc
+      maturin_args: --release --out dist
+      manylinux: 'auto'
+      artifact: wheels-windows
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  build-wheel-linux:
+    name: Build Wheel (Linux)
+    needs: preflight
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: ubuntu-latest
+      target: x86_64-unknown-linux-gnu
+      maturin_args: --release --out dist -i python3.10
+      manylinux: 'off'
+      artifact: wheels-linux
 
-      - name: Build wheel
-        uses: PyO3/maturin-action@v1
-        env:
-          # ring's aarch64 assembly expects this macro under the manylinux cross compiler.
-          CFLAGS_aarch64_unknown_linux_gnu: ${{ matrix.platform.target == 'aarch64-unknown-linux-gnu' && '-D__ARM_ARCH=8' || '' }}
-        with:
-          target: ${{ matrix.platform.target }}
-          args: ${{ matrix.platform.maturin_args }}
-          manylinux: ${{ matrix.platform.manylinux }}
+  build-wheel-macos:
+    name: Build Wheel (macOS)
+    needs: preflight
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: macos-latest
+      target: universal2-apple-darwin
+      maturin_args: --release --out dist
+      manylinux: 'auto'
+      artifact: wheels-macos
 
-      - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: wheels-${{ matrix.platform.os }}
-          path: dist/*.whl
-          retention-days: 1
+  build-wheel-linux-arm:
+    name: Build Wheel (Linux aarch64)
+    needs: preflight
+    uses: ./.github/workflows/build-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: ubuntu-latest
+      target: aarch64-unknown-linux-gnu
+      maturin_args: --release --out dist -i python3.10
+      manylinux: 'auto'
+      artifact: wheels-linux-arm
 
   # ============================================================================
-  # Python Tests (pytest)
+  # Python tests: every PR gets one full representative suite plus boundary/OS
+  # compatibility smoke. The 3x4 exhaustive suite is nightly or explicit full.
   # ============================================================================
-  test-python:
-    name: Test Python (${{ matrix.os }})
-    needs: [build-wheels, prepare-lfs-fixtures]
-    runs-on: ${{ matrix.os }}
-    timeout-minutes: 35
-    strategy:
-      fail-fast: false
-      matrix: ${{ fromJSON(github.event_name == 'pull_request' && '{"include":[{"os":"ubuntu-latest","python-version":"3.10"},{"os":"ubuntu-latest","python-version":"3.11"},{"os":"ubuntu-latest","python-version":"3.12"},{"os":"ubuntu-latest","python-version":"3.13"},{"os":"windows-latest","python-version":"3.11"},{"os":"macos-latest","python-version":"3.11"}]}' || '{"os":["windows-latest","ubuntu-latest","macos-latest"],"python-version":["3.10","3.11","3.12","3.13"]}') }}
+  test-python-core:
+    name: Python Core (Linux 3.11 full)
+    needs: [build-wheel-linux, prepare-lfs-fixtures]
+    if: github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || inputs.scope != 'full')
+    uses: ./.github/workflows/test-python-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: ubuntu-latest
+      python_versions: '["3.11"]'
+      wheel_artifact: wheels-linux
+      test_mode: full
+      restore_lfs: true
 
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+  test-python-compat-linux:
+    name: Python Compatibility (Linux boundaries)
+    needs: build-wheel-linux
+    if: github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || inputs.scope != 'full')
+    uses: ./.github/workflows/test-python-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: ubuntu-latest
+      python_versions: '["3.10", "3.13"]'
+      wheel_artifact: wheels-linux
+      test_mode: compatibility
 
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
-        with:
-          python-version: ${{ matrix.python-version }}
+  test-python-compat-windows:
+    name: Python Compatibility (Windows)
+    needs: build-wheel-windows
+    if: github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || inputs.scope != 'full')
+    uses: ./.github/workflows/test-python-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: windows-latest
+      python_versions: '["3.11"]'
+      wheel_artifact: wheels-windows
+      test_mode: compatibility
 
-      - name: Download shared LFS fixture artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: lfs-fixture-bundles
-          path: lfs-fixture-bundles
+  test-python-compat-macos:
+    name: Python Compatibility (macOS)
+    needs: build-wheel-macos
+    if: github.event_name != 'schedule' && (github.event_name != 'workflow_dispatch' || inputs.scope != 'full')
+    uses: ./.github/workflows/test-python-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: macos-latest
+      python_versions: '["3.11"]'
+      wheel_artifact: wheels-macos
+      test_mode: compatibility
 
-      - name: Restore Python TIFF fixtures
-        run: python -m zipfile -e lfs-fixture-bundles/python-tiffs.zip .
+  test-python-full-linux:
+    name: Python Full Matrix (Linux)
+    needs: [build-wheel-linux, prepare-lfs-fixtures]
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')
+    uses: ./.github/workflows/test-python-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: ubuntu-latest
+      python_versions: '["3.10", "3.11", "3.12", "3.13"]'
+      wheel_artifact: wheels-linux
+      test_mode: full
+      restore_lfs: true
 
-      - name: Download wheel artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: wheels-${{ runner.os == 'Windows' && 'windows' || runner.os == 'Linux' && 'linux' || 'macos' }}
-          path: dist/
+  test-python-full-windows:
+    name: Python Full Matrix (Windows)
+    needs: [build-wheel-windows, prepare-lfs-fixtures]
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')
+    uses: ./.github/workflows/test-python-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: windows-latest
+      python_versions: '["3.10", "3.11", "3.12", "3.13"]'
+      wheel_artifact: wheels-windows
+      test_mode: full
+      restore_lfs: true
 
-      - name: Install wheel and test dependencies
-        run: |
-          python scripts/install_compatible_wheel.py dist
-          # pyproj/rasterio back the mensura CRS-reproject and MapScene alignment
-          # tests in the default lane (the documented pyproj fallback path when the
-          # native `proj` feature is not compiled into the wheel). Other lanes
-          # already install pyproj; the default lane runs the WHOLE tests/ tree, so
-          # it needs both to exercise those paths instead of erroring on import.
-          pip install pytest numpy pillow mypy pyproj rasterio
-
-      - name: Install system fonts (Linux)
-        if: runner.os == 'Linux'
-        # Legend/label helpers resolve DejaVu on Linux; hosted images ship no
-        # fonts by default (found by the first exhaustive-lane CI run).
-        run: sudo apt-get update && sudo apt-get install -y fonts-dejavu-core
-
-      - name: Run install smoke tests
-        env:
-          FORGE3D_NO_BOOTSTRAP: '1'
-        run: pytest tests/test_install_smoke.py -v --tb=short
-
-      - name: Run license tests
-        env:
-          FORGE3D_NO_BOOTSTRAP: '1'
-        run: pytest tests/test_license.py -v --tb=short
-
-      - name: Run default Python test lane (CENSOR honesty gate)
-        env:
-          FORGE3D_NO_BOOTSTRAP: '1'
-        run: python scripts/ci_pytest_lane.py -v --tb=short
+  test-python-full-macos:
+    name: Python Full Matrix (macOS)
+    needs: [build-wheel-macos, prepare-lfs-fixtures]
+    if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')
+    uses: ./.github/workflows/test-python-wheel.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      runner: macos-latest
+      python_versions: '["3.10", "3.11", "3.12", "3.13"]'
+      wheel_artifact: wheels-macos
+      test_mode: full
+      restore_lfs: true
 
   # ============================================================================
   # Accounted slow Python tests (one hosted representative)
   # ============================================================================
   test-python-slow:
     name: Test Python Slow (ubuntu, 3.11)
-    needs: [build-wheels, prepare-lfs-fixtures]
+    needs: [build-wheel-linux, prepare-lfs-fixtures]
     runs-on: ubuntu-latest
     timeout-minutes: 45
 
@@ -541,7 +669,7 @@ jobs:
       - name: Install wheel and slow-lane dependencies
         run: |
           python scripts/install_compatible_wheel.py dist
-          pip install pytest numpy pillow
+          pip install pytest pyyaml numpy pillow
 
       - name: Run accounted slow Python lane
         env:
@@ -557,7 +685,7 @@ jobs:
   # ============================================================================
   test-terminus-fuzz:
     name: TERMINUS 10k Deterministic Fuzzer (CPU)
-    needs: build-wheels
+    needs: build-wheel-linux
     runs-on: ubuntu-latest
     timeout-minutes: 20
 
@@ -609,7 +737,7 @@ jobs:
   # ============================================================================
   test-python-linux-arm:
     name: Install Smoke (linux-arm)
-    needs: build-wheels
+    needs: build-wheel-linux-arm
     runs-on: ubuntu-latest
 
     steps:
@@ -642,13 +770,16 @@ jobs:
   # ============================================================================
   test-golden-images:
     name: Visual Goldens
-    needs: [build-wheels, terrain-golden-paths]
+    needs: [build-wheel-macos, terrain-golden-paths]
     # macos-14 is the repository's gated real-GPU lane (Metal). Hosted
     # Windows runners only expose WARP here, which made this job perpetually
     # report ABSENT and prevented an actual image mismatch from failing CI.
     runs-on: macos-14
-    if: github.event_name == 'workflow_dispatch' || needs.terrain-golden-paths.outputs.terrain_goldens == 'true'
-    # Expose which lane actually executed so ci-success can print an honest
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') ||
+      needs.terrain-golden-paths.outputs.terrain_goldens == 'true'
+    # Expose which lane actually executed so PR Core Success can print an honest
     # `ran|absent` distinction instead of treating both as opaque success.
     outputs:
       lane: ${{ steps.golden-absent.outputs.golden_lane || steps.golden-ran.outputs.golden_lane || 'unknown' }}
@@ -782,66 +913,24 @@ jobs:
           path: tests/artifacts/
           retention-days: 7
 
-  refresh-recipe-certificates:
-    name: Refresh Recipe Certificates
-    needs: build-wheels
-    if: github.event_name == 'workflow_dispatch' && inputs.update_recipe_certificates
-    runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
-    env:
-      WGPU_BACKEND: vulkan
-      FORGE3D_ALLOW_HOSTED_WINDOWS_TERRAIN: '1'
-      FORGE3D_CERT_SIGNING_KEY: ${{ secrets.FORGE3D_CERT_SIGNING_KEY }}
-      FORGE3D_REQUIRE_PRODUCTION_SIGNING: '1'
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - name: Verify runner Python
-        run: python --version
-      - uses: actions/download-artifact@v4
-        with:
-          name: wheels-windows
-          path: dist/
-      - name: Install wheel and test dependencies
-        run: |
-          python scripts/install_compatible_wheel.py dist
-          pip install pytest numpy pyproj pillow
-      - name: Require clean production GPU evidence
-        env:
-          FORGE3D_NO_BOOTSTRAP: '1'
-        run: |
-          if (-not $env:FORGE3D_CERT_SIGNING_KEY) { throw 'missing production signing key' }
-          python scripts/terrain_ci_probe.py --mode terrain
-      - name: Render and sign the recipe catalog
-        env:
-          FORGE3D_NO_BOOTSTRAP: '1'
-          FORGE3D_RUN_TERRAIN_GOLDENS: '1'
-          FORGE3D_UPDATE_RECIPE_CERTIFICATES: '1'
-        run: pytest tests/test_recipe_goldens.py::test_recipe_goldens_render_and_match -v --tb=short
-      - uses: actions/upload-artifact@v4
-        with:
-          name: refreshed-recipe-certificates
-          path: tests/golden/certificates/*.json
-          if-no-files-found: error
-          retention-days: 90
-
   # ============================================================================
   # M-06 Option-2 Full Geospatial Viewer acceptance
   #
-  # This lane is required and zero-skip when M-06 dependency paths select it on
-  # PRs/develop pushes, and always on main, schedules, and manual runs. An
-  # unavailable adapter, a stale/missing release viewer, or a skipped
-  # acceptance test is a hard error whenever the lane is required.
+  # This lane is required and zero-skip on nightly runs, explicit manual M-06/full
+  # dispatches, and reviewed internal PRs selected by both path and label. An
+  # unavailable adapter, a stale/missing release viewer, or a skipped acceptance
+  # test is a hard error whenever the lane is selected.
   # ============================================================================
   test-m06-full-geospatial-viewer:
     name: M-06 Full Geospatial Viewer (NVIDIA Vulkan)
-    needs: [build-wheels, prepare-lfs-fixtures, terrain-golden-paths]
+    needs: [build-wheel-windows, prepare-lfs-fixtures, terrain-golden-paths]
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      needs.terrain-golden-paths.outputs.m06 == 'true'
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'm06')) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'run-physical') &&
+       needs.terrain-golden-paths.outputs.m06 == 'true')
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 35
     env:
@@ -1072,12 +1161,14 @@ jobs:
   # ============================================================================
   test-f3dz-gpu:
     name: F3DZ Codec (NVIDIA Vulkan)
-    needs: [build-wheels, terrain-golden-paths]
+    needs: [build-wheel-windows, terrain-golden-paths]
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      needs.terrain-golden-paths.outputs.f3dz == 'true'
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'f3dz')) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'run-physical') &&
+       needs.terrain-golden-paths.outputs.f3dz == 'true')
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 30
     env:
@@ -1140,9 +1231,16 @@ jobs:
           $verifyCode = $LASTEXITCODE
           if ($pytestCode -ne 0) { exit $pytestCode }
           exit $verifyCode
-      - name: Record F3DZ CPU and GPU throughput
+      - name: Record separate source benchmark (nightly/full only)
+        if: github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full')
         shell: pwsh
         run: |
+          @{
+            evidence_scope = 'source-benchmark-not-installed-wheel-acceptance'
+            head_sha = (git rev-parse HEAD).Trim()
+            rustc = (rustc -Vv | Out-String).Trim()
+            cargo = (cargo -Vv | Out-String).Trim()
+          } | ConvertTo-Json -Depth 3 | Set-Content "$env:FORGE3D_F3DZ_ARTIFACT_DIR/benchmark-provenance.json"
           cargo bench --bench f3dz_bench *>&1 | Tee-Object "$env:FORGE3D_F3DZ_ARTIFACT_DIR/benchmark.log"
           exit $LASTEXITCODE
       - name: Upload F3DZ physical-GPU evidence
@@ -1180,12 +1278,14 @@ jobs:
   # ============================================================================
   test-anamnesis-portability-seed:
     name: ANAMNESIS Physical Seed (Windows Vulkan)
-    needs: [build-wheels, terrain-golden-paths]
+    needs: [build-wheel-windows, terrain-golden-paths]
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      needs.terrain-golden-paths.outputs.anamnesis == 'true'
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'anamnesis')) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'run-physical') &&
+       needs.terrain-golden-paths.outputs.anamnesis == 'true')
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 20
     env:
@@ -1260,12 +1360,14 @@ jobs:
 
   test-anamnesis-portability:
     name: ANAMNESIS Physical Consume (Windows DX12)
-    needs: [build-wheels, terrain-golden-paths, test-anamnesis-portability-seed]
+    needs: [build-wheel-windows, terrain-golden-paths, test-anamnesis-portability-seed]
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      needs.terrain-golden-paths.outputs.anamnesis == 'true'
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'anamnesis')) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'run-physical') &&
+       needs.terrain-golden-paths.outputs.anamnesis == 'true')
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 20
     env:
@@ -1355,12 +1457,14 @@ jobs:
   # ============================================================================
   test-anamnesis-production:
     name: ANAMNESIS 600-frame Production (NVIDIA Vulkan)
-    needs: [build-wheels, terrain-golden-paths]
+    needs: [build-wheel-windows, terrain-golden-paths]
     if: >-
-      github.event_name == 'workflow_dispatch' ||
       github.event_name == 'schedule' ||
-      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
-      needs.terrain-golden-paths.outputs.anamnesis == 'true'
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'anamnesis')) ||
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(github.event.pull_request.labels.*.name, 'run-physical') &&
+       needs.terrain-golden-paths.outputs.anamnesis == 'true')
     runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]
     timeout-minutes: 50
     env:
@@ -1468,10 +1572,53 @@ jobs:
           }
 
   # ============================================================================
+  # Hosted determinism families. These consume the exact platform wheels above
+  # and run only for their own paths, nightly full acceptance, or an explicit
+  # manual scope. ABSENT hosted GPU evidence never substitutes for the physical
+  # NVIDIA acceptance jobs.
+  # ============================================================================
+  determinism-render:
+    name: Hosted Render Determinism
+    needs: [build-wheel-linux, build-wheel-windows, build-wheel-macos, terrain-golden-paths]
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'determinism')) ||
+      needs.terrain-golden-paths.outputs.determinism_render == 'true'
+    uses: ./.github/workflows/determinism-matrix.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      run_render: true
+
+  determinism-f3dz:
+    name: Hosted F3DZ Determinism
+    needs: [build-wheel-linux, build-wheel-windows, terrain-golden-paths]
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'determinism' || inputs.scope == 'f3dz')) ||
+      needs.terrain-golden-paths.outputs.determinism_f3dz == 'true'
+    uses: ./.github/workflows/determinism-matrix.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      run_f3dz: true
+
+  determinism-anamnesis:
+    name: Hosted ANAMNESIS Determinism
+    needs: [build-wheel-linux, build-wheel-windows, terrain-golden-paths]
+    if: >-
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'determinism' || inputs.scope == 'anamnesis')) ||
+      needs.terrain-golden-paths.outputs.determinism_anamnesis == 'true'
+    uses: ./.github/workflows/determinism-matrix.yml
+    with:
+      ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      run_anamnesis: true
+
+  # ============================================================================
   # Documentation Build
   # ============================================================================
   build-docs:
     name: Build Documentation
+    needs: preflight
     runs-on: ubuntu-latest
 
     steps:
@@ -1486,82 +1633,129 @@ jobs:
         run: cargo doc --workspace --features default,async_readback,copc_laz,cog_streaming,gis-remote,geos-topology,weighted-oit,wsI_bigbuf,wsI_double_buf,enable-pbr,enable-tbn,enable-normal-mapping,enable-hdr-offscreen,enable-renderer-config,enable-staging-rings,shader-contract-asserts --no-deps
 
   # ============================================================================
-  # Final Status
+  # Stable hosted gate for every existing and future PR. Configure branch
+  # protection to require only this context; physical evidence remains separate.
   # ============================================================================
-  ci-success:
-    name: CI Success
-    needs: [prepare-lfs-fixtures, terrain-golden-paths, test-rust, build-wheels, test-python, test-python-slow, test-terminus-fuzz, test-python-linux-arm, test-golden-images, refresh-recipe-certificates, test-m06-full-geospatial-viewer, test-f3dz-gpu, test-anamnesis-portability-seed, test-anamnesis-portability, test-anamnesis-production, build-docs]
+  pr-core-success:
+    name: PR Core Success
+    needs: [preflight, prepare-lfs-fixtures, terrain-golden-paths, test-rust, build-wheel-windows, build-wheel-linux, build-wheel-macos, build-wheel-linux-arm, test-python-core, test-python-compat-linux, test-python-compat-windows, test-python-compat-macos, test-python-full-linux, test-python-full-windows, test-python-full-macos, test-python-slow, test-terminus-fuzz, test-python-linux-arm, test-golden-images, build-docs]
     runs-on: ubuntu-latest
     if: always()
-
     steps:
-      - name: Check all jobs succeeded
+      - name: Enforce the hosted core contract
+        shell: bash
         run: |
-          # Golden lane honesty: `test-golden-images` is gated by the
-          # `terrain-golden-paths` paths filter via its job-level `if:`. When no
-          # golden-relevant path changed the job is `skipped` — that is the ONLY
-          # reason `skipped` is acceptable here. Whenever the paths filter DID
-          # run the job, a golden pytest mismatch fails the job (no
-          # continue-on-error shields the pytest step) and therefore fails this
-          # aggregator. `absent` (no usable adapter) still reports as job
-          # `success` and is surfaced by the lane line below, not swallowed.
+          failed=0
+          require_success() {
+            if [ "$2" != "success" ]; then
+              echo "::error::$1 finished as $2"
+              failed=1
+            fi
+          }
+          require_state() {
+            if [ "$2" != "$3" ]; then
+              echo "::error::$1 should be $3 but finished as $2"
+              failed=1
+            fi
+          }
+
+          require_success preflight '${{ needs.preflight.result }}'
+          require_success prepare-lfs-fixtures '${{ needs.prepare-lfs-fixtures.result }}'
+          require_success terrain-golden-paths '${{ needs.terrain-golden-paths.result }}'
+          require_success test-rust '${{ needs.test-rust.result }}'
+          require_success build-wheel-windows '${{ needs.build-wheel-windows.result }}'
+          require_success build-wheel-linux '${{ needs.build-wheel-linux.result }}'
+          require_success build-wheel-macos '${{ needs.build-wheel-macos.result }}'
+          require_success build-wheel-linux-arm '${{ needs.build-wheel-linux-arm.result }}'
+          require_success test-python-slow '${{ needs.test-python-slow.result }}'
+          require_success test-terminus-fuzz '${{ needs.test-terminus-fuzz.result }}'
+          require_success test-python-linux-arm '${{ needs.test-python-linux-arm.result }}'
+          require_success build-docs '${{ needs.build-docs.result }}'
+
+          full_python="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') }}"
+          if [ "$full_python" = "true" ]; then
+            require_state test-python-core '${{ needs.test-python-core.result }}' skipped
+            require_state test-python-compat-linux '${{ needs.test-python-compat-linux.result }}' skipped
+            require_state test-python-compat-windows '${{ needs.test-python-compat-windows.result }}' skipped
+            require_state test-python-compat-macos '${{ needs.test-python-compat-macos.result }}' skipped
+            require_success test-python-full-linux '${{ needs.test-python-full-linux.result }}'
+            require_success test-python-full-windows '${{ needs.test-python-full-windows.result }}'
+            require_success test-python-full-macos '${{ needs.test-python-full-macos.result }}'
+          else
+            require_success test-python-core '${{ needs.test-python-core.result }}'
+            require_success test-python-compat-linux '${{ needs.test-python-compat-linux.result }}'
+            require_success test-python-compat-windows '${{ needs.test-python-compat-windows.result }}'
+            require_success test-python-compat-macos '${{ needs.test-python-compat-macos.result }}'
+            require_state test-python-full-linux '${{ needs.test-python-full-linux.result }}' skipped
+            require_state test-python-full-windows '${{ needs.test-python-full-windows.result }}' skipped
+            require_state test-python-full-macos '${{ needs.test-python-full-macos.result }}' skipped
+          fi
+
+          golden_required="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && inputs.scope == 'full') || needs.terrain-golden-paths.outputs.terrain_goldens == 'true' }}"
+          if [ "$golden_required" = "true" ]; then
+            require_success test-golden-images '${{ needs.test-golden-images.result }}'
+          else
+            require_state test-golden-images '${{ needs.test-golden-images.result }}' skipped
+          fi
           echo "golden lane: ${{ needs.test-golden-images.outputs.lane || 'skipped(paths)' }}"
-          anamnesis_required="${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.terrain-golden-paths.outputs.anamnesis == 'true' }}"
-          echo "ANAMNESIS physical lanes required: $anamnesis_required"
-          m06_required="${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' || (github.event_name == 'push' && github.ref == 'refs/heads/main') || needs.terrain-golden-paths.outputs.m06 == 'true' }}"
-          echo "M-06 full geospatial viewer required: $m06_required"
-          golden_failed=0
-          if [ "${{ needs.test-golden-images.result }}" != "success" ] && [ "${{ needs.test-golden-images.result }}" != "skipped" ]; then
-            golden_failed=1
-          fi
-          refresh_failed=0
-          if [ "${{ needs.refresh-recipe-certificates.result }}" != "success" ] && [ "${{ needs.refresh-recipe-certificates.result }}" != "skipped" ]; then
-            refresh_failed=1
-          fi
-          f3dz_failed=0
-          if [ "${{ needs.test-f3dz-gpu.result }}" != "success" ] && [ "${{ needs.test-f3dz-gpu.result }}" != "skipped" ]; then
-            f3dz_failed=1
-          fi
-          anamnesis_failed=0
-          if [ "$anamnesis_required" = "true" ]; then
-            if [ "${{ needs.test-anamnesis-portability-seed.result }}" != "success" ] || \
-               [ "${{ needs.test-anamnesis-portability.result }}" != "success" ] || \
-               [ "${{ needs.test-anamnesis-production.result }}" != "success" ]; then
-              anamnesis_failed=1
+          exit "$failed"
+
+  # This aggregate is intentionally separate from PR Core Success. It validates
+  # selected high-cost hosted and physical claims without delaying every merge.
+  full-acceptance-summary:
+    name: Full Acceptance Summary
+    needs: [pr-core-success, terrain-golden-paths, determinism-render, determinism-f3dz, determinism-anamnesis, test-m06-full-geospatial-viewer, test-f3dz-gpu, test-anamnesis-portability-seed, test-anamnesis-portability, test-anamnesis-production]
+    runs-on: ubuntu-latest
+    if: >-
+      always() &&
+      (github.event_name == 'schedule' ||
+       (github.event_name == 'workflow_dispatch' && inputs.scope != 'core') ||
+       needs.terrain-golden-paths.outputs.determinism_render == 'true' ||
+       needs.terrain-golden-paths.outputs.determinism_f3dz == 'true' ||
+       needs.terrain-golden-paths.outputs.determinism_anamnesis == 'true' ||
+       (github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(github.event.pull_request.labels.*.name, 'run-physical') &&
+        (needs.terrain-golden-paths.outputs.m06 == 'true' ||
+         needs.terrain-golden-paths.outputs.f3dz == 'true' ||
+         needs.terrain-golden-paths.outputs.anamnesis == 'true')))
+    steps:
+      - name: Enforce every selected acceptance family
+        shell: bash
+        run: |
+          failed=0
+          check_selected() {
+            selected="$1"
+            result="$2"
+            label="$3"
+            if [ "$selected" = "true" ] && [ "$result" != "success" ]; then
+              echo "::error::$label was selected but finished as $result"
+              failed=1
+            elif [ "$selected" != "true" ] && [ "$result" != "skipped" ]; then
+              echo "::error::$label was not selected but finished as $result"
+              failed=1
             fi
-          else
-            if [ "${{ needs.test-anamnesis-portability-seed.result }}" != "skipped" ] || \
-               [ "${{ needs.test-anamnesis-portability.result }}" != "skipped" ] || \
-               [ "${{ needs.test-anamnesis-production.result }}" != "skipped" ]; then
-              anamnesis_failed=1
-            fi
+          }
+          if [ '${{ needs.pr-core-success.result }}' != 'success' ]; then
+            echo "::error::PR Core Success finished as ${{ needs.pr-core-success.result }}"
+            failed=1
           fi
-          m06_failed=0
-          if [ "$m06_required" = "true" ]; then
-            if [ "${{ needs.test-m06-full-geospatial-viewer.result }}" != "success" ]; then
-              m06_failed=1
-            fi
-          else
-            if [ "${{ needs.test-m06-full-geospatial-viewer.result }}" != "skipped" ]; then
-              m06_failed=1
-            fi
-          fi
-          if [ "${{ needs.prepare-lfs-fixtures.result }}" != "success" ] || \
-             [ "${{ needs.terrain-golden-paths.result }}" != "success" ] || \
-             [ "${{ needs.test-rust.result }}" != "success" ] || \
-             [ "${{ needs.build-wheels.result }}" != "success" ] || \
-             [ "${{ needs.test-python.result }}" != "success" ] || \
-             [ "${{ needs.test-python-slow.result }}" != "success" ] || \
-             [ "${{ needs.test-terminus-fuzz.result }}" != "success" ] || \
-             [ "${{ needs.test-python-linux-arm.result }}" != "success" ] || \
-             [ "$golden_failed" -ne 0 ] || \
-             [ "$refresh_failed" -ne 0 ] || \
-             [ "$m06_failed" -ne 0 ] || \
-             [ "$f3dz_failed" -ne 0 ] || \
-             [ "$anamnesis_failed" -ne 0 ] || \
-             [ "${{ needs.build-docs.result }}" != "success" ]; then
-            echo "❌ CI failed"
-            exit 1
-          else
-            echo "✅ CI passed"
-          fi
+
+          physical_pr="${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'run-physical') }}"
+          m06_selected="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'm06')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'run-physical') && needs.terrain-golden-paths.outputs.m06 == 'true') }}"
+          f3dz_physical_selected="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'f3dz')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'run-physical') && needs.terrain-golden-paths.outputs.f3dz == 'true') }}"
+          anamnesis_physical_selected="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'anamnesis')) || (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository && contains(github.event.pull_request.labels.*.name, 'run-physical') && needs.terrain-golden-paths.outputs.anamnesis == 'true') }}"
+          render_selected="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'determinism')) || needs.terrain-golden-paths.outputs.determinism_render == 'true' }}"
+          f3dz_hosted_selected="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'determinism' || inputs.scope == 'f3dz')) || needs.terrain-golden-paths.outputs.determinism_f3dz == 'true' }}"
+          anamnesis_hosted_selected="${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && (inputs.scope == 'full' || inputs.scope == 'determinism' || inputs.scope == 'anamnesis')) || needs.terrain-golden-paths.outputs.determinism_anamnesis == 'true' }}"
+
+          check_selected "$render_selected" '${{ needs.determinism-render.result }}' determinism-render
+          check_selected "$f3dz_hosted_selected" '${{ needs.determinism-f3dz.result }}' determinism-f3dz
+          check_selected "$anamnesis_hosted_selected" '${{ needs.determinism-anamnesis.result }}' determinism-anamnesis
+          check_selected "$m06_selected" '${{ needs.test-m06-full-geospatial-viewer.result }}' m06-physical
+          check_selected "$f3dz_physical_selected" '${{ needs.test-f3dz-gpu.result }}' f3dz-physical
+          check_selected "$anamnesis_physical_selected" '${{ needs.test-anamnesis-portability-seed.result }}' anamnesis-seed
+          check_selected "$anamnesis_physical_selected" '${{ needs.test-anamnesis-portability.result }}' anamnesis-portability
+          check_selected "$anamnesis_physical_selected" '${{ needs.test-anamnesis-production.result }}' anamnesis-production
+          echo "physical PR opt-in: $physical_pr"
+          exit "$failed"

--- a/.github/workflows/determinism-matrix.yml
+++ b/.github/workflows/determinism-matrix.yml
@@ -36,106 +36,39 @@
 # present they upload a hash that the diff job enforces; if not they upload an
 # explicit ABSENT marker with the reason (loud, never a silent placeholder).
 
-name: determinism-matrix
+name: Determinism acceptance
 
 on:
-  workflow_dispatch:
-  # push trigger so direct-to-main work can never silently skip the matrix
-  # again (the original scaffolding landed on main without a single run).
-  push:
-    branches: [main]
-    paths:
-      - 'src/shaders/includes/determinism.wgsl'
-      - 'src/shaders/includes/shadow_moments.wgsl'
-      - 'src/shaders/includes/tonemap_common.wgsl'
-      - 'src/shaders/shadows.wgsl'
-      - 'src/shaders/lighting_ibl.wgsl'
-      - 'src/shaders/terrain_pbr_pom.wgsl'
-      - 'src/core/gpu.rs'
-      - 'src/core/dd.rs'
-      - 'src/core/dd/**'
-      - 'src/shaders/includes/dd.wgsl'
-      - 'src/shaders/dd_harness.wgsl'
-      - 'src/shaders/dd_jitter.wgsl'
-      - 'python/forge3d/precision.py'
-      - 'python/forge3d/precision.pyi'
-      - 'python/forge3d/__init__.py'
-      - 'python/forge3d/__init__.pyi'
-      - 'src/py_functions/precision.rs'
-      - 'src/py_functions/mod.rs'
-      - 'src/py_module/functions/precision.rs'
-      - 'src/py_module/functions.rs'
-      - 'scripts/run_dupla_proof.py'
-      - 'tests/test_dd_arithmetic.py'
-      - 'tests/test_dd_jitter.py'
-      - 'python/forge3d/determinism.py'
-      - 'scripts/check_determinism_hashes.py'
-      - 'tests/test_determinism_hash.py'
-      - 'tests/test_determinism_matrix.py'
-      - 'tests/test_f3dz_codec.py'
-      - 'tests/data/codec_corpus/**'
-      - 'tools/f3dz_determinism_report.py'
-      - 'src/codec/f3dz/**'
-      - 'src/py_functions/codec.rs'
-      - 'python/forge3d/codec.py'
-      - 'python/forge3d/anamnesis.py'
-      - 'src/core/anamnesis/**'
-      - 'scripts/check_anamnesis_portability.py'
-      - 'tests/test_anamnesis_*.py'
-      - 'tests/goldens/determinism/**'
-      - '.github/workflows/determinism-matrix.yml'
-  pull_request:
-    paths:
-      - 'src/shaders/includes/determinism.wgsl'
-      - 'src/shaders/includes/shadow_moments.wgsl'
-      - 'src/shaders/includes/tonemap_common.wgsl'
-      - 'src/shaders/shadows.wgsl'
-      - 'src/shaders/lighting_ibl.wgsl'
-      - 'src/shaders/terrain_pbr_pom.wgsl'
-      - 'src/core/gpu.rs'
-      - 'src/core/dd.rs'
-      - 'src/core/dd/**'
-      - 'src/shaders/includes/dd.wgsl'
-      - 'src/shaders/dd_harness.wgsl'
-      - 'src/shaders/dd_jitter.wgsl'
-      - 'python/forge3d/precision.py'
-      - 'python/forge3d/precision.pyi'
-      - 'python/forge3d/__init__.py'
-      - 'python/forge3d/__init__.pyi'
-      - 'src/py_functions/precision.rs'
-      - 'src/py_functions/mod.rs'
-      - 'src/py_module/functions/precision.rs'
-      - 'src/py_module/functions.rs'
-      - 'scripts/run_dupla_proof.py'
-      - 'tests/test_dd_arithmetic.py'
-      - 'tests/test_dd_jitter.py'
-      - 'python/forge3d/determinism.py'
-      - 'scripts/check_determinism_hashes.py'
-      - 'tests/test_determinism_hash.py'
-      - 'tests/test_determinism_matrix.py'
-      - 'tests/test_f3dz_codec.py'
-      - 'tests/data/codec_corpus/**'
-      - 'tools/f3dz_determinism_report.py'
-      - 'src/codec/f3dz/**'
-      - 'src/py_functions/codec.rs'
-      - 'python/forge3d/codec.py'
-      - 'python/forge3d/anamnesis.py'
-      - 'src/core/anamnesis/**'
-      - 'scripts/check_anamnesis_portability.py'
-      - 'tests/test_anamnesis_*.py'
-      - 'tests/goldens/determinism/**'
-      - '.github/workflows/determinism-matrix.yml'
+  workflow_call:
+    inputs:
+      ref:
+        description: Exact commit SHA whose already-built wheels are under test.
+        required: true
+        type: string
+      run_render:
+        required: false
+        default: false
+        type: boolean
+      run_f3dz:
+        required: false
+        default: false
+        type: boolean
+      run_anamnesis:
+        required: false
+        default: false
+        type: boolean
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || format('run-{0}', github.run_id) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+permissions:
+  contents: read
 
 env:
   SCENE: terra_determinata_v1
+  FORGE3D_NO_BOOTSTRAP: '1'
 
 jobs:
   f3dz-stream:
     name: f3dz stream (${{ matrix.os }})
+    if: inputs.run_f3dz
     strategy:
       fail-fast: false
       matrix:
@@ -144,21 +77,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-      - name: Build extension
-        shell: bash
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-${{ runner.os == 'Windows' && 'windows' || 'linux' }}
+          path: dist/
+      - name: Install the exact wheel built by the caller
         run: |
-          python -m venv .venv
-          if [ -f .venv/bin/activate ]; then source .venv/bin/activate; else source .venv/Scripts/activate; fi
-          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          echo "$PWD/.venv/Scripts" >> "$GITHUB_PATH"
-          python -m pip install -U pip maturin numpy pytest
-          maturin develop --release
+          python scripts/install_compatible_wheel.py dist
+          python -m pip install numpy pytest
       - name: Reproduce each stream twice against the committed hashes
         shell: bash
         run: |
@@ -178,6 +108,7 @@ jobs:
 
   render:
     name: render (${{ matrix.leg }})
+    if: inputs.run_render
     strategy:
       fail-fast: false
       matrix:
@@ -202,8 +133,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
-      - uses: dtolnay/rust-toolchain@stable
+          ref: ${{ inputs.ref }}
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -212,19 +142,14 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y mesa-vulkan-drivers vulkan-tools libvulkan1
-      - name: Build extension
-        shell: bash
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-${{ runner.os == 'Windows' && 'windows' || runner.os == 'macOS' && 'macos' || 'linux' }}
+          path: dist/
+      - name: Install the exact wheel built by the caller
         run: |
-          # maturin develop refuses to run without a virtualenv; hosted
-          # runners provide none, so create one and persist it for the
-          # render step (bin/ on unix, Scripts/ on windows).
-          python -m venv .venv
-          if [ -f .venv/bin/activate ]; then source .venv/bin/activate; else source .venv/Scripts/activate; fi
-          echo "VIRTUAL_ENV=$VIRTUAL_ENV" >> "$GITHUB_ENV"
-          echo "$PWD/.venv/bin" >> "$GITHUB_PATH"
-          echo "$PWD/.venv/Scripts" >> "$GITHUB_PATH"
-          python -m pip install -U pip maturin numpy
-          maturin develop --release
+          python scripts/install_compatible_wheel.py dist
+          python -m pip install numpy
       - name: Render canonical scene
         shell: bash
         env:
@@ -299,11 +224,12 @@ jobs:
 
   wasm-policy:
     name: render (wasm) — relaxed-SIMD policy gate
+    if: inputs.run_render
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.ref }}
       - name: Forbid relaxed-SIMD in any build configuration (GATED)
         run: |
           # Relaxed SIMD is nondeterministic by design (results may vary per
@@ -329,17 +255,17 @@ jobs:
 
   anamnesis-seed:
     name: anamnesis golden-store seed (linux/vulkan)
+    if: inputs.run_anamnesis
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.ref }}
       - name: Prove exact-head checkout
         shell: bash
         env:
-          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          EXPECTED_HEAD: ${{ inputs.ref }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
-      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -347,15 +273,33 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y mesa-vulkan-drivers vulkan-tools libvulkan1
-      - name: Build extension
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-linux
+          path: dist/
+      - name: Install the exact wheel built by the caller
         run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          python -m pip install -U pip maturin numpy pytest
-          maturin develop --release
+          python scripts/install_compatible_wheel.py dist
+          python -m pip install numpy pytest pillow
+      - name: Classify the hosted Vulkan adapter before runtime tests
+        id: anamnesis-probe
+        shell: bash
+        run: |
+          set +e
+          python scripts/terrain_ci_probe.py \
+            --mode terrain --json anamnesis-seed-adapter.json
+          probe_status=$?
+          set -e
+          if [ "$probe_status" -eq 0 ]; then
+            echo "status=positive" >> "$GITHUB_OUTPUT"
+          elif [ "$probe_status" -eq 2 ]; then
+            echo "status=absent" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::ANAMNESIS hosted probe crashed on a CI-safe adapter (exit $probe_status)"
+            exit "$probe_status"
+          fi
       - name: Gate ANAMNESIS incrementality, speed, hermeticity, and corruption handling
         run: |
-          source .venv/bin/activate
           python -m pytest \
             tests/test_anamnesis_incremental.py \
             tests/test_anamnesis_adversarial_keys.py \
@@ -371,18 +315,9 @@ jobs:
           WGPU_BACKEND: vulkan
           WGPU_BACKENDS: vulkan
         run: |
-          source .venv/bin/activate
-          set +e
-          python scripts/terrain_ci_probe.py \
-            --mode terrain --json anamnesis-seed-adapter.json
-          probe_status=$?
-          set -e
-          if [ "$probe_status" -eq 2 ]; then
+          if [ "${{ steps.anamnesis-probe.outputs.status }}" = "absent" ]; then
             echo "ABSENT: terrain_ci_probe proved no physical Linux/Vulkan adapter" \
               > ANAMNESIS.ABSENT
-          elif [ "$probe_status" -ne 0 ]; then
-            echo "ANAMNESIS seed probe crashed on a CI-safe adapter"
-            exit "$probe_status"
           else
             set -o pipefail
             python -m forge3d.determinism \
@@ -416,17 +351,17 @@ jobs:
   anamnesis-portability:
     name: anamnesis portability consume (windows)
     needs: anamnesis-seed
+    if: inputs.run_anamnesis
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.ref }}
       - name: Prove exact-head checkout
         shell: bash
         env:
-          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+          EXPECTED_HEAD: ${{ inputs.ref }}
         run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
-      - uses: dtolnay/rust-toolchain@stable
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
@@ -434,13 +369,14 @@ jobs:
         with:
           name: anamnesis-store-linux
           path: seeded
-      - name: Build extension
-        shell: bash
+      - uses: actions/download-artifact@v4
+        with:
+          name: wheels-windows
+          path: dist/
+      - name: Install the exact wheel built by the caller
         run: |
-          python -m venv .venv
-          source .venv/Scripts/activate
-          python -m pip install -U pip maturin numpy
-          maturin develop --release
+          python scripts/install_compatible_wheel.py dist
+          python -m pip install numpy
       - name: Require portable hits and mismatch isolation
         shell: bash
         env:
@@ -448,7 +384,6 @@ jobs:
           WGPU_BACKEND: dx12
           WGPU_BACKENDS: dx12
         run: |
-          source .venv/Scripts/activate
           if [ -f seeded/ANAMNESIS.ABSENT ]; then
             echo "ABSENT: Linux/Vulkan seed host exposed no physical adapter"
           else
@@ -490,26 +425,51 @@ jobs:
           retention-days: 7
 
   diff:
-    name: diff hashes (zero-byte tolerance)
-    needs: [render, wasm-policy]
+    name: Determinism Acceptance Summary
+    needs: [f3dz-stream, render, wasm-policy, anamnesis-seed, anamnesis-portability]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ inputs.ref }}
       - uses: actions/download-artifact@v4
+        if: inputs.run_render
         with:
           pattern: determinism-hash-*
           path: hashes
       - name: Fail on any pairwise or golden mismatch
+        if: inputs.run_render
         run: >-
           python scripts/check_determinism_hashes.py
           --hashes hashes
           --golden tests/goldens/determinism/${{ env.SCENE }}.sha256
           --scene ${{ env.SCENE }}
       - name: Validate DUPLA backend proofs
+        if: inputs.run_render
         run: >-
           python scripts/run_dupla_proof.py
           --validate-artifacts hashes
           --expected-legs intel amd nvidia apple
+      - name: Enforce every requested family
+        shell: bash
+        run: |
+          failed=0
+          check_family() {
+            requested="$1"
+            result="$2"
+            label="$3"
+            if [ "$requested" = "true" ] && [ "$result" != "success" ]; then
+              echo "::error::$label was requested but finished as $result"
+              failed=1
+            elif [ "$requested" != "true" ] && [ "$result" != "skipped" ]; then
+              echo "::error::$label was not requested but finished as $result"
+              failed=1
+            fi
+          }
+          check_family '${{ inputs.run_f3dz }}' '${{ needs.f3dz-stream.result }}' f3dz
+          check_family '${{ inputs.run_render }}' '${{ needs.render.result }}' render
+          check_family '${{ inputs.run_render }}' '${{ needs.wasm-policy.result }}' wasm-policy
+          check_family '${{ inputs.run_anamnesis }}' '${{ needs.anamnesis-seed.result }}' anamnesis-seed
+          check_family '${{ inputs.run_anamnesis }}' '${{ needs.anamnesis-portability.result }}' anamnesis-portability
+          exit "$failed"

--- a/.github/workflows/test-python-wheel.yml
+++ b/.github/workflows/test-python-wheel.yml
@@ -1,0 +1,109 @@
+name: Test one platform wheel
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: Exact commit SHA under test.
+        required: true
+        type: string
+      runner:
+        description: GitHub runner image.
+        required: true
+        type: string
+      python_versions:
+        description: JSON array of Python versions.
+        required: true
+        type: string
+      wheel_artifact:
+        description: Exact wheel artifact produced in this workflow run.
+        required: true
+        type: string
+      test_mode:
+        description: full or compatibility.
+        required: true
+        type: string
+      restore_lfs:
+        description: Restore the shared TIFF fixture bundle.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Python ${{ inputs.test_mode }} (${{ inputs.runner }}, ${{ matrix.python-version }})
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 35
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Prove exact-head checkout
+        shell: bash
+        env:
+          EXPECTED_HEAD: ${{ inputs.ref }}
+        run: test "$(git rev-parse HEAD)" = "$EXPECTED_HEAD"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Download shared LFS fixture artifact
+        if: inputs.restore_lfs
+        uses: actions/download-artifact@v4
+        with:
+          name: lfs-fixture-bundles
+          path: lfs-fixture-bundles
+
+      - name: Restore Python TIFF fixtures
+        if: inputs.restore_lfs
+        run: python -m zipfile -e lfs-fixture-bundles/python-tiffs.zip .
+
+      - name: Download exact platform wheel
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.wheel_artifact }}
+          path: dist/
+
+      - name: Install wheel and compatibility dependencies
+        if: inputs.test_mode == 'compatibility'
+        run: |
+          python scripts/install_compatible_wheel.py dist
+          python -m pip install pytest numpy
+
+      - name: Install wheel and full-suite dependencies
+        if: inputs.test_mode == 'full'
+        run: |
+          python scripts/install_compatible_wheel.py dist
+          python -m pip install pytest pyyaml numpy pillow mypy pyproj rasterio
+
+      - name: Install system fonts
+        if: inputs.test_mode == 'full' && runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y fonts-dejavu-core
+
+      - name: Run compatibility smoke
+        if: inputs.test_mode == 'compatibility'
+        env:
+          FORGE3D_NO_BOOTSTRAP: '1'
+        run: >-
+          python -m pytest
+          tests/test_install_smoke.py
+          tests/test_license.py
+          tests/test_api_contracts.py
+          -v --tb=short
+
+      - name: Run full default Python lane
+        if: inputs.test_mode == 'full'
+        env:
+          FORGE3D_NO_BOOTSTRAP: '1'
+        run: |
+          python -m pytest tests/test_install_smoke.py tests/test_license.py -v --tb=short
+          python scripts/ci_pytest_lane.py -v --tb=short

--- a/docs/carto-engine/mensura-m06-full-geospatial-viewer-spec.md
+++ b/docs/carto-engine/mensura-m06-full-geospatial-viewer-spec.md
@@ -315,7 +315,7 @@ There is no cherry-pick step: `11a141c7` was merged to main via PR #106 and is a
 
 **Files and symbols to change:**
 
-- `.github/workflows/ci.yml` — add required `test-m06-full-geospatial-viewer` on `[self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]`, set `WGPU_BACKEND=vulkan`, check out LFS fixtures, build the release `interactive_viewer`, install `pytest numpy pillow rasterio`, run only the M-06 live file with `-vv -rs --junitxml=m06.xml`, assert the JUnit skipped total is zero with Python stdlib XML parsing, upload image/diff artifacts on failure, and add the job to `ci-success.needs`. Adapter or binary absence must fail inside the fixture, never call `pytest.skip`.
+- `.github/workflows/ci.yml` — add selected `test-m06-full-geospatial-viewer` acceptance on `[self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]`, set `WGPU_BACKEND=vulkan`, check out LFS fixtures, build the release `interactive_viewer`, install `pytest numpy pillow rasterio`, run only the M-06 live file with `-vv -rs --junitxml=m06.xml`, assert the JUnit skipped total is zero with Python stdlib XML parsing, upload image/diff artifacts on failure, and add the job to `Full Acceptance Summary.needs`. Adapter or binary absence must fail inside the fixture, never call `pytest.skip`.
 - New `tests/test_m06_full_geospatial_viewer.py` — reuse the existing process/socket/snapshot launcher; create deterministic local and UTM-translated north-up fixtures, south-up/X-mirrored rejection fixtures, normalized-RGB comparison, rebase/orbit checks, and the 1 mm feature check.
 - New `tests/test_m06_viewer_matrix_contract.py` — strip comments, normalize UFCS/whitespace/multiline statements, inventory look-at, perspective, projection/view composition, inverse-VP, and previous-VP operations under `src/viewer`; compare the normalized `(path, operation)` set with an explicit allowlist and require an Anchor/frame-helper assertion at every allowed producer. Any unclassified producer or stale allowlist entry fails.
 - `tests/test_world_coord_f32_gate.py` — refresh against the integrated tree and add component/field/index cast fixtures (`origin.x as f32`, `point[i] as f32`, array/map conversion helpers) plus positive Anchor-chokepoint assertions.
@@ -334,7 +334,7 @@ There is no cherry-pick step: `11a141c7` was merged to main via PR #106 and is a
 
 - The implementation branch is based on the recorded allocation-gated integration SHA; `tests/test_allocation_gate.py` exists and passes.
 - Matrix and f32 inventories are mechanically refreshed, checked in, and demonstrably fail on injected forbidden operations.
-- On PRs/develop pushes, `test-m06-full-geospatial-viewer` is required when the M-06 dependency paths select it; main pushes, schedules, and manual runs require it unconditionally. When required, it uses the real NVIDIA Vulkan runner and cannot skip green.
+- `test-m06-full-geospatial-viewer` is required on the nightly schedule, an explicit manual `m06`/`full` dispatch, or an internal PR selected by both the M-06 dependency paths and the `run-physical` label. Ordinary pushes and unlabeled PRs do not allocate the physical runner. When selected, it uses the real NVIDIA Vulkan runner and cannot skip green; `PR Core Success` remains the stable hosted merge gate.
 - Local fallback/control tests pass; the metric, cast-before-subtract, and unsupported-transform negative controls pass; the live translated-scene test is red for the expected pre-implementation reason.
 
 **Verification/tests:**
@@ -654,7 +654,7 @@ python -c "import xml.etree.ElementTree as E; r=E.parse('m06.xml').getroot(); as
 - `tests/test_m06_full_geospatial_viewer.py` created by M06-FGV-00, reusing the process/socket/snapshot harness at `tests/test_terrain_viewer_pbr.py:39-135` rather than inventing another launcher.
 - Reuse `tests/_ssim.py:12-82` for SSIM and NumPy mean absolute RGB error, but call `ssim(..., data_range=1.0)` for normalized `[0,1]` RGB. The helper's `255.0` default is invalid for this comparison.
 - Generate GeoTIFF fixtures with the shipped native `forge3d.gis.write_raster`; keep `rasterio` installed in the acceptance job to independently read back transform/CRS metadata. Install Pillow for PNG overlay/snapshot I/O. Both remain test dependencies, not new base runtime dependencies.
-- Tag the live test `@pytest.mark.interactive_viewer` as registered at `tests/conftest.py:150`. Required evidence comes from `test-m06-full-geospatial-viewer` on the self-hosted NVIDIA runner and must be included in `ci-success.needs`; the informational macOS Metal lane remains supplementary.
+- Tag the live test `@pytest.mark.interactive_viewer` as registered at `tests/conftest.py:150`. Required evidence comes from `test-m06-full-geospatial-viewer` on the self-hosted NVIDIA runner and must be included in `Full Acceptance Summary.needs` whenever selected; the informational macOS Metal lane remains supplementary.
 
 **Required live test:**
 
@@ -746,7 +746,7 @@ python -c "import xml.etree.ElementTree as E; r=E.parse('m06.xml').getroot(); as
 | Historical citations drift during integration. | An implementer edits the wrong callsite or certifies an obsolete producer inventory. | M06-FGV-00 starts from pinned `origin/main` (which already contains the MENSURA prerequisite; ancestry is verified, not re-applied), refreshes line anchors, and makes normalized source inventories executable contracts before production edits. Discovery citations taken from the historical `mensura` branch (Option-1 code, anchoring doc) describe artifacts that do not exist on the baseline and must not be "restored". |
 | Local render parity is assumed rather than measured. | Existing users see a camera/orientation/normal regression. | Identity-fallback differential plus existing simple/PBR/shadow goldens are mandatory. |
 | Normalized RGB uses the SSIM helper's `data_range=255.0` default. | Stabilizer constants swamp the signal and make the 0.999 threshold nearly unfalsifiable. | Call `ssim(..., data_range=1.0)` explicitly for `[0,1]` images and retain the MAE gate. |
-| Informational interactive-viewer CI is treated as P0 evidence. | Metal, `continue-on-error`, or a missing-binary skip appears green without exercising the Vulkan contract. | Required `test-m06-full-geospatial-viewer` builds the binary on the self-hosted NVIDIA runner, fails on absence/skip, and is included in `ci-success.needs`. |
+| Informational interactive-viewer CI is treated as P0 evidence. | Metal, `continue-on-error`, or a missing-binary skip appears green without exercising the Vulkan contract. | Selected `test-m06-full-geospatial-viewer` builds the binary on the self-hosted NVIDIA runner, fails on absence/skip, and is included in `Full Acceptance Summary.needs`. |
 | Test fixture generation assumes undeclared raster packages. | CI fails or skips before rendering. | Write DEMs with native `forge3d.gis.write_raster`, install Pillow and rasterio explicitly in the acceptance job, and keep both out of base runtime dependencies. |
 | Simple-shader height remains tied to raster pixel width. | The same geospatial footprint changes relief when DEM resolution changes. | Use raster width only for legacy local fallback and physical `abs(world_span_xz.x)` as `simple_height_extent` for georeferenced terrain; regression-test both contracts. |
 | A visual 1 mm point test passes because oversized markers overlap. | False precision win. | Pair the visual centroid assertion with a Rust packed-render-position delta assertion and a deliberately unanchored negative control. |
@@ -802,7 +802,7 @@ python -m pytest tests/test_terrain_viewer_pbr.py tests/test_vector_overlay_rend
 python -m pytest tests/test_recipe_goldens.py tests/test_determinism_hash.py -q
 ```
 
-The P0 live command runs in `test-m06-full-geospatial-viewer` CI on the self-hosted NVIDIA runner with `WGPU_BACKEND=vulkan` (path-gated on PRs/develop pushes and unconditional on main pushes, schedules, and manual runs). Build the release viewer first, install Pillow and rasterio explicitly, and reject adapter absence, binary absence, or any skipped M-06 test whenever the lane is required. The existing informational macOS lane is supplementary only.
+The P0 live command runs in `test-m06-full-geospatial-viewer` CI on the self-hosted NVIDIA runner with `WGPU_BACKEND=vulkan` when selected by the nightly schedule, an explicit manual `m06`/`full` scope, or an internal PR with both matching M-06 paths and the `run-physical` label. Build the release viewer first, install Pillow and rasterio explicitly, and reject adapter absence, binary absence, or any skipped M-06 test whenever the lane is selected. The existing informational macOS lane is supplementary only and `PR Core Success` does not claim physical evidence.
 
 ### Allocation and budget gates
 
@@ -821,7 +821,7 @@ The implementation must satisfy all of the following:
    - [ ] M06-FGV-00 branch starts directly from pinned `origin/main@a257a452`, proves `11a141c7` is an ancestor (no cherry-pick), records the resulting SHA/status, and never uses `mensura@5e625c0a` as the implementation base or ports its Option-1 commits.
    - [ ] Re-read `ci.yml`, `.cargo/config.toml`, `pyproject.toml`, budget policy, and allocation gate on that integration SHA; `tests/test_allocation_gate.py` passes.
    - [ ] Mechanical world-field and matrix inventories match explicit checked-in allowlists; injected forbidden operations fail both gates.
-   - [ ] Required `test-m06-full-geospatial-viewer` is in `ci-success.needs`, fails on adapter/binary absence or skips, and uploads failure artifacts.
+   - [ ] Selected `test-m06-full-geospatial-viewer` is in `Full Acceptance Summary.needs`, fails on adapter/binary absence or skips, and uploads failure artifacts.
    - [ ] Acceptance environment installs NumPy, Pillow, and rasterio; native `forge3d.gis.write_raster` creates the fixtures and rasterio independently verifies metadata.
    - [ ] Metric warp and cast-before-subtract negative controls fail as designed; unsupported signed transforms reject before allocation; the pre-implementation translated live case is recorded red.
 2. **Land bottom-up with compile checkpoints**
@@ -842,7 +842,7 @@ The implementation must satisfy all of the following:
    - [ ] World-coordinate gate reports exactly one sanctioned narrowing implementation, positively requires Anchor conversion for DVec/f64 operands, and explicit viewer storage contracts pass.
    - [ ] Matrix gate rejects look-at/perspective/projection-view producer operations outside its explicit file/callsite allowlist; every allowlisted and no-matrix inventory row has a positive assertion.
 4. **Live measurable acceptance**
-   - [ ] Fresh release `interactive_viewer` binary built in required self-hosted NVIDIA/Vulkan CI; M-06 run reports zero skipped tests and `ci-success` requires it. Informational macOS CI status is not substituted.
+   - [ ] Fresh release `interactive_viewer` binary built in selected self-hosted NVIDIA/Vulkan CI; M-06 run reports zero skipped tests and `Full Acceptance Summary` requires it whenever selected. Informational macOS CI status is not substituted.
    - [ ] Local vs UTM-translated render: `ssim(..., data_range=1.0) >= 0.999`, normalized mean absolute RGB error <= 0.5/255; adapter/backend recorded.
    - [ ] South-up and X-mirrored fixtures return the typed unsupported-transform diagnostic with unchanged resource-ledger counts.
    - [ ] Pre/post target-driven 1 km rebase render meets the same thresholds with stable pick ID, absolute f64 pick world position, and label screen position.

--- a/docs/carto-engine/mensura-m06-world-coord-anchoring.md
+++ b/docs/carto-engine/mensura-m06-world-coord-anchoring.md
@@ -99,7 +99,8 @@ The required CI job is `M-06 Full Geospatial Viewer (NVIDIA Vulkan)` in
 fresh release `interactive_viewer`, requires a real hardware terrain probe, and
 runs the source gates plus `tests/test_m06_full_geospatial_viewer.py`. A standard
 JUnit parser fails the job for zero collected tests, any failure/error, or any
-skip. `ci-success` requires this job.
+skip. `Full Acceptance Summary` requires this job whenever M-06 is selected;
+`PR Core Success` deliberately makes no physical-hardware claim.
 
 The live file records backend, images, frame metrics, resource counts, and viewer
 logs under `tests/artifacts/m06`. It measures:
@@ -205,7 +206,7 @@ and locally admissible proof are complete. NVIDIA/Vulkan-only rows remain
 | A34 | Live translated/rebased terrain equivalence on NVIDIA/Vulkan | NOT_PROVEN | Required test is wired fail closed. | The exact published remediation head must complete the required external job green. |
 | A35 | Live effects, full orbit, CSM/fog/temporal no-flash on NVIDIA/Vulkan | NOT_PROVEN | Required assertions and artifacts are wired. | The exact published remediation head must complete the required external job green. |
 | A36 | Live 500k points, 1 mm separation, resource stability, and rollback on NVIDIA/Vulkan | NOT_PROVEN | Required assertions and negative controls are wired. | The exact published remediation head must complete the required external job green. |
-| A37 | Exact-head required CI: zero skips/failures/errors and uploaded evidence | NOT_PROVEN | `ci-success` depends on `test-m06-full-geospatial-viewer`; JUnit and evidence validators are fail closed. | Refresh the required exact-head job after publication; local evidence is not release proof. |
+| A37 | Exact-head required CI: zero skips/failures/errors and uploaded evidence | NOT_PROVEN | `Full Acceptance Summary` depends on `test-m06-full-geospatial-viewer` whenever selected; JUnit and evidence validators are fail closed. | Refresh the selected exact-head job after publication; local evidence is not release proof. |
 
 | Specification task | Status | Local closure | Remaining deficiency |
 |---|---|---|---|

--- a/docs/ci-validation.md
+++ b/docs/ci-validation.md
@@ -1,0 +1,74 @@
+# CI validation tiers
+
+forge3d separates merge validation from high-cost acceptance. A green hosted
+check is evidence only for the claim named by that check; it is not evidence of
+physical NVIDIA/Vulkan execution.
+
+## Pull-request core
+
+`PR Core Success` is the stable branch-protection context for every pull
+request to `main` or `develop`. It requires:
+
+- the cheap workflow-contract preflight before fan-out;
+- the three hosted Rust jobs and four independently built platform wheels;
+- one full Python suite on Linux/Python 3.11;
+- compatibility smoke on Linux/Python 3.10 and 3.13, Windows/Python 3.11, and
+  macOS/Python 3.11;
+- the representative slow lane, TERMINUS, Linux aarch64 install smoke, docs,
+  and path-selected hosted visual goldens.
+
+The exhaustive 3 operating systems by 4 Python versions suite runs only in the
+nightly schedule or a manual `full` dispatch. It replaces, rather than
+duplicates, the ordinary PR Python lanes in those runs.
+
+Configure branch protection to require `PR Core Success`. Do not require `Full
+Acceptance Summary` globally: it is intentionally skipped when no expensive
+acceptance family is selected.
+
+After this policy first lands on the base branch, each already-open pull
+request needs one new `pull_request` event so it receives the new required
+context. Use **Update branch**, rebase/merge the current base branch into the PR,
+or push a new commit. Future PRs receive the check automatically.
+
+## Hosted determinism
+
+The render, F3DZ, and ANAMNESIS determinism families are path-selected
+independently. They install the exact Linux, Windows, or macOS wheel artifacts
+already built in the caller run; they do not rebuild the extension. A nightly
+run and manual `full` or `determinism` scope select the relevant complete set.
+
+Hosted render legs may record an explicit `ABSENT` result when no qualifying
+adapter exists. That result documents hosted-runner capability only and never
+satisfies a physical acceptance requirement.
+
+## Physical acceptance
+
+M-06, F3DZ, and ANAMNESIS keep their existing exact NVIDIA/Vulkan or DX12
+acceptance commands, zero-skip contracts, thresholds, and 90-day evidence. The
+frequency is narrower:
+
+- the nightly schedule runs every physical family;
+- manual `full`, `m06`, `f3dz`, or `anamnesis` selects the named family;
+- an internal pull request runs a physical family only when both its paths
+  match and the PR has the `run-physical` label;
+- ordinary pushes and unlabeled PRs do not allocate a self-hosted GPU runner.
+
+Adding or removing `run-physical` emits a PR event and starts a replacement CI
+run immediately; PR concurrency cancels the obsolete run.
+
+`Full Acceptance Summary` validates every selected hosted and physical family.
+It is a reporting/acceptance context, not the global merge gate.
+
+There is no TESSELLA job on `main`. Its path classifier is reserved as a
+fail-closed contract: any future TESSELLA physical job must consume the
+`tessella` path output or an explicit manual scope and must not run on every PR.
+
+## Certificate refresh
+
+Certificate mutation is not part of CI. `Refresh recipe certificates` is a
+manual-only workflow that runs only from the protected `main` ref, builds one
+Windows wheel for that exact SHA, and proves the checkout on the physical
+NVIDIA/Vulkan runner. Its signing job uses the protected `production-signing`
+Environment, requires the production signing secret, renders/signs the catalog,
+and uploads the signed certificates plus provenance for 90 days. Configure the
+secret and required reviewer on that Environment before enabling the workflow.

--- a/tests/test_anamnesis_inertness.py
+++ b/tests/test_anamnesis_inertness.py
@@ -22,7 +22,7 @@ def test_native_recompute_control_is_required_on_physical_gpu_ci():
         Path(__file__).resolve().parents[1] / ".github" / "workflows" / "ci.yml"
     ).read_text(encoding="utf-8")
     production_job = workflow.split("  test-anamnesis-production:", 1)[1].split(
-        "\n  build-docs:", 1
+        "\n  # ============================================================================\n  # Hosted determinism families", 1
     )[0]
     required_fragments = (
         "runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]",

--- a/tests/test_anamnesis_p1.py
+++ b/tests/test_anamnesis_p1.py
@@ -109,6 +109,9 @@ def test_p1_portability_and_production_lanes_fail_closed():
         assert "probe_status" in job
         assert 'exit "$probe_status"' in job
         assert "grep -Eq" not in job
+    assert hosted_seed.index("Classify the hosted Vulkan adapter") < hosted_seed.index(
+        "Gate ANAMNESIS incrementality"
+    )
 
     physical_seed = _job(
         ci, "test-anamnesis-portability-seed", "test-anamnesis-portability"
@@ -116,7 +119,7 @@ def test_p1_portability_and_production_lanes_fail_closed():
     physical_consumer = _job(
         ci, "test-anamnesis-portability", "test-anamnesis-production"
     )
-    production = _job(ci, "test-anamnesis-production", "build-docs")
+    production = _job(ci, "test-anamnesis-production", "determinism-render")
     physical_runner = (
         "runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]"
     )

--- a/tests/test_assert_junit_zero_skips.py
+++ b/tests/test_assert_junit_zero_skips.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import sys
 
 import pytest
+import yaml
 
 from scripts.assert_junit_zero_skips import JUnitValidationError, verify_junit
 from scripts.summarize_m06_evidence import (
@@ -259,22 +260,74 @@ def test_m06_evidence_summary_fails_closed_on_synthetic_merge_checkout(
     assert summarize_m06_main() == 1
 
 
+def _checkout_refs(workflow_text: str) -> list[str | None]:
+    workflow = yaml.load(workflow_text, Loader=yaml.BaseLoader)
+    refs: list[str | None] = []
+    for job in workflow.get("jobs", {}).values():
+        if not isinstance(job, dict):
+            continue
+        for step in job.get("steps", []):
+            if step.get("uses") == "actions/checkout@v4":
+                refs.append(step.get("with", {}).get("ref"))
+    return refs
+
+
 def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
     root = Path(__file__).resolve().parents[1]
-    exact_ref = "ref: ${{ github.event.pull_request.head.sha || github.sha }}"
-    expected_counts = {
-        "ci.yml": 17,
-        "determinism-matrix.yml": 6,
-    }
-
-    for name, expected_count in expected_counts.items():
+    exact_refs = (
+        "ref: ${{ github.event.pull_request.head.sha || github.sha }}",
+        "ref: ${{ inputs.ref }}",
+    )
+    # Semantic discovery avoids the old brittle checkout-count assertion: adding
+    # a properly pinned job must not break every Python lane, while an unpinned
+    # checkout in any PR-reachable reusable workflow must still fail preflight.
+    for name in (
+        "ci.yml",
+        "build-wheel.yml",
+        "test-python-wheel.yml",
+        "determinism-matrix.yml",
+    ):
         workflow = (root / ".github" / "workflows" / name).read_text(encoding="utf-8")
-        checkout_steps = workflow.split("- uses: actions/checkout@v4")[1:]
-        # Exact counts keep a newly added job from bypassing this provenance
-        # review accidentally.
-        assert len(checkout_steps) == expected_count
-        for index, tail in enumerate(checkout_steps, start=1):
-            step = tail.split("\n\n", 1)[0]
-            assert exact_ref in step, (
+        checkout_refs = _checkout_refs(workflow)
+        assert checkout_refs, f"{name} has no checkout provenance to verify"
+        for index, checkout_ref in enumerate(checkout_refs, start=1):
+            assert checkout_ref in {ref.removeprefix("ref: ") for ref in exact_refs}, (
                 f"{name} checkout step {index} is not exact-head pinned"
             )
+
+    ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_jobs = yaml.load(ci, Loader=yaml.BaseLoader)["jobs"]
+    for reusable in ("build-wheel.yml", "test-python-wheel.yml", "determinism-matrix.yml"):
+        callers = [
+            job
+            for job in ci_jobs.values()
+            if isinstance(job, dict)
+            and job.get("uses") == f"./.github/workflows/{reusable}"
+        ]
+        assert callers, f"CI does not call {reusable}"
+        for caller in callers:
+            assert caller.get("with", {}).get("ref") == (
+                "${{ github.event.pull_request.head.sha || github.sha }}"
+            )
+
+    certificate = (
+        root / ".github" / "workflows" / "certificate-refresh.yml"
+    ).read_text(encoding="utf-8")
+    assert _checkout_refs(certificate) == ["${{ github.sha }}"]
+
+
+def test_checkout_contract_cannot_be_satisfied_by_a_comment_or_sibling_key():
+    deceptive = """
+name: deceptive
+on:
+  pull_request:
+jobs:
+  bad:
+    runs-on: ubuntu-latest
+    steps:
+      # ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - uses: actions/checkout@v4
+      - name: "ref: ${{ github.event.pull_request.head.sha || github.sha }}"
+        run: echo not-a-checkout-ref
+"""
+    assert _checkout_refs(deceptive) == [None]

--- a/tests/test_ci_cost_controls.py
+++ b/tests/test_ci_cost_controls.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-import json
 import re
 from pathlib import Path
+
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -14,6 +15,13 @@ UPLOAD_STEP = re.compile(
 
 def _workflow(name: str) -> str:
     return (ROOT / ".github" / "workflows" / name).read_text(encoding="utf-8")
+
+
+def _workflow_data(name: str) -> dict:
+    data = yaml.load(_workflow(name), Loader=yaml.BaseLoader)
+    assert isinstance(data, dict), f"{name} is not a workflow mapping"
+    assert isinstance(data.get("jobs"), dict), f"{name} has no jobs mapping"
+    return data
 
 
 def _job(workflow: str, name: str) -> str:
@@ -46,41 +54,69 @@ def test_ci_cost_controls_are_scoped_and_retained() -> None:
     concurrency = re.search(r"(?ms)^concurrency:\n.*?(?=^env:)", workflow)
     assert concurrency
     body = concurrency.group()
-    assert "format('certificate-refresh-{0}', github.run_id)" in body
     assert "format('pr-{0}', github.event.pull_request.number)" in body
     assert "format('manual-{0}', github.ref_name)" in body
     assert "format('run-{0}', github.run_id)" in body
-    assert (
-        "cancel-in-progress: ${{ github.event_name == 'pull_request' || "
-        "(github.event_name == 'workflow_dispatch' && !inputs.update_recipe_certificates) }}"
-    ) in body
+    assert "cancel-in-progress: ${{ github.event_name == 'pull_request'" in body
 
-    matrix_line = re.search(
-        r"matrix:\s*\$\{\{\s*fromJSON\(github\.event_name == 'pull_request' "
-        r"&& '(?P<pr>\{[^']+\})' \|\| '(?P<non_pr>\{[^']+\})'\)\s*\}\}",
-        workflow,
+    trigger = workflow.split("\npermissions:", 1)[0]
+    assert (
+        "types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]"
+        in trigger
     )
-    assert matrix_line, "test-python matrix contract is missing"
-    assert json.loads(matrix_line.group("pr")) == {
-        "include": [
-            {"os": "ubuntu-latest", "python-version": "3.10"},
-            {"os": "ubuntu-latest", "python-version": "3.11"},
-            {"os": "ubuntu-latest", "python-version": "3.12"},
-            {"os": "ubuntu-latest", "python-version": "3.13"},
-            {"os": "windows-latest", "python-version": "3.11"},
-            {"os": "macos-latest", "python-version": "3.11"},
-        ]
-    }
-    assert json.loads(matrix_line.group("non_pr")) == {
-        "os": ["windows-latest", "ubuntu-latest", "macos-latest"],
-        "python-version": ["3.10", "3.11", "3.12", "3.13"],
-    }
+    for scope in ("core", "full", "determinism", "m06", "f3dz", "anamnesis"):
+        assert f"          - {scope}" in trigger
+
+    preflight = _job(workflow, "preflight")
+    assert "tests/test_ci_cost_controls.py" in preflight
+    assert "tests/test_ci_lfs_fanout.py" in preflight
+    assert "tests/test_determinism_matrix.py" in preflight
+    for job_name in (
+        "prepare-lfs-fixtures",
+        "terrain-golden-paths",
+        "test-rust",
+        "build-wheel-windows",
+        "build-wheel-linux",
+        "build-wheel-macos",
+        "build-wheel-linux-arm",
+        "build-docs",
+    ):
+        assert "needs: preflight" in _job(workflow, job_name)
+
+    for platform in ("windows", "linux", "macos", "linux-arm"):
+        job = _job(workflow, f"build-wheel-{platform}")
+        assert "uses: ./.github/workflows/build-wheel.yml" in job
+        assert f"artifact: wheels-{platform}" in job
+
+    core = _job(workflow, "test-python-core")
+    assert "runner: ubuntu-latest" in core
+    assert "python_versions: '[\"3.11\"]'" in core
+    assert "test_mode: full" in core
+    for job_name in (
+        "test-python-compat-linux",
+        "test-python-compat-windows",
+        "test-python-compat-macos",
+    ):
+        assert "test_mode: compatibility" in _job(workflow, job_name)
+    assert "python_versions: '[\"3.10\", \"3.13\"]'" in _job(
+        workflow, "test-python-compat-linux"
+    )
+    for job_name in (
+        "test-python-full-linux",
+        "test-python-full-windows",
+        "test-python-full-macos",
+    ):
+        job = _job(workflow, job_name)
+        assert "github.event_name == 'schedule'" in job
+        assert "inputs.scope == 'full'" in job
+        assert "python_versions: '[\"3.10\", \"3.11\", \"3.12\", \"3.13\"]'" in job
 
     assert "retention-days: 1" in _artifact_step(
         _job(workflow, "prepare-lfs-fixtures"), "lfs-fixture-bundles"
     )
+    wheel_workflow = _workflow("build-wheel.yml")
     assert "retention-days: 1" in _artifact_step(
-        _job(workflow, "build-wheels"), "wheels-${{ matrix.platform.os }}"
+        _job(wheel_workflow, "build"), "${{ inputs.artifact }}"
     )
     for job, artifact in (
         ("test-terminus-fuzz", "terminus-fuzzer-evidence"),
@@ -90,7 +126,6 @@ def test_ci_cost_controls_are_scoped_and_retained() -> None:
         assert "retention-days: 7" in _artifact_step(_job(workflow, job), artifact)
 
     for job, artifact in (
-        ("refresh-recipe-certificates", "refreshed-recipe-certificates"),
         ("test-m06-full-geospatial-viewer", "m06-full-geospatial-viewer-evidence"),
         ("test-f3dz-gpu", "f3dz-physical-gpu-evidence"),
         ("test-anamnesis-portability-seed", "anamnesis-physical-portable-store"),
@@ -103,6 +138,24 @@ def test_ci_cost_controls_are_scoped_and_retained() -> None:
     assert "name: documentation" not in workflow
     assert "  build-docs:" in workflow
     assert "cargo doc --workspace" in _job(workflow, "build-docs")
+
+    assert "refresh-recipe-certificates" not in workflow
+    certificate = _workflow("certificate-refresh.yml")
+    certificate_trigger = certificate.split("\npermissions:", 1)[0]
+    assert "  workflow_dispatch:" in certificate_trigger
+    assert "  push:" not in certificate_trigger
+    assert "  pull_request:" not in certificate_trigger
+    assert certificate.count("uses: ./.github/workflows/build-wheel.yml") == 1
+    assert "artifact: certificate-refresh-wheel-windows" in certificate
+    assert "--require-nvidia-vulkan" in certificate
+    assert "ref: ${{ github.sha }}" in certificate
+    assert "github.ref == 'refs/heads/main'" in certificate
+    assert "github.ref_protected" in certificate
+    assert "environment: production-signing" in certificate
+    assert "group: certificate-refresh-production" in certificate
+    assert "retention-days: 90" in _artifact_step(
+        _job(certificate, "refresh"), "refreshed-recipe-certificates"
+    )
 
 
 def test_publish_cost_controls_are_tag_only_and_retention_aware() -> None:
@@ -128,19 +181,217 @@ def test_publish_cost_controls_are_tag_only_and_retention_aware() -> None:
 
     expected = "retention-days: ${{ startsWith(github.ref, 'refs/tags/v') && 90 || 1 }}"
     uploads = _upload_steps(workflow)
-    assert len(uploads) == 2
+    assert uploads
     assert all(expected in upload for upload in uploads)
 
 
 def test_determinism_cost_controls_keep_pr_cancellation_and_evidence() -> None:
     workflow = _workflow("determinism-matrix.yml")
-    concurrency = re.search(r"(?ms)^concurrency:\n.*?(?=^env:)", workflow)
-    assert concurrency
-    body = concurrency.group()
-    assert "format('pr-{0}', github.event.pull_request.number)" in body
-    assert "format('run-{0}', github.run_id)" in body
-    assert "cancel-in-progress: ${{ github.event_name == 'pull_request' }}" in body
+    trigger = workflow.split("\npermissions:", 1)[0]
+    assert "  workflow_call:" in trigger
+    assert "  workflow_dispatch:" not in trigger
+    assert "  push:" not in trigger
+    assert "  pull_request:" not in trigger
+    assert "maturin develop" not in workflow
+    assert "PyO3/maturin-action" not in workflow
+    assert "actions/download-artifact@v4" in workflow
+    for family in ("run_render", "run_f3dz", "run_anamnesis"):
+        assert family in trigger
 
     uploads = _upload_steps(workflow)
-    assert len(uploads) == 5
+    assert uploads
     assert all("retention-days: 7" in upload for upload in uploads)
+    for artifact in (
+        "f3dz-determinism-${{ matrix.os }}",
+        "determinism-hash-${{ matrix.leg }}",
+        "determinism-hash-wasm",
+        "anamnesis-store-linux",
+        "anamnesis-hosted-consumer-evidence",
+    ):
+        assert "retention-days: 7" in _artifact_step(workflow, artifact)
+
+
+def test_all_workflows_parse_and_local_reusable_calls_are_well_formed() -> None:
+    workflow_dir = ROOT / ".github" / "workflows"
+    parsed = {path.name: _workflow_data(path.name) for path in workflow_dir.glob("*.yml")}
+    assert parsed
+
+    allowed_call_keys = {
+        "name",
+        "uses",
+        "with",
+        "secrets",
+        "strategy",
+        "needs",
+        "if",
+        "permissions",
+        "concurrency",
+    }
+    for caller_name, workflow in parsed.items():
+        for job_name, job in workflow["jobs"].items():
+            if not isinstance(job, dict):
+                continue
+            uses = job.get("uses", "")
+            if not uses.startswith("./.github/workflows/"):
+                continue
+            assert set(job) <= allowed_call_keys, (
+                f"{caller_name}:{job_name} uses unsupported keys for a reusable call: "
+                f"{sorted(set(job) - allowed_call_keys)}"
+            )
+            target_name = Path(uses).name
+            assert target_name in parsed, f"{caller_name}:{job_name} calls missing {uses}"
+            target_on = parsed[target_name].get("on", {})
+            assert isinstance(target_on, dict) and "workflow_call" in target_on, (
+                f"{caller_name}:{job_name} target {target_name} is not reusable"
+            )
+            call_contract = target_on["workflow_call"] or {}
+            declared_inputs = call_contract.get("inputs", {})
+            provided_inputs = job.get("with", {}) or {}
+            assert set(provided_inputs) <= set(declared_inputs), (
+                f"{caller_name}:{job_name} passes unknown inputs to {target_name}: "
+                f"{sorted(set(provided_inputs) - set(declared_inputs))}"
+            )
+            required_inputs = {
+                name
+                for name, contract in declared_inputs.items()
+                if str(contract.get("required", "false")).casefold() == "true"
+            }
+            assert required_inputs <= set(provided_inputs), (
+                f"{caller_name}:{job_name} omits required {target_name} inputs: "
+                f"{sorted(required_inputs - set(provided_inputs))}"
+            )
+            for input_name, value in provided_inputs.items():
+                input_type = declared_inputs[input_name].get("type")
+                if input_type == "boolean" and not str(value).startswith("${{"):
+                    assert str(value).casefold() in {"true", "false"}, (
+                        f"{caller_name}:{job_name} passes non-boolean {input_name}={value}"
+                    )
+
+
+def test_tessella_cannot_become_an_unscoped_pr_job() -> None:
+    workflow = _workflow("ci.yml")
+    paths = _job(workflow, "terrain-golden-paths")
+    assert "tessella: ${{ steps.filter.outputs.tessella }}" in paths
+    assert "            tessella:" in paths
+
+    for path in (
+        "src/terrain/renderer/virtual_texture.rs",
+        "src/core/feedback_buffer.rs",
+        "src/core/screen_space_effects/hzb.rs",
+        "src/shaders/hzb_build.wgsl",
+        "tests/test_terrain_vt_pbr_families.py",
+        "tests/test_tv20_virtual_texturing.py",
+    ):
+        assert f"              - '{path}'" in paths
+
+    # Main currently has no TESSELLA acceptance job. Lock that honest state so
+    # a future lane cannot appear under a generic name without an explicit
+    # contract/test update that wires the classifier or a manual scope.
+    jobs = _workflow_data("ci.yml")["jobs"]
+    tessella_jobs = []
+    tessella_tokens = (
+        "test_tv20_virtual_texturing.py",
+        "test_terrain_vt_pbr_families.py",
+        "hzb_build.wgsl",
+        "virtual_texture.rs",
+        "feedback_buffer.rs",
+    )
+    for name, body in jobs.items():
+        if name == "terrain-golden-paths":
+            continue
+        serialized = yaml.safe_dump(body).casefold()
+        physical_domain_job = "self-hosted" in serialized and any(
+            token in serialized for token in tessella_tokens
+        )
+        if (
+            "tessella" in name.casefold()
+            or "tessella" in serialized
+            or physical_domain_job
+        ):
+            tessella_jobs.append(name)
+    assert tessella_jobs == [], f"TESSELLA jobs require an explicit scoped contract: {tessella_jobs}"
+
+
+def test_physical_selection_truth_table_and_job_conditions() -> None:
+    jobs = _workflow_data("ci.yml")["jobs"]
+
+    def normalize(value: str) -> str:
+        return " ".join(value.split())
+
+    def expected_condition(scope: str, output: str) -> str:
+        return normalize(
+            f"""
+            github.event_name == 'schedule' ||
+            (github.event_name == 'workflow_dispatch' &&
+             (inputs.scope == 'full' || inputs.scope == '{scope}')) ||
+            (github.event_name == 'pull_request' &&
+             github.event.pull_request.head.repo.full_name == github.repository &&
+             contains(github.event.pull_request.labels.*.name, 'run-physical') &&
+             needs.terrain-golden-paths.outputs.{output} == 'true')
+            """
+        )
+
+    expected = {
+        "test-m06-full-geospatial-viewer": expected_condition("m06", "m06"),
+        "test-f3dz-gpu": expected_condition("f3dz", "f3dz"),
+        "test-anamnesis-portability-seed": expected_condition(
+            "anamnesis", "anamnesis"
+        ),
+        "test-anamnesis-portability": expected_condition("anamnesis", "anamnesis"),
+        "test-anamnesis-production": expected_condition("anamnesis", "anamnesis"),
+    }
+    for job_name, condition in expected.items():
+        assert normalize(jobs[job_name]["if"]) == condition
+
+    def selected(
+        event: str,
+        *,
+        scope: str = "core",
+        internal: bool = False,
+        labeled: bool = False,
+        path_selected: bool = False,
+        family: str = "m06",
+    ) -> bool:
+        return event == "schedule" or (
+            event == "workflow_dispatch" and scope in {"full", family}
+        ) or (
+            event == "pull_request" and internal and labeled and path_selected
+        )
+
+    cases = (
+        ({"event": "push", "path_selected": True}, False),
+        ({"event": "pull_request", "path_selected": True}, False),
+        (
+            {
+                "event": "pull_request",
+                "internal": True,
+                "path_selected": True,
+            },
+            False,
+        ),
+        (
+            {
+                "event": "pull_request",
+                "internal": True,
+                "labeled": True,
+                "path_selected": False,
+            },
+            False,
+        ),
+        (
+            {
+                "event": "pull_request",
+                "internal": True,
+                "labeled": True,
+                "path_selected": True,
+            },
+            True,
+        ),
+        ({"event": "schedule"}, True),
+        ({"event": "workflow_dispatch", "scope": "core"}, False),
+        ({"event": "workflow_dispatch", "scope": "full"}, True),
+        ({"event": "workflow_dispatch", "scope": "m06"}, True),
+        ({"event": "workflow_dispatch", "scope": "f3dz"}, False),
+    )
+    for arguments, wanted in cases:
+        assert selected(**arguments) is wanted

--- a/tests/test_ci_lfs_fanout.py
+++ b/tests/test_ci_lfs_fanout.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import re
 from pathlib import Path
+
+import yaml
 
 from scripts.ci_pytest_lane import default_lane_files
 
@@ -15,9 +18,26 @@ def _workflow() -> str:
 
 def test_ci_downloads_verified_lfs_media_once_and_shares_one_artifact() -> None:
     workflow = _workflow()
+    python_workflow = (
+        ROOT / ".github" / "workflows" / "test-python-wheel.yml"
+    ).read_text(encoding="utf-8")
 
-    assert "git lfs pull" not in workflow
-    assert "lfs: true" not in workflow
+    for path in (ROOT / ".github" / "workflows").glob("*.yml"):
+        text = path.read_text(encoding="utf-8")
+        assert not re.search(r"\bgit\s+lfs\s+(?:pull|fetch|checkout)\b", text), (
+            f"{path.name} reintroduced per-job LFS transfer"
+        )
+        data = yaml.load(text, Loader=yaml.BaseLoader)
+        for job_name, job in data.get("jobs", {}).items():
+            if not isinstance(job, dict):
+                continue
+            for step in job.get("steps", []):
+                if step.get("uses") != "actions/checkout@v4":
+                    continue
+                lfs = step.get("with", {}).get("lfs", "false").casefold()
+                assert lfs not in {"true", "1", "yes", "on"}, (
+                    f"{path.name}:{job_name} checkout reintroduced LFS fanout"
+                )
     assert (
         "https://media.githubusercontent.com/media/milos-agathon/forge3d/"
         "92a86baa3c8f6ba3c3a7368e4f80d4004905a433"
@@ -27,7 +47,12 @@ def test_ci_downloads_verified_lfs_media_once_and_shares_one_artifact() -> None:
     assert "875b243474b151175f76037acd60c2149ac2e46fba9ba2bbce0c9a6998015dd3" in workflow
     assert "d09d229fa265749720a6b4bd40c440799f43286bf2d401d732ea77f89d0bd478" in workflow
     assert "is still an LFS pointer" in workflow
-    assert workflow.count("name: lfs-fixture-bundles") == 4
+    prepare = workflow.split("  prepare-lfs-fixtures:", 1)[1].split(
+        "  terrain-golden-paths:", 1
+    )[0]
+    assert prepare.count("name: lfs-fixture-bundles") == 1
+    assert python_workflow.count("name: lfs-fixture-bundles") == 1
+    assert "if: inputs.restore_lfs" in python_workflow
     assert workflow.count("uses: actions/upload-artifact@v4") >= 1
     assert "retention-days: 1" in workflow
 
@@ -51,27 +76,45 @@ def test_ci_lfs_manifest_contains_only_lane_fixtures() -> None:
 
 def test_python_and_m06_restore_only_their_fixture_bundles() -> None:
     workflow = _workflow()
-    python_job = workflow.split("  test-python:", 1)[1].split(
-        "\n  # ============================================================================\n  # Accounted slow Python tests (one hosted representative)", 1
-    )[0]
+    python_workflow = (
+        ROOT / ".github" / "workflows" / "test-python-wheel.yml"
+    ).read_text(encoding="utf-8")
     slow_job = workflow.split("  test-python-slow:", 1)[1].split(
         "\n  # ============================================================================\n  # TERMINUS", 1
     )[0]
     golden_job = workflow.split("  test-golden-images:", 1)[1].split(
-        "  refresh-recipe-certificates:", 1
+        "  test-m06-full-geospatial-viewer:", 1
     )[0]
     m06_job = workflow.split("  test-m06-full-geospatial-viewer:", 1)[1].split(
-        "  build-docs:", 1
+        "\n  # ============================================================================\n  # COMPENDIUM F3DZ", 1
     )[0]
 
-    for job in (python_job, slow_job):
-        assert "needs: [build-wheels, prepare-lfs-fixtures]" in job
-        assert job.count(".zip") == 1
-        assert "python-tiffs.zip" in job
-        assert "m06-dem.zip" not in job
-        assert "forge3d.pdb" not in job
+    assert python_workflow.count("python-tiffs.zip") == 1
+    assert "m06-dem.zip" not in python_workflow
+    assert "forge3d.pdb" not in python_workflow
+    assert "needs: [build-wheel-linux, prepare-lfs-fixtures]" in slow_job
+    assert slow_job.count(".zip") == 1
+    assert "python-tiffs.zip" in slow_job
+    assert "m06-dem.zip" not in slow_job
+    for full_job in (
+        "test-python-core",
+        "test-python-full-linux",
+        "test-python-full-windows",
+        "test-python-full-macos",
+    ):
+        assert "restore_lfs: true" in workflow.split(f"  {full_job}:", 1)[1].split(
+            "\n\n", 1
+        )[0]
+    for smoke_job in (
+        "test-python-compat-linux",
+        "test-python-compat-windows",
+        "test-python-compat-macos",
+    ):
+        assert "restore_lfs:" not in workflow.split(f"  {smoke_job}:", 1)[1].split(
+            "\n\n", 1
+        )[0]
     assert "lfs-fixture-bundles" not in golden_job
-    assert "needs: [build-wheels, prepare-lfs-fixtures, terrain-golden-paths]" in m06_job
+    assert "needs: [build-wheel-windows, prepare-lfs-fixtures, terrain-golden-paths]" in m06_job
     assert "m06-dem.zip" in m06_job
     assert "python-tiffs.zip" not in m06_job
     assert "Get-PSDrive -PSProvider FileSystem" in m06_job
@@ -126,7 +169,6 @@ def test_m06_path_filter_and_aggregator_contract() -> None:
     ):
         assert f"              - '{pattern}'" in m06_paths
     for broad_pattern in (
-        ".github/workflows/ci.yml",
         "docs/**",
         "examples/**",
         "python/**",
@@ -134,41 +176,34 @@ def test_m06_path_filter_and_aggregator_contract() -> None:
         "assets/**",
     ):
         assert f"              - '{broad_pattern}'" not in m06_paths
+    for workflow_path in (
+        ".github/workflows/ci.yml",
+        ".github/workflows/build-wheel.yml",
+    ):
+        assert f"              - '{workflow_path}'" in m06_paths
 
     m06_job = workflow.split("  test-m06-full-geospatial-viewer:", 1)[1].split(
         "\n  # ============================================================================\n  # COMPENDIUM F3DZ", 1
     )[0]
-    assert "needs: [build-wheels, prepare-lfs-fixtures, terrain-golden-paths]" in m06_job
+    assert "needs: [build-wheel-windows, prepare-lfs-fixtures, terrain-golden-paths]" in m06_job
     assert "if: >-" in m06_job
     for clause in (
-        "github.event_name == 'workflow_dispatch'",
         "github.event_name == 'schedule'",
-        "github.event_name == 'push' && github.ref == 'refs/heads/main'",
+        "inputs.scope == 'full'",
+        "inputs.scope == 'm06'",
+        "github.event_name == 'pull_request'",
+        "contains(github.event.pull_request.labels.*.name, 'run-physical')",
         "needs.terrain-golden-paths.outputs.m06 == 'true'",
     ):
         assert clause in m06_job
+    assert "github.event_name == 'push'" not in m06_job
 
-    aggregate = workflow.split("  ci-success:", 1)[1]
-    assert "m06_required=" in aggregate
-    required_branch, skip_tail = aggregate.split(
-        'if [ "$m06_required" = "true" ]; then', 1
-    )[1].split("\n          else\n", 1)
-    skip_branch = skip_tail.split("\n          fi\n          if ", 1)[0]
-    success_check = (
-        '${{ needs.test-m06-full-geospatial-viewer.result }}" != "success"'
+    aggregate = workflow.split("  full-acceptance-summary:", 1)[1]
+    assert "m06_selected=" in aggregate
+    assert (
+        "check_selected \"$m06_selected\" '${{ needs.test-m06-full-geospatial-viewer.result }}' m06-physical"
+        in aggregate
     )
-    skipped_check = (
-        '${{ needs.test-m06-full-geospatial-viewer.result }}" != "skipped"'
-    )
-    assert success_check in required_branch
-    assert success_check not in skip_branch
-    assert skipped_check in skip_branch
-    assert skipped_check not in required_branch
-    final_gate = aggregate.split(
-        'if [ "${{ needs.prepare-lfs-fixtures.result }}" != "success" ] ||', 1
-    )[1]
-    assert '[ "$m06_failed" -ne 0 ] || \\' in final_gate
-    assert "needs.test-m06-full-geospatial-viewer.result" not in final_gate
 
 
 def test_m06_acceptance_keeps_only_unique_physical_coverage() -> None:

--- a/tests/test_determinism_matrix.py
+++ b/tests/test_determinism_matrix.py
@@ -150,14 +150,42 @@ def test_f3dz_stream_hashes_run_on_two_hosted_platforms():
     assert "f3dz-determinism-${{ matrix.os }}" in workflow
 
 
-def test_shadow_shader_changes_reach_push_and_pull_request_matrix_triggers():
+def test_shadow_shader_changes_select_only_the_render_family_in_ci():
+    ci = (WORKFLOW.parent / "ci.yml").read_text()
+    classifier = ci.split("            determinism_render:\n", 1)[1].split(
+        "\n            determinism_f3dz:\n", 1
+    )[0]
+    assert "'src/shaders/shadows.wgsl'" in classifier
+    assert "'src/shaders/includes/shadow_moments.wgsl'" in classifier
+    assert "'src/shaders/csm.wgsl'" not in classifier
+
+    caller = ci.split("  determinism-render:", 1)[1].split(
+        "\n  determinism-f3dz:", 1
+    )[0]
+    assert "needs.terrain-golden-paths.outputs.determinism_render == 'true'" in caller
+    assert "uses: ./.github/workflows/determinism-matrix.yml" in caller
+    assert "run_render: true" in caller
+
+
+def test_matrix_reuses_caller_wheels_instead_of_rebuilding_extensions():
     workflow = WORKFLOW.read_text()
-    push_paths = workflow.split("  push:", 1)[1].split("  pull_request:", 1)[0]
-    pull_request_paths = workflow.split("  pull_request:", 1)[1].split("jobs:", 1)[0]
-    for trigger_paths in (push_paths, pull_request_paths):
-        assert "'src/shaders/shadows.wgsl'" in trigger_paths
-        assert "'src/shaders/includes/shadow_moments.wgsl'" in trigger_paths
-        assert "'src/shaders/csm.wgsl'" not in trigger_paths
+    assert "  workflow_call:" in workflow
+    assert "maturin develop" not in workflow
+    assert "PyO3/maturin-action" not in workflow
+    for artifact in ("wheels-linux", "wheels-windows"):
+        assert artifact in workflow
+    assert "'macos'" in workflow
+    assert "ref: ${{ inputs.ref }}" in workflow
+    assert "FORGE3D_NO_BOOTSTRAP: '1'" in workflow
+    anamnesis = workflow.split("  anamnesis-seed:", 1)[1].split(
+        "\n  anamnesis-portability:", 1
+    )[0]
+    assert anamnesis.index("Classify the hosted Vulkan adapter") < anamnesis.index(
+        "Gate ANAMNESIS incrementality"
+    )
+    summary = workflow.split("  diff:", 1)[1]
+    for family in ("f3dz-stream", "render", "wasm-policy", "anamnesis-seed", "anamnesis-portability"):
+        assert f"needs.{family}.result" in summary
 
 
 def test_dupla_aggregation_accepts_verified_and_explicit_absence(tmp_path):

--- a/tests/test_f3dz_codec.py
+++ b/tests/test_f3dz_codec.py
@@ -220,12 +220,15 @@ def test_physical_gpu_ci_contract_is_zero_skip_and_records_benchmark() -> None:
     job = workflow.split("  test-f3dz-gpu:", 1)[1].split(
         "\n  test-anamnesis-portability-seed:", 1
     )[0]
-    assert "needs: [build-wheels, terrain-golden-paths]" in job
+    assert "needs: [build-wheel-windows, terrain-golden-paths]" in job
     assert "if: >-" in job
-    assert "github.event_name == 'workflow_dispatch'" in job
     assert "github.event_name == 'schedule'" in job
-    assert "github.event_name == 'push'" in job
-    assert "github.ref == 'refs/heads/main'" in job
+    assert "inputs.scope == 'full'" in job
+    assert "inputs.scope == 'f3dz'" in job
+    assert "github.event_name == 'pull_request'" in job
+    assert "github.event.pull_request.head.repo.full_name == github.repository" in job
+    assert "contains(github.event.pull_request.labels.*.name, 'run-physical')" in job
+    assert "github.event_name == 'push'" not in job
     assert "needs.terrain-golden-paths.outputs.f3dz == 'true'" in job
 
     f3dz_paths = workflow.split("            f3dz:\n", 1)[1].split(
@@ -272,7 +275,6 @@ def test_physical_gpu_ci_contract_is_zero_skip_and_records_benchmark() -> None:
     for path in required_paths:
         assert f"              - '{path}'" in f3dz_paths
     excluded_paths = (
-        ".github/workflows/ci.yml",
         "docs/formats/f3dz.md",
         "tools/f3dz_determinism_report.py",
         ".cargo/**",
@@ -283,12 +285,24 @@ def test_physical_gpu_ci_contract_is_zero_skip_and_records_benchmark() -> None:
     )
     for path in excluded_paths:
         assert f"              - '{path}'" not in f3dz_paths
+    for workflow_path in (
+        ".github/workflows/ci.yml",
+        ".github/workflows/build-wheel.yml",
+    ):
+        assert f"              - '{workflow_path}'" in f3dz_paths
     assert "runs-on: [self-hosted, Windows, X64, forge3d-gpu, gpu-nvidia]" in job
     assert "FORGE3D_REQUIRE_F3DZ_GPU: '1'" in job
     assert "python scripts/terrain_ci_probe.py" not in job
     assert "python -m pytest tests/test_f3dz_codec.py" in job
     assert "scripts/assert_junit_zero_skips.py" in job
     assert "cargo bench --bench f3dz_bench" in job
+    benchmark = job.split(
+        "      - name: Record separate source benchmark (nightly/full only)", 1
+    )[1].split("\n      - name: Upload F3DZ physical-GPU evidence", 1)[0]
+    assert "github.event_name == 'schedule'" in benchmark
+    assert "inputs.scope == 'full'" in benchmark
+    assert "source-benchmark-not-installed-wheel-acceptance" in benchmark
+    assert "benchmark-provenance.json" in benchmark
     assert "f3dz-physical-gpu-evidence" in job
     assert "Get-PSDrive -PSProvider FileSystem" in job
     assert "Sort-Object Free -Descending" in job

--- a/tests/test_no_silent_degradation.py
+++ b/tests/test_no_silent_degradation.py
@@ -196,7 +196,13 @@ def test_c_every_feature_referenced_and_ci_list_curated():
     # The wheel's maturin list is the extension-module compile lane. Together,
     # portable/default closure + system lane + wheel lane must cover everything.
     maturin = _maturin_features()
-    assert "PyO3/maturin-action" in ci_yml, "CI has no wheel build exercising maturin features"
+    wheel_yml = (ROOT / ".github" / "workflows" / "build-wheel.yml").read_text(
+        encoding="utf-8"
+    )
+    assert "uses: ./.github/workflows/build-wheel.yml" in ci_yml
+    assert "PyO3/maturin-action" in wheel_yml, (
+        "reusable CI wheel builder does not exercise maturin features"
+    )
     covered = _feature_closure(PORTABLE_CI_CARGO_FEATURES) | DEDICATED_SYSTEM_FEATURES | maturin
     assert covered == declared, f"declared features not compiled by any CI lane: {sorted(declared - covered)}"
 
@@ -377,7 +383,9 @@ def test_e_slow_lane_is_marker_selected_and_accounted():
         "\n  # ============================================================================\n  # TERMINUS", 1
     )[0]
     assert "python scripts/ci_pytest_lane.py --slow-lane" in slow_job
-    aggregate = ci_yml.split("  ci-success:", 1)[1]
+    aggregate = ci_yml.split("  pr-core-success:", 1)[1].split(
+        "\n  full-acceptance-summary:", 1
+    )[0]
     assert "test-python-slow" in aggregate.split("\n    runs-on:", 1)[0]
 
 
@@ -390,11 +398,7 @@ def test_e_anamnesis_physical_jobs_are_path_gated_honestly():
     )[0]
     assert "anamnesis: ${{ steps.filter.outputs.anamnesis }}" in paths_job
     anamnesis_paths = paths_job.split("            anamnesis:\n", 1)[1]
-    for broad_path in (
-        "'.github/workflows/ci.yml'",
-        "'src/**'",
-        "'python/**'",
-    ):
+    for broad_path in ("'src/**'", "'python/**'"):
         assert broad_path not in anamnesis_paths
     for path in (
         "'src/core/anamnesis/**'",
@@ -445,13 +449,18 @@ def test_e_anamnesis_physical_jobs_are_path_gated_honestly():
         "'scripts/assert_junit_zero_skips.py'",
         "'tests/anamnesis_gpu_acceptance.py'",
         "'tests/goldens/determinism/**'",
+        "'.github/workflows/ci.yml'",
+        "'.github/workflows/build-wheel.yml'",
     ):
         assert path in anamnesis_paths
 
     required = (
-        "github.event_name == 'workflow_dispatch'",
         "github.event_name == 'schedule'",
-        "github.event_name == 'push' && github.ref == 'refs/heads/main'",
+        "inputs.scope == 'full'",
+        "inputs.scope == 'anamnesis'",
+        "github.event_name == 'pull_request'",
+        "github.event.pull_request.head.repo.full_name == github.repository",
+        "contains(github.event.pull_request.labels.*.name, 'run-physical')",
         "needs.terrain-golden-paths.outputs.anamnesis == 'true'",
     )
     for job_name in (
@@ -464,28 +473,22 @@ def test_e_anamnesis_physical_jobs_are_path_gated_honestly():
         )[0]
         for fragment in required:
             assert fragment in job
+        assert "github.event_name == 'push'" not in job
     production = ci_yml.split("  test-anamnesis-production:", 1)[1].split(
-        "\n  # ============================================================================\n  # Documentation Build", 1
+        "\n  # ============================================================================\n  # Hosted determinism families", 1
     )[0]
     assert "test_real_gpu_600_frame_acceptance" in production
-    aggregate = ci_yml.split("  ci-success:", 1)[1]
-    assert "anamnesis_required" in aggregate
-    required_branch, skip_tail = aggregate.split(
-        'if [ "$anamnesis_required" = "true" ]; then', 1
-    )[1].split("\n          else\n", 1)
-    skip_branch = skip_tail.split("\n          fi\n          if ", 1)[0]
+    aggregate = ci_yml.split("  full-acceptance-summary:", 1)[1]
+    assert "anamnesis_physical_selected=" in aggregate
     for job_name in (
         "test-anamnesis-portability-seed",
         "test-anamnesis-portability",
         "test-anamnesis-production",
     ):
-        result_prefix = f"needs.{job_name}.result "
-        success_check = result_prefix + '}}" != "success"'
-        skipped_check = result_prefix + '}}" != "skipped"'
-        assert success_check in required_branch
-        assert success_check not in skip_branch
-        assert skipped_check in skip_branch
-        assert skipped_check not in required_branch
+        assert (
+            f"check_selected \"$anamnesis_physical_selected\" "
+            f"'${{{{ needs.{job_name}.result }}}}'"
+        ) in aggregate
 
 
 # ---------------------------------------------------------------------------
@@ -493,15 +496,16 @@ def test_e_anamnesis_physical_jobs_are_path_gated_honestly():
 # ---------------------------------------------------------------------------
 def test_f_probe_positive_golden_mismatch_fails_ci_and_probe_negative_is_absent():
     ci_yml = (ROOT / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    # Stop at the dispatch-only certificate refresh job.  That separate lane
-    # intentionally downloads the Windows wheel on the labeled GPU runner;
-    # the hosted Metal golden lane itself must remain macOS-wheel-only.
+    # Certificate mutation lives in a different manual-only workflow; the
+    # hosted Metal golden lane itself must remain macOS-wheel-only.
     golden_job = ci_yml.split("  test-golden-images:", 1)[1].split(
-        "\n  refresh-recipe-certificates:", 1
+        "\n  test-m06-full-geospatial-viewer:", 1
     )[0]
     pytest_step = golden_job.split("- name: Run visual golden tests", 1)[1].split("\n      - name:", 1)[0]
     probe_step = golden_job.split("- name: Probe terrain golden backend", 1)[1].split("\n      - name:", 1)[0]
-    aggregate = ci_yml.split("  ci-success:", 1)[1]
+    aggregate = ci_yml.split("  pr-core-success:", 1)[1].split(
+        "\n  full-acceptance-summary:", 1
+    )[0]
 
     assert "runs-on: macos-14" in golden_job, "golden lane must use the gated Metal runner"
     assert "WGPU_BACKEND: metal" in golden_job
@@ -527,5 +531,5 @@ def test_f_probe_positive_golden_mismatch_fails_ci_and_probe_negative_is_absent(
     assert 'if [ -z "$FORGE3D_CERT_SIGNING_KEY" ]' in signing_step
     assert "exit 1" in signing_step
     assert "UNTRUSTED external PR" in golden_job
-    assert 'needs.test-golden-images.result }}" != "success"' in aggregate
-    assert 'needs.test-golden-images.result }}" != "skipped"' in aggregate
+    assert "require_success test-golden-images '${{ needs.test-golden-images.result }}'" in aggregate
+    assert "require_state test-golden-images '${{ needs.test-golden-images.result }}' skipped" in aggregate


### PR DESCRIPTION
## Summary

- makes PR Core Success the stable hosted branch-protection context for pull requests;
- builds platform wheels independently and reuses the exact same-run artifacts across focused Python and determinism workflows;
- runs one representative full Python lane plus boundary/platform compatibility on ordinary PRs, reserving the exhaustive matrix for nightly or manual full runs;
- path-selects render, F3DZ, and ANAMNESIS determinism families;
- limits physical M-06, F3DZ, and ANAMNESIS jobs to nightly, explicit manual scopes, or internal relevant PRs carrying run-physical;
- moves production certificate refresh into a protected-main, manual-only workflow;
- adds YAML-aware contracts for exact-head checkout, reusable inputs, LFS fanout, cost controls, physical-selection truth tables, and the current TESSELLA no-job boundary.

## Validation

- git diff --check
- workflow YAML parse: 8 files
- Python contract-test compilation
- focused CI policy suite: 51 passed

## Evidence boundaries

This proves the repository workflow structure and static policy contracts locally. It does not yet prove GitHub execution of every reusable workflow expression or any hosted, NVIDIA/Vulkan, DX12, signing, artifact-transfer, or physical-acceptance outcome.

## Rollout

After PR Core Success succeeds on this exact head, main branch protection will require that GitHub Actions check. Existing open PRs need a fresh pull-request event after this workflow lands. The run-physical label must remain limited to relevant internal PRs because it allocates self-hosted acceptance capacity.