### PR TITLE
Refresh production recipe certificates after TESSELLA

### DIFF
--- a/tests/golden/certificates/mapscene_alignment_utm.json
+++ b/tests/golden/certificates/mapscene_alignment_utm.json
@@ -132,47 +132,47 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 4.048895835876465,
+      "gpu_ms": 1.4950400590896606,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.005119999870657921,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.005119999870657921,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0030720001086592674,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.19865599274635315,
+      "gpu_ms": 0.04505600035190582,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "87dcadeda3a7924bffed69509e5976ee0c9a7dd75c7cd2c0128e2c4f032703ef6340b8146f4a4e30bb824bfb49a499ac0fd4be905002b8904858b8deba6d0b05",
+    "sig": "cbc20c2e82e1e125d94ea53cf57ff5517c2afc41f8e81c4ab648acc95afdecd895afd0f71467898b61b1acfb5bb3f32a477a9394a956fb2aa1e47b1688fa2d05",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_auto_water.json
+++ b/tests/golden/certificates/mapscene_auto_water.json
@@ -133,47 +133,47 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 5.426176071166992,
+      "gpu_ms": 1.70905601978302,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.22220799326896667,
+      "gpu_ms": 0.04403200000524521,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -186,7 +186,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "370a9fad4e79d420908ab18e485aeb48b084668760c0b3c07b244664b8bc86437f38a933872ea8a1d8bfb0e28baa5fa2653b0eeace59f2939788afa90c2e760e",
+    "sig": "e6c8ccc3c2df98d9d286b1b0e227893ad7223e89255f3417ed1c39701a32de747824bc29f69628b6b7f235e6a77b5a7368a53d97fd79e77a23fd6da4ca38ee0b",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_buildings.json
+++ b/tests/golden/certificates/mapscene_buildings.json
@@ -140,17 +140,17 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 3.7212159633636475,
+      "gpu_ms": 1.9537919759750366,
       "label": "terrain.shadow"
     },
     {
@@ -165,17 +165,17 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.19148799777030945,
+      "gpu_ms": 0.050175998359918594,
       "label": "terrain.main"
     },
     {
@@ -193,7 +193,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "dc9f8c2cf6a0110a40930454ddcb54514cb4b722d6e44ac82032c19df73d1d4154412d4d35e2afd031517a73eb4e406d3fdc7531a2bce555eee382a1ca02540e",
+    "sig": "c5c9d655e14496b7b1e312b8eee4b7c212451ea419040bbb306cc04af4bca554491895af65ff6c7bce3967fc874e040cd4baebf8e5702f4fc6a527ebee0b0708",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_clipmap_large_region.json
+++ b/tests/golden/certificates/mapscene_clipmap_large_region.json
@@ -146,34 +146,34 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "clipmap_lod_select": "08753b5167dc79a032f02a5bd217bd0522028c5973e88cbb1a1095d786f29a60",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.clipmap.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.clipmap.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "terrain_visbuffer_resolve": "7a7acf957a3e10465cff1ad4f296a6c9c41e89275e5d2d1755f4c3b1055f2e89"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 7.24889612197876,
+      "gpu_ms": 1.8974720239639282,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
@@ -183,12 +183,12 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.5642240047454834,
+      "gpu_ms": 0.12902399897575378,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -201,7 +201,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "aebaa07b2e691c4226baefe0a51923f8bd1aa4803e7580c2e3cdf2a12eb05679ba7b80858900bb23e928c6a91c4dcd6307032e4ece6c6702133834af04ff9f0c",
+    "sig": "612b3ae80dc0e6e81956b9441dda2f87fdb33ed690e72c89e343586f7667b681107a26489225b7de84b1e0f389132d5dbbe9e48c153e4a5df3c79f8e74a6ec01",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_cloud_shadows.json
+++ b/tests/golden/certificates/mapscene_cloud_shadows.json
@@ -132,47 +132,47 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 4.934656143188477,
+      "gpu_ms": 1.6373759508132935,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.2396160066127777,
+      "gpu_ms": 0.04608000069856644,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "59f05dce5f49938257530eb5a661fd44ec5b9fa1c1a01335c5a7cc59bb06f4de215f5178bafb1a0ac30ab3888a06ac336326799b0681af8fcaca3c3dd7206206",
+    "sig": "bf36368970fa897373bedcc73604d5cf30a517af36ce945653de62fa9e486a794dc8289b0ff9024cf0e3fabd1582381b04b6e78c0be8d350f8519101cae6a704",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_copc_points.json
+++ b/tests/golden/certificates/mapscene_copc_points.json
@@ -147,12 +147,12 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "point_instanced.wgsl": "e8159414ae314a3988323cde19c5f4e0ebbc61f01dead822d25e3b386f438dfc",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "vf.Vector.OIT.Compose": "934b46d4b65e4911a49ba0b29b6c2deea2662d8eac1db0cab40a78677a88122d",
       "vf.Vector.PointEDL": "7072f56a0ae357ab08cd6b4fc1f82573b3abf01db331b205f82c0596c678f8de"
     }
@@ -160,7 +160,7 @@
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 4.532224178314209,
+      "gpu_ms": 1.462272047996521,
       "label": "terrain.shadow"
     },
     {
@@ -170,42 +170,42 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.0030720001086592674,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.21913599967956543,
+      "gpu_ms": 0.043007999658584595,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.032768,
+      "gpu_ms": 0.009216,
       "label": "vector.oit"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.009216,
+      "gpu_ms": 0.002048,
       "label": "vector.oit.compose"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.01024,
+      "gpu_ms": 0.003072,
       "label": "vector.edl"
     },
     {
@@ -218,7 +218,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "3cc48d9490fc6503b5a4495bb1717f80e0ca7dfed48c0166125f6fcb39abb18fc49c10ba4d0f998ff3133187493f50a5a965ed60e51d86c331bc00dfda871f0c",
+    "sig": "121270e06c4d9c2cb493f99abc32540fc0a44b46754b120f0b72d58a078b4e48d10d2552dbcbb4077c1a7f2894a3da73496ec4af725f2abdedcd22d0e4345800",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_furniture_graticule.json
+++ b/tests/golden/certificates/mapscene_furniture_graticule.json
@@ -132,47 +132,47 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 3.733504056930542,
+      "gpu_ms": 1.563647985458374,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.2088959962129593,
+      "gpu_ms": 0.04505600035190582,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "03f278975c25fff4726063a9811553f1b80b0d2c13fb7d2e7ec089be7bc07b814f4bbacda5fbe0f5f66d31909b1aec91b9f6799597abc23c46a460e6ae35b50d",
+    "sig": "0a8a2fbfb04e9f83f8f325ce0a3c4acec2130a51e1b8c496ab2dc30a8c12a4682061ff7ac1a179082c0ea3c4b331229d8d63beb0efad1c8f61b0a3dae244840b",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_label_arabic_joining.json
+++ b/tests/golden/certificates/mapscene_label_arabic_joining.json
@@ -167,19 +167,19 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "overlays_shader": "3f7493a10d4734daa97dedac61a21ab27ebc20e1c9353018abb40f31fdfa803d",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "text_overlay_shader": "06e0fd5a97f2ad8d44664a1dc8f0e7fdd90231f032a863f7e23315314cb8e0df"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 1.6558079719543457,
+      "gpu_ms": 1.760256052017212,
       "label": "terrain.shadow"
     },
     {
@@ -189,22 +189,22 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.0010239999974146485,
+      "gpu_ms": 0.002047999994829297,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.04710400104522705,
+      "gpu_ms": 0.04915200173854828,
       "label": "terrain.main"
     },
     {
@@ -214,7 +214,7 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.0030720001086592674,
+      "gpu_ms": 0.002047999994829297,
       "label": "scene.main"
     },
     {
@@ -232,7 +232,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "7b69d7e6219b6a30e4b3c003859720030bc0d1c82402177b63c2bba976455ffc91951012972328d73cc3e97b89161e1fd252aa597fcaa14c868f605bdde67607",
+    "sig": "649dae22350c6222312e17a3ca38b98c9483b03cf1e232a699a263d66245e8d99b5c2905141da9be97d1f7cae1f1372445957925ff27c6de026755ae2e002406",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_label_halo_depth.json
+++ b/tests/golden/certificates/mapscene_label_halo_depth.json
@@ -167,19 +167,19 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "overlays_shader": "3f7493a10d4734daa97dedac61a21ab27ebc20e1c9353018abb40f31fdfa803d",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "text_overlay_shader": "06e0fd5a97f2ad8d44664a1dc8f0e7fdd90231f032a863f7e23315314cb8e0df"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 1.6547839641571045,
+      "gpu_ms": 2.0899839401245117,
       "label": "terrain.shadow"
     },
     {
@@ -204,7 +204,7 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.04710400104522705,
+      "gpu_ms": 0.05427199974656105,
       "label": "terrain.main"
     },
     {
@@ -214,12 +214,12 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0030720001086592674,
       "label": "scene.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.009216000325977802,
+      "gpu_ms": 0.010239999741315842,
       "label": "scene.readback_copy"
     },
     {
@@ -232,7 +232,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "91aaffb5003fac61f1fea4cac97108ebae92d60ab98ba9cc0038017cb4e304bec8748f90bdbc8c2b4e4f8579bb854b542eb124bfac25fb3d091a9ea840282a0c",
+    "sig": "fc52c8040ea1bab4cc91dbcde0a0275d6dc8e133a78a057168abd063585d89334a761a99365e055690237fb8844a7e3587b2bf2abd3db3c59c83a0099b907702",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_label_occlusion_ridge.json
+++ b/tests/golden/certificates/mapscene_label_occlusion_ridge.json
@@ -167,19 +167,19 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "overlays_shader": "3f7493a10d4734daa97dedac61a21ab27ebc20e1c9353018abb40f31fdfa803d",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "text_overlay_shader": "06e0fd5a97f2ad8d44664a1dc8f0e7fdd90231f032a863f7e23315314cb8e0df"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 3.59116792678833,
+      "gpu_ms": 1.7469439506530762,
       "label": "terrain.shadow"
     },
     {
@@ -189,37 +189,37 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.0010239999974146485,
+      "gpu_ms": 0.002047999994829297,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.19865599274635315,
+      "gpu_ms": 0.048128001391887665,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.0071680000983178616,
+      "gpu_ms": 0.002047999994829297,
       "label": "scene.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.01945599913597107,
+      "gpu_ms": 0.009216000325977802,
       "label": "scene.readback_copy"
     },
     {
@@ -232,7 +232,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "330812553ee1e5f36f09b5a75510c673a9f3b1049d37691fb488c917de8ff661ddd336c994b74f61a9ca7b531d504e65f2d099878c12b874bd0af2f6eae3e403",
+    "sig": "9362f4d6fa2a53fe2d2d63f3aa2c3b38acb7f096bd112eeac796bdcc0643392f953869972042f771a319f40a6148ae8d0d64fb66a67287f932becd6aee720703",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_material_maps.json
+++ b/tests/golden/certificates/mapscene_material_maps.json
@@ -132,47 +132,47 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 4.05401611328125,
+      "gpu_ms": 1.4704639911651611,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.004095999989658594,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.22118400037288666,
+      "gpu_ms": 0.04505600035190582,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "d8bccb4329908281c2bc8dcc1efe0bbb338c82bd7b9dcb55c93391913ca746d973a64a9e711d9990a4cef34cc490e49c41f3e8d6f865a065b4c7298d6d71130e",
+    "sig": "32880ba4d96681e8eb91ee3f740aac39cb31205d5bb7c556164eaa361eafdfc4a7e697cd9db19650413bfcb8505101bae9f61f4f161f4d5339210575215df00f",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_offline_aovs.json
+++ b/tests/golden/certificates/mapscene_offline_aovs.json
@@ -150,7 +150,7 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.offline.accumulate.pipeline": "cd37fc252033f64ac13406bfef71e937c11a6087a120f416eb24ba5d79e61126",
@@ -159,13 +159,13 @@
       "terrain.offline.resolve.pipeline": "d2367288470929cc76d87081dc0d30617ecafd4c7a4b094edcbc797a8ac00f62",
       "terrain.offline.tonemap.pipeline": "e1fab6d8fe610bc10c1d42adbf5f7601ff24ac0ad137043f4a7702a526cac587",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.aov.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.aov.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 4,
-      "gpu_ms": 3.6239359378814697,
+      "gpu_ms": 2.712575912475586,
       "label": "terrain.offline.accumulate_batch"
     },
     {
@@ -178,7 +178,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "63716d8c54892789fa0841341590acebb54c851af7569688f301f7b618bcf0a27043f1d41176f2b049cb0c7cc62a4a5f27e879dae419ebaae3a737877877700f",
+    "sig": "f90754cbed854006f57f8a42b342188de671614c9a4c5a3e0847658eb1dcfba77279ddafa609ef539a0cf758a59269974b825bbac3200757072404a9138e6809",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_png16_color.json
+++ b/tests/golden/certificates/mapscene_png16_color.json
@@ -132,47 +132,47 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 4.529151916503906,
+      "gpu_ms": 1.4612480401992798,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.0030720001086592674,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.20684799551963806,
+      "gpu_ms": 0.04505600035190582,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "fe0434699253e7144d5305403b4a64fda4cacf4b317b7d7fc52f7969ddac35b08bbb161949a053582ef4f5ed3c1bbb29ef4c9b0b4db883f7cc01682f96c64209",
+    "sig": "38bd4ce830247a31fb3486d74e0f394835bb083e90b90227b1ab69d30bc2277d1a933144ff99fa9864c5d9b2931c6196b2de6b02036c190a09750b01a4785f0e",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_screen_space_contact.json
+++ b/tests/golden/certificates/mapscene_screen_space_contact.json
@@ -137,17 +137,17 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 0.9195520281791687,
+      "gpu_ms": 0.4853760004043579,
       "label": "terrain.shadow"
     },
     {
@@ -157,27 +157,27 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.20070399343967438,
+      "gpu_ms": 0.050175998359918594,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -190,7 +190,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "b52badf019de9babfa08f5e9dee151e0d449e3c2ce7b9193c68bc8baa6297100d008ef5c61e973d8bdef58d77ee5a894c4fe4f667b0c869a3f2c655df1928801",
+    "sig": "152ecfd56e9556348e13d3fcef700b63d268247cb1af33fd0b4f237101b4570ea823286a793e6a3f42529e881c518046963cc4374f419fd9f3fcc00601828906",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_screen_space_reflection.json
+++ b/tests/golden/certificates/mapscene_screen_space_reflection.json
@@ -133,17 +133,17 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 5.015552043914795,
+      "gpu_ms": 2.2210559844970703,
       "label": "terrain.shadow"
     },
     {
@@ -158,7 +158,7 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
@@ -168,12 +168,12 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.2099200040102005,
+      "gpu_ms": 0.05119999870657921,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -186,7 +186,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "370a9fad4e79d420908ab18e485aeb48b084668760c0b3c07b244664b8bc86437f38a933872ea8a1d8bfb0e28baa5fa2653b0eeace59f2939788afa90c2e760e",
+    "sig": "e6c8ccc3c2df98d9d286b1b0e227893ad7223e89255f3417ed1c39701a32de747824bc29f69628b6b7f235e6a77b5a7368a53d97fd79e77a23fd6da4ca38ee0b",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_terrain_raster.json
+++ b/tests/golden/certificates/mapscene_terrain_raster.json
@@ -132,22 +132,22 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 1.6629760265350342,
+      "gpu_ms": 1.6650240421295166,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.0010239999974146485,
+      "gpu_ms": 0.0,
       "label": "terrain.material_vt"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "87dcadeda3a7924bffed69509e5976ee0c9a7dd75c7cd2c0128e2c4f032703ef6340b8146f4a4e30bb824bfb49a499ac0fd4be905002b8904858b8deba6d0b05",
+    "sig": "cbc20c2e82e1e125d94ea53cf57ff5517c2afc41f8e81c4ab648acc95afdecd895afd0f71467898b61b1acfb5bb3f32a477a9394a956fb2aa1e47b1688fa2d05",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_textured_gltf_landmark.json
+++ b/tests/golden/certificates/mapscene_textured_gltf_landmark.json
@@ -132,27 +132,27 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 3.59116792678833,
+      "gpu_ms": 1.6732159852981567,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
@@ -162,17 +162,17 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.2088959962129593,
+      "gpu_ms": 0.048128001391887665,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "03f278975c25fff4726063a9811553f1b80b0d2c13fb7d2e7ec089be7bc07b814f4bbacda5fbe0f5f66d31909b1aec91b9f6799597abc23c46a460e6ae35b50d",
+    "sig": "0a8a2fbfb04e9f83f8f325ce0a3c4acec2130a51e1b8c496ab2dc30a8c12a4682061ff7ac1a179082c0ea3c4b331229d8d63beb0efad1c8f61b0a3dae244840b",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_thematic_choropleth.json
+++ b/tests/golden/certificates/mapscene_thematic_choropleth.json
@@ -150,25 +150,25 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "line_aa.wgsl": "0ebdc403a1ef64bff361ef867fc6ccdf71b3f5367d5a59b7c3c888eb74fde085",
       "polygon_fill.wgsl": "75693f644f709f14a914b3d0acec9d5c0b5668365363a1eafe08aecd15c75c5a",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "vf.Vector.OIT.Compose": "934b46d4b65e4911a49ba0b29b6c2deea2662d8eac1db0cab40a78677a88122d"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 3.340287923812866,
+      "gpu_ms": 2.0439040660858154,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
@@ -183,32 +183,32 @@
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.2017280012369156,
+      "gpu_ms": 0.05427199974656105,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
       "draw_calls": 4,
-      "gpu_ms": 0.015359999611973763,
+      "gpu_ms": 0.004095999989658594,
       "label": "vector.polygon_fill"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.023552,
+      "gpu_ms": 0.011264,
       "label": "vector.oit"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.004096,
+      "gpu_ms": 0.003072,
       "label": "vector.oit.compose"
     },
     {
@@ -221,7 +221,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "ab4cfdc054c9e00b060dca3d74442f12a970a1a55c029fa274076b55beefb69f1869194d2d4f8913149b4092360e9506d5138f1c066b193a607206b4457aa602",
+    "sig": "fdfa98ade6b9973f007b237a97e6d0ed6e085e0e3b132a320bf2d913f88a1a39bc76f56dce05756df7ffd01a0c4e6c16ba82a11a0938a6762dc390c8b69c9d0c",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_tiles3d_points.json
+++ b/tests/golden/certificates/mapscene_tiles3d_points.json
@@ -147,12 +147,12 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "point_instanced.wgsl": "e8159414ae314a3988323cde19c5f4e0ebbc61f01dead822d25e3b386f438dfc",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "vf.Vector.OIT.Compose": "934b46d4b65e4911a49ba0b29b6c2deea2662d8eac1db0cab40a78677a88122d",
       "vf.Vector.PointEDL": "7072f56a0ae357ab08cd6b4fc1f82573b3abf01db331b205f82c0596c678f8de"
     }
@@ -160,32 +160,32 @@
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 4.326399803161621,
+      "gpu_ms": 1.4612480401992798,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.0030720001086592674,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.21401600539684296,
+      "gpu_ms": 0.04403200000524521,
       "label": "terrain.main"
     },
     {
@@ -195,17 +195,17 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.031744,
+      "gpu_ms": 0.009216,
       "label": "vector.oit"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.01024,
+      "gpu_ms": 0.003072,
       "label": "vector.oit.compose"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.01024,
+      "gpu_ms": 0.003072,
       "label": "vector.edl"
     },
     {
@@ -218,7 +218,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "3cc48d9490fc6503b5a4495bb1717f80e0ca7dfed48c0166125f6fcb39abb18fc49c10ba4d0f998ff3133187493f50a5a965ed60e51d86c331bc00dfda871f0c",
+    "sig": "121270e06c4d9c2cb493f99abc32540fc0a44b46754b120f0b72d58a078b4e48d10d2552dbcbb4077c1a7f2894a3da73496ec4af725f2abdedcd22d0e4345800",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_vector_labels.json
+++ b/tests/golden/certificates/mapscene_vector_labels.json
@@ -167,24 +167,24 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "overlays_shader": "3f7493a10d4734daa97dedac61a21ab27ebc20e1c9353018abb40f31fdfa803d",
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50",
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42",
       "text_overlay_shader": "06e0fd5a97f2ad8d44664a1dc8f0e7fdd90231f032a863f7e23315314cb8e0df"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 1.6547839641571045,
+      "gpu_ms": 1.9619840383529663,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.0010239999974146485,
+      "gpu_ms": 0.002047999994829297,
       "label": "terrain.material_vt"
     },
     {
@@ -204,7 +204,7 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.04608000069856644,
+      "gpu_ms": 0.05119999870657921,
       "label": "terrain.main"
     },
     {
@@ -214,12 +214,12 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0030720001086592674,
       "label": "scene.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.008191999979317188,
+      "gpu_ms": 0.009216000325977802,
       "label": "scene.readback_copy"
     },
     {
@@ -232,7 +232,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "949a3bdcd3f7038841d23d16af1304a0e9c46959e2b04f863e323166ab42612d186b7b31878d9bbec72f216ecc74159d8b7ec42adc2162ca1d259309e033ad0f",
+    "sig": "ce239b8bbb649a2d8159917876f318a08b0c36c51ea29bd17152f24eb0749fd22b10cf8395bdb32e3dd025f54516491360aae617bfb371c19480981f9c865900",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_vector_stroke_quality.json
+++ b/tests/golden/certificates/mapscene_vector_stroke_quality.json
@@ -132,17 +132,17 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 2.470911979675293,
+      "gpu_ms": 1.7448960542678833,
       "label": "terrain.shadow"
     },
     {
@@ -167,7 +167,7 @@
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.06758400052785873,
+      "gpu_ms": 0.050175998359918594,
       "label": "terrain.main"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "1a94986e62dd1ee6155c982fa7d2769eebd9f0b218b2ea5a1e798faab5fceab5c678486f8273925dcb5a75b4af90432d9a232b0f0e99de23736601aee1a74b0a",
+    "sig": "86df5bac13636b8dd993823756bac4c1d46d263df34f12bca16071e6662dfa31991148f601af82b6ae551f2ee81394ffb609c4686dffa36b4774aa1660759f0d",
     "signed_fields": [
       "adapter",
       "allocations",

--- a/tests/golden/certificates/mapscene_vector_stroke_quality_4x.json
+++ b/tests/golden/certificates/mapscene_vector_stroke_quality_4x.json
@@ -132,47 +132,47 @@
   },
   "degradations": [],
   "engine": {
-    "git_sha": "e51c6c7b3d3e",
+    "git_sha": "5a0bf9317bb0",
     "version": "1.34.0",
     "wgsl_module_hashes": {
       "terrain.shadow_depth.shader": "5cb47cb163eba8496ca4c80b931f961d2d51c752cbddbf116690106bfa2a8ce0",
-      "terrain_pbr_pom.shader": "122a8073702abd4257853bb9edbebe353735c2a153b5e14d88cd8d87f368cb50"
+      "terrain_pbr_pom.shader": "eb5127b8502f542a78926eeba26f9e0211c3ecad712a8abfa86bd57672b52b42"
     }
   },
   "passes": [
     {
       "draw_calls": 0,
-      "gpu_ms": 2.619391918182373,
+      "gpu_ms": 1.745919942855835,
       "label": "terrain.shadow"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.material_vt"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.height_ao"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sun_visibility"
     },
     {
       "draw_calls": 0,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.sky"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.4413439929485321,
+      "gpu_ms": 0.10035199671983719,
       "label": "terrain.main"
     },
     {
       "draw_calls": 1,
-      "gpu_ms": 0.002047999994829297,
+      "gpu_ms": 0.0010239999974146485,
       "label": "terrain.resolve"
     },
     {
@@ -185,7 +185,7 @@
   "signature": {
     "alg": "ed25519",
     "pubkey": "293714d07f70116c88cea0db72023726047d3de56cb4f3f6964305937952f46e",
-    "sig": "eb16e6871530003da316daaeab24d656cf30c518751cf60b30e9d4fca639f160303d68f7995336030016e82d9e87b0f1c035c0018d477e40930ec3c79b2de80c",
+    "sig": "d075b6ef935789f9fdc5c551e6965873ee59ffad924d685bd005c38855a98fb88412734a6964724ddcb5d370ce5d2e4728b63c8ccdcf8bd765a070a10b372509",
     "signed_fields": [
       "adapter",
       "allocations",


### PR DESCRIPTION
Publishes the 22 production-signed recipe certificates generated by protected workflow run 30918710700 from exact main SHA 5a0bf9317bb03d042825fdb27188996c1620e16f. The refresh proved an NVIDIA GeForce RTX 3070 on Vulkan with no software fallback. Local publication verification: all 22 Ed25519 signatures validate against the pinned public key, all certificates record zero degradations, git diff --check passes, and focused certificate-policy tests pass (3/3). Pixel goldens are unchanged.