### PR TITLE
Prepare CI contracts for trusted target-tree validation

### DIFF
--- a/tests/test_assert_junit_zero_skips.py
+++ b/tests/test_assert_junit_zero_skips.py
@@ -290,9 +290,18 @@ def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
     # checkout in any PR-reachable reusable workflow must still fail preflight.
     ci = (root / ".github" / "workflows" / "ci.yml").read_text(encoding="utf-8")
     ci_jobs = yaml.load(ci, Loader=yaml.BaseLoader)["jobs"]
-    assert _checkout_refs(yaml.dump({"jobs": {"preflight": ci_jobs["preflight"]}})) == [
-        "${{ github.sha }}"
-    ]
+    preflight_refs = _checkout_refs(
+        yaml.dump({"jobs": {"preflight": ci_jobs["preflight"]}})
+    )
+    live_base_ref = (
+        "${{ github.event_name == 'pull_request' && "
+        "format('refs/heads/{0}', github.base_ref) || github.sha }}"
+    )
+    trusted_base_ref = "${{ steps.policy-base.outputs.sha }}"
+    assert preflight_refs in (
+        ["${{ github.sha }}"],
+        [live_base_ref, trusted_base_ref],
+    )
     for job_name, job in ci_jobs.items():
         if job_name == "preflight" or not isinstance(job, dict):
             continue
@@ -336,13 +345,100 @@ def test_preflight_uses_evaluated_state_without_weakening_source_provenance():
     )
     jobs = yaml.load(workflow, Loader=yaml.BaseLoader)["jobs"]
     preflight = jobs["preflight"]
-    assert _checkout_refs(yaml.dump({"jobs": {"preflight": preflight}})) == [
-        "${{ github.sha }}"
-    ]
-    run_blocks = "\n".join(
-        step.get("run", "") for step in preflight["steps"] if isinstance(step, dict)
-    )
-    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in run_blocks
+    checkout_refs = _checkout_refs(yaml.dump({"jobs": {"preflight": preflight}}))
+    if checkout_refs == ["${{ github.sha }}"]:
+        run_blocks = "\n".join(
+            step.get("run", "")
+            for step in preflight["steps"]
+            if isinstance(step, dict)
+        )
+        assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in run_blocks
+    else:
+        live_base_ref = (
+            "${{ github.event_name == 'pull_request' && "
+            "format('refs/heads/{0}', github.base_ref) || github.sha }}"
+        )
+        trusted_base_ref = "${{ steps.policy-base.outputs.sha }}"
+        assert checkout_refs == [live_base_ref, trusted_base_ref]
+        steps = preflight["steps"]
+        base_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Checkout live policy base"
+        )
+        snapshot_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Snapshot live policy base"
+        )
+        trusted_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Checkout trusted CI contracts"
+        )
+        merge_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Materialize current-base candidate tree"
+        )
+        setup_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("uses") == "actions/setup-python@v5"
+        )
+        validate_index = next(
+            index
+            for index, step in enumerate(steps)
+            if step.get("name") == "Validate workflow and cost-control contracts"
+        )
+        assert (
+            base_index
+            < snapshot_index
+            < trusted_index
+            < merge_index
+            < setup_index
+            < validate_index
+        )
+        base_checkout = steps[base_index]
+        assert base_checkout["with"] == {
+            "ref": live_base_ref,
+            "fetch-depth": "0",
+        }
+        snapshot_step = steps[snapshot_index]
+        assert snapshot_step["id"] == "policy-base"
+        assert 'sha=$(git rev-parse HEAD)' in snapshot_step["run"]
+        trusted_checkout = steps[trusted_index]
+        assert trusted_checkout["with"] == {
+            "ref": trusted_base_ref,
+            "path": ".ci-contracts",
+        }
+        merge_step = steps[merge_index]
+        assert merge_step["if"] == "github.event_name == 'pull_request'"
+        assert merge_step["env"] == {
+            "POLICY_BASE_SHA": trusted_base_ref,
+            "PR_NUMBER": "${{ github.event.pull_request.number }}",
+            "PR_HEAD_SHA": "${{ github.event.pull_request.head.sha }}",
+        }
+        merge_run = merge_step["run"]
+        assert 'test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"' in merge_run
+        assert (
+            "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+            in merge_run
+        )
+        assert (
+            'test "$(git rev-parse refs/remotes/pull/${PR_NUMBER}/head)" = '
+            '"$PR_HEAD_SHA"' in merge_run
+        )
+        assert 'git merge --no-commit --no-ff "$PR_HEAD_SHA"' in merge_run
+        assert 'test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"' in merge_run
+        assert 'test "$(git rev-parse MERGE_HEAD)" = "$PR_HEAD_SHA"' in merge_run
+        validate_step = steps[validate_index]
+        assert validate_step["working-directory"] == ".ci-contracts"
+        assert validate_step["env"] == {
+            "FORGE3D_NO_BOOTSTRAP": "1",
+            "FORGE3D_CI_CONTRACT_ROOT": "${{ github.workspace }}",
+            "PYTHONPATH": "${{ github.workspace }}/.ci-contracts",
+        }
 
     pr_head_ref = "${{ github.event.pull_request.head.sha || github.sha }}"
     for job_name, job in jobs.items():

--- a/tests/test_assert_junit_zero_skips.py
+++ b/tests/test_assert_junit_zero_skips.py
@@ -1,6 +1,7 @@
 """Adversarial fixtures for the required-lane JUnit verifier."""
 
 import json
+import os
 from pathlib import Path
 import sys
 
@@ -15,6 +16,14 @@ from scripts.summarize_m06_evidence import (
     markdown_summary,
     write_summary,
 )
+
+
+def _contract_root() -> Path:
+    return Path(
+        os.environ.get(
+            "FORGE3D_CI_CONTRACT_ROOT", Path(__file__).resolve().parents[1]
+        )
+    )
 
 
 def _write(tmp_path: Path, body: str) -> Path:
@@ -273,7 +282,7 @@ def _checkout_refs(workflow_text: str) -> list[str | None]:
 
 
 def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
-    root = Path(__file__).resolve().parents[1]
+    root = _contract_root()
     pr_head_ref = "${{ github.event.pull_request.head.sha || github.sha }}"
     reusable_ref = "${{ inputs.ref }}"
     # Semantic discovery avoids the old brittle checkout-count assertion: adding
@@ -321,7 +330,7 @@ def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
 
 
 def test_preflight_uses_evaluated_state_without_weakening_source_provenance():
-    root = Path(__file__).resolve().parents[1]
+    root = _contract_root()
     workflow = (root / ".github" / "workflows" / "ci.yml").read_text(
         encoding="utf-8"
     )

--- a/tests/test_ci_cost_controls.py
+++ b/tests/test_ci_cost_controls.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
 import yaml
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(
+    os.environ.get(
+        "FORGE3D_CI_CONTRACT_ROOT", Path(__file__).resolve().parents[1]
+    )
+)
 UPLOAD_STEP = re.compile(
     r"(?ms)^      - (?:name|uses):.*?"
     r"(?=^      - (?:name|uses):|^  [A-Za-z0-9_-]+:|\Z)"

--- a/tests/test_ci_cost_controls.py
+++ b/tests/test_ci_cost_controls.py
@@ -73,10 +73,29 @@ def test_ci_cost_controls_are_scoped_and_retained() -> None:
         assert f"          - {scope}" in trigger
 
     preflight = _job(workflow, "preflight")
-    assert "name: Checkout evaluated workflow state" in preflight
-    assert "ref: ${{ github.sha }}" in preflight
-    assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in preflight
-    assert "base-added policy tests are available" in preflight
+    if "name: Checkout trusted CI contracts" in preflight:
+        live_base_ref = (
+            "ref: ${{ github.event_name == 'pull_request' && "
+            "format('refs/heads/{0}', github.base_ref) || github.sha }}"
+        )
+        assert preflight.count(live_base_ref) == 1
+        assert "name: Snapshot live policy base" in preflight
+        assert "id: policy-base" in preflight
+        assert 'echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"' in preflight
+        assert "ref: ${{ steps.policy-base.outputs.sha }}" in preflight
+        assert "path: .ci-contracts" in preflight
+        assert "POLICY_BASE_SHA: ${{ steps.policy-base.outputs.sha }}" in preflight
+        assert 'test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"' in preflight
+        assert 'git merge --no-commit --no-ff "$PR_HEAD_SHA"' in preflight
+        assert 'test "$(git rev-parse MERGE_HEAD)" = "$PR_HEAD_SHA"' in preflight
+        assert "working-directory: .ci-contracts" in preflight
+        assert "FORGE3D_CI_CONTRACT_ROOT: ${{ github.workspace }}" in preflight
+        assert "PYTHONPATH: ${{ github.workspace }}/.ci-contracts" in preflight
+    else:
+        assert "name: Checkout evaluated workflow state" in preflight
+        assert "ref: ${{ github.sha }}" in preflight
+        assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in preflight
+        assert "base-added policy tests are available" in preflight
     assert "tests/test_ci_cost_controls.py" in preflight
     assert "tests/test_ci_lfs_fanout.py" in preflight
     assert "tests/test_determinism_matrix.py" in preflight

--- a/tests/test_ci_lfs_fanout.py
+++ b/tests/test_ci_lfs_fanout.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import re
 from pathlib import Path
 
@@ -8,7 +9,11 @@ import yaml
 from scripts.ci_pytest_lane import default_lane_files
 
 
-ROOT = Path(__file__).resolve().parents[1]
+ROOT = Path(
+    os.environ.get(
+        "FORGE3D_CI_CONTRACT_ROOT", Path(__file__).resolve().parents[1]
+    )
+)
 WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 
 

--- a/tests/test_determinism_matrix.py
+++ b/tests/test_determinism_matrix.py
@@ -1,4 +1,5 @@
 import json
+import os
 import re
 import subprocess
 import sys
@@ -9,7 +10,10 @@ import pytest
 
 SCRIPT = Path(__file__).parents[1] / "scripts" / "check_determinism_hashes.py"
 DUPLA_SCRIPT = Path(__file__).parents[1] / "scripts" / "run_dupla_proof.py"
-WORKFLOW = Path(__file__).parents[1] / ".github" / "workflows" / "determinism-matrix.yml"
+CONTRACT_ROOT = Path(
+    os.environ.get("FORGE3D_CI_CONTRACT_ROOT", Path(__file__).parents[1])
+)
+WORKFLOW = CONTRACT_ROOT / ".github" / "workflows" / "determinism-matrix.yml"
 SCENE = "terra_determinata_v1"
 SHA = "d" * 64
 


### PR DESCRIPTION
This is phase 1 of the legacy-PR preflight correction. It lets the existing base-owned CI contract tests inspect an explicitly selected candidate tree while keeping their helper scripts and imports anchored to the trusted checkout. Default CI behavior is unchanged.\n\nIt also adds a fail-closed transition contract: the validator accepts either the currently deployed preflight or the exact upcoming trusted-checkout structure, including one captured base SHA, ordering, immutable PR-head verification, local merge, isolated validator working directory, and exact-head downstream provenance. Other shapes fail.\n\nWhy separate this change: the current validator cannot safely approve a workflow that switches to a base-owned validator in the same PR. After this lands, a second narrow PR will add the trusted checkout and current-base plus exact-head materialization.\n\nValidation: 43 focused contract tests passed; all 8 workflow YAML files parsed; Python compilation and diff checks passed.