### PR TITLE
Validate legacy PRs with the trusted live-base policy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,25 +45,57 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      # Preflight validates the evaluated event state. On pull requests this is
-      # the synthetic merge commit, so base-added policy tests are available to
-      # legacy PR heads. Every source/artifact job below remains exact-head.
-      - name: Checkout evaluated workflow state
+      # Pull-request activity payloads can retain an old base SHA and expose the
+      # legacy PR head as github.sha. Start from the live base branch instead,
+      # then integrate the immutable PR head locally. Every source/artifact job
+      # below remains exact-head.
+      - name: Checkout live policy base
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.sha }}
+          ref: ${{ github.event_name == 'pull_request' && format('refs/heads/{0}', github.base_ref) || github.sha }}
+          fetch-depth: 0
 
-      - name: Prove evaluated preflight checkout
+      - name: Snapshot live policy base
+        id: policy-base
         shell: bash
-        run: test "$(git rev-parse HEAD)" = "$GITHUB_SHA"
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      # Execute the validator from a second base-owned checkout so a candidate
+      # cannot weaken the tests or helper modules that judge its merged tree.
+      - name: Checkout trusted CI contracts
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.policy-base.outputs.sha }}
+          path: .ci-contracts
+
+      - name: Materialize current-base candidate tree
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          POLICY_BASE_SHA: ${{ steps.policy-base.outputs.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"
+          git fetch --no-tags origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
+          test "$(git rev-parse refs/remotes/pull/${PR_NUMBER}/head)" = "$PR_HEAD_SHA"
+          git merge --no-commit --no-ff "$PR_HEAD_SHA"
+          test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"
+          test "$(git rev-parse MERGE_HEAD)" = "$PR_HEAD_SHA"
+          printf 'policy_base_sha=%s\ncandidate_head_sha=%s\n' \
+            "$POLICY_BASE_SHA" "$PR_HEAD_SHA" >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
 
       - name: Validate workflow and cost-control contracts
+        working-directory: .ci-contracts
         env:
           FORGE3D_NO_BOOTSTRAP: '1'
+          FORGE3D_CI_CONTRACT_ROOT: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}/.ci-contracts
         run: |
           python -m pip install pytest pyyaml
           python -m pytest \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,8 @@ jobs:
           test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"
           git fetch --no-tags origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/pull/${PR_NUMBER}/head"
           test "$(git rev-parse refs/remotes/pull/${PR_NUMBER}/head)" = "$PR_HEAD_SHA"
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git merge --no-commit --no-ff "$PR_HEAD_SHA"
           test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"
           test "$(git rev-parse MERGE_HEAD)" = "$PR_HEAD_SHA"

--- a/docs/ci-validation.md
+++ b/docs/ci-validation.md
@@ -17,10 +17,13 @@ request to `main` or `develop`. It requires:
 - the representative slow lane, TERMINUS, Linux aarch64 install smoke, docs,
   and path-selected hosted visual goldens.
 
-The preflight validates the evaluated event state (the proposed merge on pull
-requests), so policy tests added on the base branch are available to older PR
-heads. Wheels, source tests, and acceptance evidence remain built from the
-exact PR head SHA.
+For pull requests, the preflight checks out the live base branch, fetches and
+verifies the immutable PR head, and materializes their merge locally before it
+runs the workflow contracts from a separate base-owned checkout. This avoids
+stale activity-event SHAs, makes policy tests added on the base branch available
+to older PR heads, and prevents a candidate from weakening its own validator. A
+merge conflict fails preflight. Wheels, source tests, and acceptance evidence
+remain built from the exact PR head SHA.
 
 The exhaustive 3 operating systems by 4 Python versions suite runs only in the
 nightly schedule or a manual `full` dispatch. It replaces, rather than

--- a/tests/test_assert_junit_zero_skips.py
+++ b/tests/test_assert_junit_zero_skips.py
@@ -298,10 +298,7 @@ def test_ci_checkout_steps_pin_pull_requests_to_the_exact_head():
         "format('refs/heads/{0}', github.base_ref) || github.sha }}"
     )
     trusted_base_ref = "${{ steps.policy-base.outputs.sha }}"
-    assert preflight_refs in (
-        ["${{ github.sha }}"],
-        [live_base_ref, trusted_base_ref],
-    )
+    assert preflight_refs == [live_base_ref, trusted_base_ref]
     for job_name, job in ci_jobs.items():
         if job_name == "preflight" or not isinstance(job, dict):
             continue
@@ -346,6 +343,12 @@ def test_preflight_uses_evaluated_state_without_weakening_source_provenance():
     jobs = yaml.load(workflow, Loader=yaml.BaseLoader)["jobs"]
     preflight = jobs["preflight"]
     checkout_refs = _checkout_refs(yaml.dump({"jobs": {"preflight": preflight}}))
+    live_base_ref = (
+        "${{ github.event_name == 'pull_request' && "
+        "format('refs/heads/{0}', github.base_ref) || github.sha }}"
+    )
+    trusted_base_ref = "${{ steps.policy-base.outputs.sha }}"
+    assert checkout_refs == [live_base_ref, trusted_base_ref]
     if checkout_refs == ["${{ github.sha }}"]:
         run_blocks = "\n".join(
             step.get("run", "")
@@ -354,11 +357,6 @@ def test_preflight_uses_evaluated_state_without_weakening_source_provenance():
         )
         assert 'test "$(git rev-parse HEAD)" = "$GITHUB_SHA"' in run_blocks
     else:
-        live_base_ref = (
-            "${{ github.event_name == 'pull_request' && "
-            "format('refs/heads/{0}', github.base_ref) || github.sha }}"
-        )
-        trusted_base_ref = "${{ steps.policy-base.outputs.sha }}"
         assert checkout_refs == [live_base_ref, trusted_base_ref]
         steps = preflight["steps"]
         base_index = next(

--- a/tests/test_assert_junit_zero_skips.py
+++ b/tests/test_assert_junit_zero_skips.py
@@ -427,6 +427,11 @@ def test_preflight_uses_evaluated_state_without_weakening_source_provenance():
             'test "$(git rev-parse refs/remotes/pull/${PR_NUMBER}/head)" = '
             '"$PR_HEAD_SHA"' in merge_run
         )
+        assert 'git config --local user.name "github-actions[bot]"' in merge_run
+        assert (
+            'git config --local user.email '
+            '"41898282+github-actions[bot]@users.noreply.github.com"' in merge_run
+        )
         assert 'git merge --no-commit --no-ff "$PR_HEAD_SHA"' in merge_run
         assert 'test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"' in merge_run
         assert 'test "$(git rev-parse MERGE_HEAD)" = "$PR_HEAD_SHA"' in merge_run

--- a/tests/test_ci_cost_controls.py
+++ b/tests/test_ci_cost_controls.py
@@ -87,6 +87,11 @@ def test_ci_cost_controls_are_scoped_and_retained() -> None:
         assert "path: .ci-contracts" in preflight
         assert "POLICY_BASE_SHA: ${{ steps.policy-base.outputs.sha }}" in preflight
         assert 'test "$(git rev-parse HEAD)" = "$POLICY_BASE_SHA"' in preflight
+        assert 'git config --local user.name "github-actions[bot]"' in preflight
+        assert (
+            'git config --local user.email '
+            '"41898282+github-actions[bot]@users.noreply.github.com"' in preflight
+        )
         assert 'git merge --no-commit --no-ff "$PR_HEAD_SHA"' in preflight
         assert 'test "$(git rev-parse MERGE_HEAD)" = "$PR_HEAD_SHA"' in preflight
         assert "working-directory: .ci-contracts" in preflight

--- a/tests/test_ci_cost_controls.py
+++ b/tests/test_ci_cost_controls.py
@@ -73,6 +73,7 @@ def test_ci_cost_controls_are_scoped_and_retained() -> None:
         assert f"          - {scope}" in trigger
 
     preflight = _job(workflow, "preflight")
+    assert "name: Checkout trusted CI contracts" in preflight
     if "name: Checkout trusted CI contracts" in preflight:
         live_base_ref = (
             "ref: ${{ github.event_name == 'pull_request' && "


### PR DESCRIPTION
Completes the legacy-PR rollout correction after #152.\n\nThe cheap preflight resolves the live base once, captures its immutable SHA, checks out the validator from that exact SHA in a separate directory, fetches and verifies the immutable PR head, and materializes the current-base candidate merge locally. The base-owned tests inspect the merged candidate tree without importing candidate validator code. Every source, wheel, determinism, and physical job remains pinned to the exact PR head. Conflicts fail before fanout.\n\nValidation:\n- 43 merged-main validator tests passed against the proposed tree\n- 43 candidate contract tests passed\n- all 8 workflow YAML files parsed\n- Python compilation and diff checks passed\n- PR #143 plus current main merge-tree simulation succeeded\n- independent adversarial review found no remaining P0/P1 issue