### PR TITLE
Allow CI preflight on existing pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,17 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      # Preflight validates the evaluated event state. On pull requests this is
+      # the synthetic merge commit, so base-added policy tests are available to
+      # legacy PR heads. Every source/artifact job below remains exact-head.
+      - name: Checkout evaluated workflow state
+        uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
+
+      - name: Prove evaluated preflight checkout
+        shell: bash
+        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
 
       - uses: actions/setup-python@v5
         with:

--- a/docs/ci-validation.md
+++ b/docs/ci-validation.md
@@ -17,6 +17,11 @@ request to `main` or `develop`. It requires:
 - the representative slow lane, TERMINUS, Linux aarch64 install smoke, docs,
   and path-selected hosted visual goldens.
 
+The preflight validates the evaluated event state (the proposed merge on pull
+requests), so policy tests added on the base branch are available to older PR
+heads. Wheels, source tests, and acceptance evidence remain built from the
+exact PR head SHA.
+
 The exhaustive 3 operating systems by 4 Python versions suite runs only in the
 nightly schedule or a manual `full` dispatch. It replaces, rather than
 duplicates, the ordinary PR Python lanes in those runs.
@@ -27,8 +32,9 @@ acceptance family is selected.
 
 After this policy first lands on the base branch, each already-open pull
 request needs one new `pull_request` event so it receives the new required
-context. Use **Update branch**, rebase/merge the current base branch into the PR,
-or push a new commit. Future PRs receive the check automatically.
+context. Add or remove the harmless `ci` label, use **Update branch**,
+rebase/merge the current base branch into the PR, or push a new commit. Future
+PRs receive the check automatically.
 
 ## Hosted determinism
 

--- a/tests/test_assert_junit_zero_skips.py
+++ b/tests/test_assert_junit_zero_skips.py
@@ -274,29 +274,35 @@ def _checkout_refs(workflow_text: str) -> list[str | None]:
 
 def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
     root = Path(__file__).resolve().parents[1]
-    exact_refs = (
-        "ref: ${{ github.event.pull_request.head.sha || github.sha }}",
-        "ref: ${{ inputs.ref }}",
-    )
+    pr_head_ref = "${{ github.event.pull_request.head.sha || github.sha }}"
+    reusable_ref = "${{ inputs.ref }}"
     # Semantic discovery avoids the old brittle checkout-count assertion: adding
     # a properly pinned job must not break every Python lane, while an unpinned
     # checkout in any PR-reachable reusable workflow must still fail preflight.
-    for name in (
-        "ci.yml",
-        "build-wheel.yml",
-        "test-python-wheel.yml",
-        "determinism-matrix.yml",
-    ):
+    ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
+    ci_jobs = yaml.load(ci, Loader=yaml.BaseLoader)["jobs"]
+    assert _checkout_refs(yaml.dump({"jobs": {"preflight": ci_jobs["preflight"]}})) == [
+        "${{ github.sha }}"
+    ]
+    for job_name, job in ci_jobs.items():
+        if job_name == "preflight" or not isinstance(job, dict):
+            continue
+        for index, checkout_ref in enumerate(
+            _checkout_refs(yaml.dump({"jobs": {job_name: job}})), start=1
+        ):
+            assert checkout_ref == pr_head_ref, (
+                f"ci.yml:{job_name} checkout step {index} is not exact-head pinned"
+            )
+
+    for name in ("build-wheel.yml", "test-python-wheel.yml", "determinism-matrix.yml"):
         workflow = (root / ".github" / "workflows" / name).read_text(encoding="utf-8")
         checkout_refs = _checkout_refs(workflow)
         assert checkout_refs, f"{name} has no checkout provenance to verify"
         for index, checkout_ref in enumerate(checkout_refs, start=1):
-            assert checkout_ref in {ref.removeprefix("ref: ") for ref in exact_refs}, (
+            assert checkout_ref == reusable_ref, (
                 f"{name} checkout step {index} is not exact-head pinned"
             )
 
-    ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
-    ci_jobs = yaml.load(ci, Loader=yaml.BaseLoader)["jobs"]
     for reusable in ("build-wheel.yml", "test-python-wheel.yml", "determinism-matrix.yml"):
         callers = [
             job
@@ -306,14 +312,39 @@ def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
         ]
         assert callers, f"CI does not call {reusable}"
         for caller in callers:
-            assert caller.get("with", {}).get("ref") == (
-                "${{ github.event.pull_request.head.sha || github.sha }}"
-            )
+            assert caller.get("with", {}).get("ref") == pr_head_ref
 
     certificate = (
         root / ".github" / "workflows" / "certificate-refresh.yml"
     ).read_text(encoding="utf-8")
     assert _checkout_refs(certificate) == ["${{ github.sha }}"]
+
+
+def test_preflight_uses_evaluated_state_without_weakening_source_provenance():
+    root = Path(__file__).resolve().parents[1]
+    workflow = (root / ".github" / "workflows" / "ci.yml").read_text(
+        encoding="utf-8"
+    )
+    jobs = yaml.load(workflow, Loader=yaml.BaseLoader)["jobs"]
+    preflight = jobs["preflight"]
+    assert _checkout_refs(yaml.dump({"jobs": {"preflight": preflight}})) == [
+        "${{ github.sha }}"
+    ]
+    run_blocks = "\n".join(
+        step.get("run", "") for step in preflight["steps"] if isinstance(step, dict)
+    )
+    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in run_blocks
+
+    pr_head_ref = "${{ github.event.pull_request.head.sha || github.sha }}"
+    for job_name, job in jobs.items():
+        if job_name == "preflight" or not isinstance(job, dict):
+            continue
+        for checkout_ref in _checkout_refs(yaml.dump({"jobs": {job_name: job}})):
+            assert checkout_ref == pr_head_ref
+        if isinstance(job.get("uses"), str) and job["uses"].startswith(
+            "./.github/workflows/"
+        ):
+            assert job.get("with", {}).get("ref") == pr_head_ref
 
 
 def test_checkout_contract_cannot_be_satisfied_by_a_comment_or_sibling_key():

--- a/tests/test_ci_cost_controls.py
+++ b/tests/test_ci_cost_controls.py
@@ -68,6 +68,10 @@ def test_ci_cost_controls_are_scoped_and_retained() -> None:
         assert f"          - {scope}" in trigger
 
     preflight = _job(workflow, "preflight")
+    assert "name: Checkout evaluated workflow state" in preflight
+    assert "ref: ${{ github.sha }}" in preflight
+    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in preflight
+    assert "base-added policy tests are available" in preflight
     assert "tests/test_ci_cost_controls.py" in preflight
     assert "tests/test_ci_lfs_fanout.py" in preflight
     assert "tests/test_determinism_matrix.py" in preflight


### PR DESCRIPTION
## Summary

- checks out the evaluated event state only for CI Preflight, so legacy PRs can use policy tests added on the base branch;
- proves the preflight checkout equals GITHUB_SHA;
- keeps every source, wheel, determinism, and physical checkout pinned to the exact PR head;
- adds regression contracts and rollout documentation for that provenance split.

## Triggering evidence

The post-merge label rollout started PR #143 run 30903032019. Preflight failed in 13 seconds because the legacy head did not contain tests/test_ci_cost_controls.py. The live synthetic merge ref does contain all required policy tests.

## Validation

- focused CI policy suite: 52 passed
- workflow YAML parse: 8 files
- Python contract-test compilation
- git diff --check

## Evidence boundary

This locally proves the workflow structure and the live merge-ref file availability. GitHub execution of this exact follow-up head remains pending. All artifact-producing jobs remain exact PR-head builds.